### PR TITLE
Feat liquidate with bonds

### DIFF
--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -220,8 +220,13 @@ contract Terms is ITerms {
         // current debt and merge the function with repay.
         require(debtOf[onBehalf][id] == 0 || _isHealthy(term, onBehalf), "Buyer is unhealthy");
 
-        bondSharesOf[onBehalf][id] += debt.toSharesDown(totalAssets[id], totalShares[id]);
+        uint256 sharesToMint = debt.toSharesDown(totalAssets[id], totalShares[id]);
+
         withdrawable[id] += debt;
+        bondSharesOf[onBehalf][id] += sharesToMint;
+
+        totalShares[id] += sharesToMint;
+        totalAssets[id] += debt;
 
         IERC20(term.loanToken).transferFrom(msg.sender, address(this), debt);
     }

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -186,6 +186,12 @@ contract Terms is ITerms {
         uint256 originalDebt = debtOf[borrower][id];
         debtOf[borrower][id] -= totalRepaid;
 
+        uint256 sharesToBurn = totalRepaid.toSharesUp(totalAssets[id], totalShares[id]);
+        bondSharesOf[msg.sender][id] -= sharesToBurn;
+
+        totalShares[id] -= sharesToBurn;
+        totalAssets[id] -= totalRepaid;
+
         // Realize bad debt
         if (repayableDebt < originalDebt) {
             // Because roundings are not aligned the effective bad debt is either the remaining debt or the original debt minus the theoretical repayable debt.
@@ -194,11 +200,7 @@ contract Terms is ITerms {
             totalAssets[id] -= badDebt;
         }
 
-        withdrawable[id] += totalRepaid;
-
         if (data.length > 0) IMorphoLiquidationCallback(msg.sender).onLiquidate(seizures, borrower, msg.sender, data);
-
-        IERC20(term.loanToken).transferFrom(msg.sender, address(this), totalRepaid);
 
         return seizures;
     }

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -132,7 +132,8 @@ contract LiquidationTest is BaseTest {
         loanToken.transfer(liquidator, 1000);
         Term memory t = liquidationTerms[n - 1];
         Oracle(t.collaterals[0].oracle).setPrice(0.25e36);
-
+        vm.prank(liquidator);
+        terms.mintAtPar(t, 1000, liquidator);
         vm.prank(liquidator);
         uint256 gasBefore;
         uint256 gasUsed;

--- a/test/TermsTest.sol
+++ b/test/TermsTest.sol
@@ -127,6 +127,8 @@ contract TermsTest is BaseTest {
         testMint();
 
         loanToken.transfer(liquidator, 1000);
+        vm.prank(liquidator);
+        terms.mintAtPar(term, 87, liquidator);
         Oracle(collaterals[0].oracle).setPrice(0.75e36);
 
         vm.prank(liquidator);
@@ -135,6 +137,8 @@ contract TermsTest is BaseTest {
         assertEq(ret[0].repaidAmount, 87);
         assertEq(terms.withdrawable(id), 87);
         assertEq(terms.bondOf(lender, id), 87);
+        assertEq(terms.bondOf(liquidator, id), 0);
+
         assertEq(terms.totalAssets(id), 87);
     }
 


### PR DESCRIPTION
This PR refactors liquidation to require the liquidator to use bonds instead of loan asset.