### PR TITLE
`bool asBorrower`: include withdraw vs. borrow or repay vs. lend information in offer

### DIFF
--- a/src/Matching.sol
+++ b/src/Matching.sol
@@ -23,13 +23,18 @@ contract Matching is IMatching {
 
     function take(Term memory term, uint256 assets, bytes calldata data)
         external
-        returns (bool buy, address counterparty, uint256 bonds)
+        returns (bool buy, bool asBorrower, address counterparty, uint256 bonds)
     {
         (Offer memory offer, Signature memory sig) = abi.decode(data, (Offer, Signature));
         _checkSignature(offer, sig);
         _checkOffer(term, offer);
         require((consumed[offer.offering][offer.nonce] += assets) <= offer.assets, "consumed");
-        return (offer.buy, offer.offering, assets * (1e18 + (term.maturity - block.timestamp) * offer.rate) / 1e18);
+        return (
+            offer.buy,
+            offer.asBorrower,
+            offer.offering,
+            assets * (1e18 + (term.maturity - block.timestamp) * offer.rate) / 1e18
+        );
     }
 
     /// INTERNAL ///

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -36,7 +36,7 @@ contract Terms is ITerms {
     function take(Term memory term, uint256 assets, address onBehalf, address matching, bytes calldata data) external {
         require(term.maturity >= block.timestamp, "maturity");
 
-        (bool buy, address counterparty, uint256 bonds) = IMatching(matching).take(term, assets, data);
+        (bool buy, bool asBorrower, address counterparty, uint256 bonds) = IMatching(matching).take(term, assets, data);
         require(isMatching[counterparty][matching], "not a matching contract");
 
         (address buyer, address seller) = buy ? (counterparty, onBehalf) : (onBehalf, counterparty);
@@ -49,11 +49,15 @@ contract Terms is ITerms {
             uint256 withdrawn =
                 UtilsLib.min(bondSharesOf[seller][id].mulDivDown(totalBonds[id] + 1, totalShares[id] + 1), bonds);
             uint256 withdrawnShares = withdrawn.mulDivUp(totalShares[id] + 1, totalBonds[id] + 1);
+            uint256 borrowed = bonds - withdrawn;
+
+            if (buyer == counterparty) require((asBorrower ? bought : repaid) == 0, "buyer role");
+            else require((asBorrower ? withdrawn : borrowed) == 0, "seller role");
 
             debtOf[buyer][id] -= repaid;
             bondSharesOf[buyer][id] += boughtShares;
             bondSharesOf[seller][id] -= withdrawnShares;
-            debtOf[seller][id] += bonds - withdrawn;
+            debtOf[seller][id] += borrowed;
 
             totalShares[id] += boughtShares;
             totalShares[id] -= withdrawnShares;

--- a/src/interfaces/IMatching.sol
+++ b/src/interfaces/IMatching.sol
@@ -6,6 +6,11 @@ import "./ITerms.sol";
 
 struct Offer {
     bool buy;
+    // Buying as a borrower is repaying.
+    // Buying as a lender is lending.
+    // Selling as a borrower is borrowing.
+    // Selling as a lender is withdrawing.
+    bool asBorrower;
     address offering;
     uint256 assets;
     address loanToken;
@@ -26,5 +31,5 @@ struct Signature {
 interface IMatching {
     function take(Term memory term, uint256 assets, bytes calldata data)
         external
-        returns (bool buy, address counterparty, uint256 bonds);
+        returns (bool buy, bool asBorrower, address counterparty, uint256 bonds);
 }

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -83,18 +83,19 @@ abstract contract BaseTest is Test {
         return arr;
     }
 
-    function setupBond(Term memory term, uint256 bonds) internal {
+    function setupBond(Term memory term, uint256 bonds, bool asBorrower) internal {
         uint256 collateral = (bonds * 1e18 + term.collaterals[0].lltv - 1) / term.collaterals[0].lltv;
-        setupBond(term, bonds, collateral);
+        setupBond(term, bonds, collateral, asBorrower);
     }
 
-    function setupBond(Term memory term, uint256 bonds, uint256 collateral) internal {
+    function setupBond(Term memory term, uint256 bonds, uint256 collateral, bool asBorrower) internal {
         deal(address(loanToken), lender, bonds);
         deal(address(term.collaterals[0].token), address(this), collateral);
 
         terms.supplyCollateral(term, address(term.collaterals[0].token), collateral, borrower);
         Offer memory borrowOffer = Offer({
             buy: false,
+            asBorrower: asBorrower,
             offering: borrower,
             assets: bonds,
             loanToken: term.loanToken,

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -38,21 +38,21 @@ contract LiquidationTest is BaseTest {
     }
 
     function testLiquidateHealthy() public {
-        setupBond(term, 100);
+        setupBond(term, 100, true);
 
         vm.expectRevert("position is healthy");
         terms.liquidate(term, new Seizure[](2), borrower, "");
     }
 
     function testLiquidateNoOp() public {
-        setupBond(term, 100);
+        setupBond(term, 100, true);
         oracle.setPrice(0);
 
         terms.liquidate(term, new Seizure[](2), borrower, "");
     }
 
     function testLiquidateInconsistentInput() public {
-        setupBond(term, 100);
+        setupBond(term, 100, true);
         oracle.setPrice(0);
 
         Seizure[] memory seizures = new Seizure[](2);
@@ -65,7 +65,7 @@ contract LiquidationTest is BaseTest {
 
     function testLiquidateBondsInput() public {
         // Setup
-        setupBond(term, 100);
+        setupBond(term, 100, true);
         oracle.setPrice(1e36 - 1);
         deal(address(loanToken), address(this), 1);
 
@@ -81,7 +81,7 @@ contract LiquidationTest is BaseTest {
 
     function testLiquidateCollateralInput() public {
         // Setup
-        setupBond(term, 100);
+        setupBond(term, 100, true);
         oracle.setPrice(1e36 - 1);
         deal(address(loanToken), address(this), 1);
 
@@ -97,7 +97,7 @@ contract LiquidationTest is BaseTest {
 
     function testLiquidateBadDebt() public {
         // Setup
-        setupBond(term, 100);
+        setupBond(term, 100, true);
         oracle.setPrice(0.5e36);
         deal(address(loanToken), address(this), 1);
 
@@ -114,7 +114,7 @@ contract LiquidationTest is BaseTest {
         vm.assume(data.length > 0);
 
         // Setup
-        setupBond(term, 100);
+        setupBond(term, 100, true);
         oracle.setPrice(1e36 - 1);
         deal(address(loanToken), address(this), 1);
 

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -63,7 +63,7 @@ contract OtherFunctionsTest is BaseTest {
         supply = bound(supply, minCollateral, 1e41);
         withdraw = bound(withdraw, 0, (supply - minCollateral) / 2);
         deal(address(collateralToken1), address(this), supply);
-        setupBond(term, bonds, supply);
+        setupBond(term, bonds, supply, true);
 
         // Test
         terms.withdrawCollateral(term, address(collateralToken1), withdraw, borrower);
@@ -82,7 +82,7 @@ contract OtherFunctionsTest is BaseTest {
         supply = bound(supply, minCollateral, 1e41);
         withdraw = bound(withdraw, supply - minCollateral + 1, supply);
         deal(address(collateralToken1), address(this), supply);
-        setupBond(term, bonds, supply);
+        setupBond(term, bonds, supply, true);
 
         // Test
         vm.expectRevert("Unhealthy borrower");
@@ -93,7 +93,7 @@ contract OtherFunctionsTest is BaseTest {
         // Note that if this changes the values when the input is in the bounds, it will break withdraw tests.
         bonds = bound(bonds, 0, MAX_TEST_AMOUNT);
         repaid = bound(repaid, 0, bonds);
-        setupBond(term, bonds);
+        setupBond(term, bonds, true);
 
         vm.warp(block.timestamp + 99);
 

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -36,6 +36,7 @@ contract TakeTest is BaseTest {
         id = keccak256(abi.encode(term));
 
         lendOffer.buy = true;
+        borrowOffer.asBorrower = false;
         lendOffer.offering = lender;
         lendOffer.assets = 100;
         lendOffer.loanToken = address(loanToken);
@@ -48,6 +49,7 @@ contract TakeTest is BaseTest {
         }
 
         borrowOffer.buy = false;
+        borrowOffer.asBorrower = true;
         borrowOffer.offering = borrower;
         borrowOffer.assets = 100;
         borrowOffer.loanToken = address(loanToken);
@@ -119,6 +121,7 @@ contract TakeTest is BaseTest {
     function testWithdrawSecondaryWithBorrower() public {
         terms.take(term, 100, lender, address(matching), abi.encode(borrowOffer, sig(borrowOffer, borrowerSK)));
         lendOffer.offering = borrower;
+        lendOffer.asBorrower = true;
         lendOffer.nonce = 1;
         terms.take(term, 100, lender, address(matching), abi.encode(lendOffer, sig(lendOffer, borrowerSK)));
 
@@ -161,6 +164,7 @@ contract TakeTest is BaseTest {
         terms.take(term, 100, borrower, address(matching), abi.encode(lendOffer, sig(lendOffer, lenderSK)));
 
         borrowOffer.offering = lender;
+        borrowOffer.asBorrower = false;
         borrowOffer.nonce = 1;
         terms.take(term, 100, borrower, address(matching), abi.encode(borrowOffer, sig(borrowOffer, lenderSK)));
 


### PR DESCRIPTION
fixes #42 

A buy offer could be intended as a -debt offer (repay) but end up in a different term where there is no debt, and it's taken as a +bond (lend) offer. 

Or: a sell offer could be intended as a -bond (withdraw) offer but end up in a different term where there is are bonds, and it's taken a +debt (borrow) offer. 

With `asBorrower`, on a buy offer you say you strictly want to repay if `true`, or strictly lend if `false`. 

On a sell offer you say you strictly want to borrow if `true`, or strictly withdraw if `false`. 
