### PR TITLE
Feat mint at par

### DIFF
--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -218,8 +218,13 @@ contract Terms is ITerms {
         // current debt and merge the function with repay.
         require(debtOf[onBehalf][id] == 0 || _isHealthy(term, onBehalf), "Buyer is unhealthy");
 
-        bondSharesOf[onBehalf][id] += debt.toSharesDown(totalAssets[id], totalShares[id]);
+        uint256 sharesToMint = debt.toSharesDown(totalAssets[id], totalShares[id]);
+
         withdrawable[id] += debt;
+        bondSharesOf[onBehalf][id] += sharesToMint;
+
+        totalShares[id] += sharesToMint;
+        totalAssets[id] += debt;
 
         IERC20(term.loanToken).transferFrom(msg.sender, address(this), debt);
     }

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -203,18 +203,24 @@ contract Terms is ITerms {
         return seizures;
     }
 
+    //@dev It is always possible to mint at par because a user can
+    //match with himself - using two different addresses - and
+    //flash-loan collateral by following these steps: flashloan;
+    //borrow/lend at par to mint X bonds; repay as borrower; withdraw
+    //collateral to repay flashloan; lender address has now X bonds
+    //and there's X withdrawable lent assets; note however that the
+    //value (not the amount) of bond could be lesser than of the loan
+    //asset, in case of accounted bad debt.
     function mintAtPar(Term memory term, uint256 debt, address onBehalf) public {
-        // This is always possible because a user can match with
-        // himself using two different addresses and flashloaning
-        // collateral: following these steps: flashloan, borrow/mint
-        // at par X bonds, repay, withdraw collateral, lender address
-        // has now X bonds and there's X withdrawable assets.
         bytes32 id = _id(term);
 
-        require(debtOf[msg.sender][id] == 0 || _isHealthy(term, onBehalf), "Buyer is unhealthy");
-        uint256 boughtShares = debt.toSharesDown(totalAssets[id], totalShares[id]);
-        bondSharesOf[onBehalf][id] += boughtShares;
+        // Maybe we could relax this restriction and just offset the
+        // current debt and merge the function with repay.
+        require(debtOf[onBehalf][id] == 0 || _isHealthy(term, onBehalf), "Buyer is unhealthy");
+
+        bondSharesOf[onBehalf][id] += debt.toSharesDown(totalAssets[id], totalShares[id]);
         withdrawable[id] += debt;
+
         IERC20(term.loanToken).transferFrom(msg.sender, address(this), debt);
     }
 

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -203,6 +203,21 @@ contract Terms is ITerms {
         return seizures;
     }
 
+    function mintAtPar(Term memory term, uint256 debt, address onBehalf) public {
+        // This is always possible because a user can match with
+        // himself using two different addresses and flashloaning
+        // collateral: following these steps: flashloan, borrow/mint
+        // at par X bonds, repay, withdraw collateral, lender address
+        // has now X bonds and there's X withdrawable assets.
+        bytes32 id = _id(term);
+
+        require(debtOf[msg.sender][id] == 0 || _isHealthy(term, onBehalf), "Buyer is unhealthy");
+        uint256 boughtShares = debt.toSharesDown(totalAssets[id], totalShares[id]);
+        bondSharesOf[onBehalf][id] += boughtShares;
+        withdrawable[id] += debt;
+        IERC20(term.loanToken).transferFrom(msg.sender, address(this), debt);
+    }
+
     function bondOf(address owner, bytes32 id) public view returns (uint256) {
         return bondSharesOf[owner][id].toAssetsDown(totalAssets[id], totalShares[id]);
     }

--- a/test/TermsTest.sol
+++ b/test/TermsTest.sol
@@ -137,4 +137,15 @@ contract TermsTest is BaseTest {
         assertEq(terms.bondOf(lender, id), 87);
         assertEq(terms.totalAssets(id), 87);
     }
+
+    function testFuzzMintAtPar(uint256 amount) public {
+        uint256 MAX_AMOUNT = 1 ether - 100;
+        amount = bound(amount, 1, MAX_AMOUNT);
+        loanToken.transfer(liquidator, MAX_AMOUNT);
+        assertEq(terms.bondOf(liquidator, id), 0);
+        vm.prank(liquidator);
+        terms.mintAtPar(term, amount, liquidator);
+        assertEq(loanToken.balanceOf(liquidator), MAX_AMOUNT - amount);
+        assertEq(terms.bondOf(liquidator, id), amount);
+    }
 }

--- a/test/TermsTest.sol
+++ b/test/TermsTest.sol
@@ -138,13 +138,16 @@ contract TermsTest is BaseTest {
         assertEq(terms.totalAssets(id), 87);
     }
 
-    function testFuzzMintAtPar(uint256 amount) public {
+    function testFuzzMintAtPar(uint256 amount, address user) public {
         uint256 MAX_AMOUNT = 1 ether - 100;
         amount = bound(amount, 1, MAX_AMOUNT);
+        vm.assume(user != liquidator);
+        uint256 userBondsBefore = terms.bondOf(user, id);
         loanToken.transfer(liquidator, MAX_AMOUNT);
         assertEq(terms.bondOf(liquidator, id), 0);
         vm.prank(liquidator);
         terms.mintAtPar(term, amount, liquidator);
+        assertEq(userBondsBefore, terms.bondOf(user, id));
         assertEq(loanToken.balanceOf(liquidator), MAX_AMOUNT - amount);
         assertEq(terms.bondOf(liquidator, id), amount);
     }


### PR DESCRIPTION
As discussed with @QGarchery, it is always possible to mint bonds at par. So we provide an implementation to ease out the process.