### PR TITLE
save gas & simplify in `liquidate`

### DIFF
--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -139,11 +139,12 @@ contract Terms is ITerms {
     {
         Vars memory vars;
         bytes32 id = _id(term);
+        uint256[] memory prices = new uint256[](term.collaterals.length);
 
         for (uint256 i = 0; i < term.collaterals.length; i++) {
-            uint256 price = IOracle(term.collaterals[i].oracle).price();
+            prices[i] = IOracle(term.collaterals[i].oracle).price();
             uint256 collateralQuoted =
-                collateralOf[borrower][id][term.collaterals[i].token].mulDivDown(price, ORACLE_PRICE_SCALE);
+                collateralOf[borrower][id][term.collaterals[i].token].mulDivDown(prices[i], ORACLE_PRICE_SCALE);
             vars.maxDebt += collateralQuoted.mulDivDown(term.collaterals[i].lltv, 1e18);
             vars.repayableDebt += collateralQuoted.mulDivUp(1e18, LIQUIDATION_INCENTIVE_FACTOR);
         }
@@ -158,15 +159,12 @@ contract Terms is ITerms {
             collateralIndex = seizure.collateralIndex;
             require(UtilsLib.exactlyOneZero(seizure.repaidBonds, seizure.seizedAssets), "INCONSISTENT_INPUT");
 
-            uint256 collateralPrice = IOracle(term.collaterals[seizure.collateralIndex].oracle).price();
-
             if (seizure.seizedAssets > 0) {
-                seizure.repaidBonds = seizure.seizedAssets.mulDivUp(collateralPrice, ORACLE_PRICE_SCALE).mulDivUp(
-                    1e18, LIQUIDATION_INCENTIVE_FACTOR
-                );
+                seizure.repaidBonds = seizure.seizedAssets.mulDivUp(prices[seizure.collateralIndex], ORACLE_PRICE_SCALE)
+                    .mulDivUp(1e18, LIQUIDATION_INCENTIVE_FACTOR);
             } else {
                 seizure.seizedAssets = seizure.repaidBonds.mulDivDown(LIQUIDATION_INCENTIVE_FACTOR, 1e18).mulDivDown(
-                    ORACLE_PRICE_SCALE, collateralPrice
+                    ORACLE_PRICE_SCALE, prices[seizure.collateralIndex]
                 );
             }
 

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -207,7 +207,6 @@ contract Terms is ITerms {
         // Realize bad debt
         uint256 badDebt;
 
-        if (totalRepaid > originalDebt) totalRepaid = originalDebt;
         if (repayableDebt < originalDebt) {
             // Because roundings are not aligned the effective bad debt is either the remaining debt or the original
             // debt minus the theoretical repayable debt.

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -119,12 +119,6 @@ contract Terms is ITerms {
         SafeTransferLib.safeTransfer(collateral, msg.sender, assets);
     }
 
-    struct Vars {
-        uint256 maxDebt;
-        uint256 repayableDebt;
-        uint256 totalRepaid;
-    }
-
     /// @notice Execute the given collection of `seizures` on the given `term` of the given `borrower`.
     /// @dev On each seizure either `repaidBonds` or `seizedAssets` should be equal to zero.
     /// @param term The term of the bond.
@@ -137,20 +131,22 @@ contract Terms is ITerms {
         external
         returns (Seizure[] memory)
     {
-        Vars memory vars;
+        uint256 repayableDebt;
+        uint256 maxDebt;
         bytes32 id = _id(term);
         uint256[] memory prices = new uint256[](term.collaterals.length);
 
         for (uint256 i = 0; i < term.collaterals.length; i++) {
             prices[i] = IOracle(term.collaterals[i].oracle).price();
-            uint256 collateralQuoted =
-                collateralOf[borrower][id][term.collaterals[i].token].mulDivDown(prices[i], ORACLE_PRICE_SCALE);
-            vars.maxDebt += collateralQuoted.mulDivDown(term.collaterals[i].lltv, 1e18);
-            vars.repayableDebt += collateralQuoted.mulDivUp(1e18, LIQUIDATION_INCENTIVE_FACTOR);
+            {
+                address token = term.collaterals[i].token;
+                uint256 collateralQuoted = collateralOf[borrower][id][token].mulDivDown(prices[i], ORACLE_PRICE_SCALE);
+                maxDebt += collateralQuoted.mulDivDown(term.collaterals[i].lltv, 1e18);
+                repayableDebt += collateralQuoted.mulDivUp(1e18, LIQUIDATION_INCENTIVE_FACTOR);
+            }
         }
-        uint256 originalDebt = debtOf[borrower][id];
-        require(originalDebt > vars.maxDebt, "position is healthy");
 
+        uint256 totalRepaid;
         uint256 collateralIndex = type(uint256).max;
         Seizure memory seizure;
         for (uint256 i = seizures.length; i > 0; i--) {
@@ -168,31 +164,39 @@ contract Terms is ITerms {
                 );
             }
 
-            vars.totalRepaid += seizure.repaidBonds;
-            collateralOf[borrower][id][term.collaterals[seizure.collateralIndex].token] -= seizure.seizedAssets;
+            totalRepaid += seizure.repaidBonds;
+            address token = term.collaterals[seizure.collateralIndex].token;
+            collateralOf[borrower][id][token] -= seizure.seizedAssets;
         }
 
         // Realize bad debt
-        uint256 badDebt;
-        if (vars.repayableDebt < originalDebt) {
-            // Because roundings are not aligned the effective bad debt is either the remaining debt or the original
-            // debt minus the theoretical repayable debt.
-            badDebt = UtilsLib.min(originalDebt - vars.totalRepaid, originalDebt - vars.repayableDebt);
-            totalBonds[id] -= badDebt;
+        {
+            uint256 originalDebt = debtOf[borrower][id];
+            require(originalDebt > maxDebt, "position is healthy");
+
+            uint256 badDebt;
+
+            if (repayableDebt < originalDebt) {
+                // Because roundings are not aligned the effective bad debt is either the remaining debt or the original
+                // debt minus the theoretical repayable debt.
+                badDebt = UtilsLib.min(originalDebt - totalRepaid, originalDebt - repayableDebt);
+                totalBonds[id] -= badDebt;
+            }
+
+            withdrawable[id] += totalRepaid;
+            debtOf[borrower][id] = originalDebt - totalRepaid - badDebt;
         }
 
-        withdrawable[id] += vars.totalRepaid;
-        debtOf[borrower][id] = originalDebt - vars.totalRepaid - badDebt;
-
         for (uint256 i = 0; i < seizures.length; i++) {
+            seizure = seizures[i];
             SafeTransferLib.safeTransfer(
-                term.collaterals[seizures[i].collateralIndex].token, msg.sender, seizures[i].seizedAssets
+                term.collaterals[seizure.collateralIndex].token, msg.sender, seizure.seizedAssets
             );
         }
 
         if (data.length > 0) IMorphoLiquidationCallback(msg.sender).onLiquidate(seizures, borrower, msg.sender, data);
 
-        SafeTransferLib.safeTransferFrom(term.loanToken, msg.sender, address(this), vars.totalRepaid);
+        SafeTransferLib.safeTransferFrom(term.loanToken, msg.sender, address(this), totalRepaid);
 
         return seizures;
     }

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -122,13 +122,14 @@ contract Terms is ITerms {
     struct Vars {
         uint256 maxDebt;
         uint256 repayableDebt;
+        uint256 totalRepaid;
     }
 
     /// @notice Execute the given collection of `seizures` on the given `term` of the given `borrower`.
-    /// @dev On each seizure either `repaidAmounts` or `seizedAssets` should be equal to zero.
+    /// @dev On each seizure either `repaidBonds` or `seizedAssets` should be equal to zero.
     /// @param term The term of the bond.
     /// @param seizures An array of amounts of debt to repay or assets to seize with the index of the collateral in the
-    /// term's collateral assets.
+    /// term's collateral assets. Must be sorted by collateral index in increasing order.
     /// @param borrower The debtor of the loan.
     /// @param data Arbitrary data to pass to the callback. Pass empty data if not needed.
     /// @return A collection of the actual amounts of debt repaid or asset seized with the collateral index.
@@ -136,8 +137,6 @@ contract Terms is ITerms {
         external
         returns (Seizure[] memory)
     {
-        require(seizures.length == term.collaterals.length, "should have all collats");
-
         Vars memory vars;
         bytes32 id = _id(term);
 
@@ -148,50 +147,54 @@ contract Terms is ITerms {
             vars.maxDebt += collateralQuoted.mulDivDown(term.collaterals[i].lltv, 1e18);
             vars.repayableDebt += collateralQuoted.mulDivUp(1e18, LIQUIDATION_INCENTIVE_FACTOR);
         }
-        require(debtOf[borrower][id] > vars.maxDebt, "position is healthy");
+        uint256 originalDebt = debtOf[borrower][id];
+        require(originalDebt > vars.maxDebt, "position is healthy");
 
-        uint256 totalRepaid;
+        uint256 collateralIndex = type(uint256).max;
+        Seizure memory seizure;
+        for (uint256 i = seizures.length; i > 0; i--) {
+            seizure = seizures[i - 1];
+            require(collateralIndex > seizure.collateralIndex, "not in order");
+            collateralIndex = seizure.collateralIndex;
+            require(UtilsLib.exactlyOneZero(seizure.repaidBonds, seizure.seizedAssets), "INCONSISTENT_INPUT");
 
-        for (uint256 i = 0; i < term.collaterals.length; i++) {
-            if (seizures[i].repaidBonds + seizures[i].seizedAssets > 0) {
-                require(
-                    UtilsLib.exactlyOneZero(seizures[i].repaidBonds, seizures[i].seizedAssets), "INCONSISTENT_INPUT"
+            uint256 collateralPrice = IOracle(term.collaterals[seizure.collateralIndex].oracle).price();
+
+            if (seizure.seizedAssets > 0) {
+                seizure.repaidBonds = seizure.seizedAssets.mulDivUp(collateralPrice, ORACLE_PRICE_SCALE).mulDivUp(
+                    1e18, LIQUIDATION_INCENTIVE_FACTOR
                 );
-
-                uint256 collateralPrice = IOracle(term.collaterals[i].oracle).price();
-
-                if (seizures[i].seizedAssets > 0) {
-                    seizures[i].repaidBonds = seizures[i].seizedAssets.mulDivUp(collateralPrice, ORACLE_PRICE_SCALE)
-                        .mulDivUp(1e18, LIQUIDATION_INCENTIVE_FACTOR);
-                } else {
-                    seizures[i].seizedAssets = seizures[i].repaidBonds.mulDivDown(LIQUIDATION_INCENTIVE_FACTOR, 1e18)
-                        .mulDivDown(ORACLE_PRICE_SCALE, collateralPrice);
-                }
-
-                totalRepaid += seizures[i].repaidBonds;
-                collateralOf[borrower][id][term.collaterals[i].token] -= seizures[i].seizedAssets;
-
-                SafeTransferLib.safeTransfer(term.collaterals[i].token, msg.sender, seizures[i].seizedAssets);
+            } else {
+                seizure.seizedAssets = seizure.repaidBonds.mulDivDown(LIQUIDATION_INCENTIVE_FACTOR, 1e18).mulDivDown(
+                    ORACLE_PRICE_SCALE, collateralPrice
+                );
             }
+
+            vars.totalRepaid += seizure.repaidBonds;
+            collateralOf[borrower][id][term.collaterals[seizure.collateralIndex].token] -= seizure.seizedAssets;
         }
 
-        uint256 originalDebt = debtOf[borrower][id];
-        debtOf[borrower][id] -= totalRepaid;
-
         // Realize bad debt
+        uint256 badDebt;
         if (vars.repayableDebt < originalDebt) {
             // Because roundings are not aligned the effective bad debt is either the remaining debt or the original
             // debt minus the theoretical repayable debt.
-            uint256 badDebt = UtilsLib.min(debtOf[borrower][id], originalDebt - vars.repayableDebt);
-            debtOf[borrower][id] -= badDebt;
+            badDebt = UtilsLib.min(originalDebt - vars.totalRepaid, originalDebt - vars.repayableDebt);
             totalBonds[id] -= badDebt;
         }
 
-        withdrawable[id] += totalRepaid;
+        withdrawable[id] += vars.totalRepaid;
+        debtOf[borrower][id] = originalDebt - vars.totalRepaid - badDebt;
+
+        for (uint256 i = 0; i < seizures.length; i++) {
+            SafeTransferLib.safeTransfer(
+                term.collaterals[seizures[i].collateralIndex].token, msg.sender, seizures[i].seizedAssets
+            );
+        }
 
         if (data.length > 0) IMorphoLiquidationCallback(msg.sender).onLiquidate(seizures, borrower, msg.sender, data);
 
-        SafeTransferLib.safeTransferFrom(term.loanToken, msg.sender, address(this), totalRepaid);
+        SafeTransferLib.safeTransferFrom(term.loanToken, msg.sender, address(this), vars.totalRepaid);
 
         return seizures;
     }

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -175,10 +175,9 @@ contract Terms is ITerms {
         require(originalDebt > maxDebt, "position is healthy");
 
         uint256 totalRepaid;
-        Seizure memory seizure;
 
         for (uint256 i = 0; i < seizures.length; i++) {
-            seizure = seizures[i];
+            Seizure memory seizure = seizures[i];
             require(UtilsLib.exactlyOneZero(seizure.repaidBonds, seizure.seizedAssets), "INCONSISTENT_INPUT");
 
             if (seizure.seizedAssets > 0) {
@@ -210,7 +209,7 @@ contract Terms is ITerms {
         debtOf[borrower][id] = originalDebt - totalRepaid - badDebt;
 
         for (uint256 i = 0; i < seizures.length; i++) {
-            seizure = seizures[i];
+            Seizure memory seizure = seizures[i];
             SafeTransferLib.safeTransfer(
                 term.collaterals[seizure.collateralIndex].token, msg.sender, seizure.seizedAssets
             );

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -173,6 +173,7 @@ contract Terms is ITerms {
         // Realize bad debt
         uint256 badDebt;
 
+        if (totalRepaid > originalDebt) totalRepaid = originalDebt;
         if (repayableDebt < originalDebt) {
             // Because roundings are not aligned the effective bad debt is either the remaining debt or the original
             // debt minus the theoretical repayable debt.

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -123,7 +123,7 @@ contract Terms is ITerms {
     /// @dev On each seizure either `repaidBonds` or `seizedAssets` should be equal to zero.
     /// @param term The term of the bond.
     /// @param seizures An array of amounts of debt to repay or assets to seize with the index of the collateral in the
-    /// term's collateral assets. Must be sorted by collateral index in increasing order.
+    /// term's collateral assets.
     /// @param borrower The debtor of the loan.
     /// @param data Arbitrary data to pass to the callback. Pass empty data if not needed.
     /// @return A collection of the actual amounts of debt repaid or asset seized with the collateral index.

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -139,8 +139,9 @@ contract Terms is ITerms {
         for (uint256 i = 0; i < term.collaterals.length; i++) {
             prices[i] = IOracle(term.collaterals[i].oracle).price();
             {
-                address token = term.collaterals[i].token;
-                uint256 collateralQuoted = collateralOf[borrower][id][token].mulDivDown(prices[i], ORACLE_PRICE_SCALE);
+                address collateralToken = term.collaterals[i].token;
+                uint256 collateralQuoted =
+                    collateralOf[borrower][id][collateralToken].mulDivDown(prices[i], ORACLE_PRICE_SCALE);
                 maxDebt += collateralQuoted.mulDivDown(term.collaterals[i].lltv, 1e18);
                 repayableDebt += collateralQuoted.mulDivUp(1e18, LIQUIDATION_INCENTIVE_FACTOR);
             }
@@ -166,8 +167,8 @@ contract Terms is ITerms {
             }
 
             totalRepaid += seizure.repaidBonds;
-            address token = term.collaterals[seizure.collateralIndex].token;
-            collateralOf[borrower][id][token] -= seizure.seizedAssets;
+            address collateralToken = term.collaterals[seizure.collateralIndex].token;
+            collateralOf[borrower][id][collateralToken] -= seizure.seizedAssets;
         }
 
         // Realize bad debt

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -146,13 +146,14 @@ contract Terms is ITerms {
             }
         }
 
+        uint256 originalDebt = debtOf[borrower][id];
+        require(originalDebt > maxDebt, "position is healthy");
+
         uint256 totalRepaid;
-        uint256 collateralIndex = type(uint256).max;
         Seizure memory seizure;
-        for (uint256 i = seizures.length; i > 0; i--) {
-            seizure = seizures[i - 1];
-            require(collateralIndex > seizure.collateralIndex, "not in order");
-            collateralIndex = seizure.collateralIndex;
+
+        for (uint256 i = 0; i < seizures.length; i++) {
+            seizure = seizures[i];
             require(UtilsLib.exactlyOneZero(seizure.repaidBonds, seizure.seizedAssets), "INCONSISTENT_INPUT");
 
             if (seizure.seizedAssets > 0) {
@@ -170,22 +171,17 @@ contract Terms is ITerms {
         }
 
         // Realize bad debt
-        {
-            uint256 originalDebt = debtOf[borrower][id];
-            require(originalDebt > maxDebt, "position is healthy");
+        uint256 badDebt;
 
-            uint256 badDebt;
-
-            if (repayableDebt < originalDebt) {
-                // Because roundings are not aligned the effective bad debt is either the remaining debt or the original
-                // debt minus the theoretical repayable debt.
-                badDebt = UtilsLib.min(originalDebt - totalRepaid, originalDebt - repayableDebt);
-                totalBonds[id] -= badDebt;
-            }
-
-            withdrawable[id] += totalRepaid;
-            debtOf[borrower][id] = originalDebt - totalRepaid - badDebt;
+        if (repayableDebt < originalDebt) {
+            // Because roundings are not aligned the effective bad debt is either the remaining debt or the original
+            // debt minus the theoretical repayable debt.
+            badDebt = UtilsLib.min(originalDebt - totalRepaid, originalDebt - repayableDebt);
+            totalBonds[id] -= badDebt;
         }
+
+        withdrawable[id] += totalRepaid;
+        debtOf[borrower][id] = originalDebt - totalRepaid - badDebt;
 
         for (uint256 i = 0; i < seizures.length; i++) {
             seizure = seizures[i];

--- a/src/interfaces/ITerms.sol
+++ b/src/interfaces/ITerms.sol
@@ -37,6 +37,8 @@ struct Signature {
 }
 
 struct Seizure {
+    // Index of the collateral in the term's collateral assets.
+    uint256 collateralIndex;
     // Amount of bonds to repay.
     uint256 repaidBonds;
     // Amount of collateral asset to seize.

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -103,4 +103,35 @@ abstract contract BaseTest is Test {
         // take `bonds` because the rate is 0.
         terms.take(term, bonds, lender, borrowOffer, sig(borrowOffer, borrowerSK));
     }
+
+    function setupMaxBondWithCollaterals(Term memory term, uint256 collateral0, uint256 collateral1) internal {
+        uint256 maxDebt = (collateral0 * term.collaterals[0].lltv + collateral1 * term.collaterals[1].lltv) / 1e18;
+        setupBondWithCollaterals(term, maxDebt, collateral0, collateral1);
+    }
+
+    function setupBondWithCollaterals(Term memory term, uint256 bonds, uint256 collateral0, uint256 collateral1)
+        internal
+    {
+        deal(address(loanToken), lender, bonds);
+        deal(address(term.collaterals[0].token), address(this), collateral0);
+        deal(address(term.collaterals[1].token), address(this), collateral1);
+
+        terms.supplyCollateral(term, address(term.collaterals[0].token), collateral0, borrower);
+        terms.supplyCollateral(term, address(term.collaterals[1].token), collateral1, borrower);
+        Offer memory borrowOffer = Offer({
+            buy: false,
+            offering: borrower,
+            assets: bonds,
+            loanToken: term.loanToken,
+            collaterals: term.collaterals,
+            maturity: block.timestamp + 100,
+            offerStart: block.timestamp,
+            offerExpiry: block.timestamp + 200,
+            rate: 0,
+            nonce: 0
+        });
+
+        // take `bonds` because the rate is 0.
+        terms.take(term, bonds, lender, borrowOffer, sig(borrowOffer, borrowerSK));
+    }
 }

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -130,10 +130,12 @@ abstract contract BaseTest is Test {
             offerStart: block.timestamp,
             offerExpiry: block.timestamp + 200,
             rate: 0,
-            nonce: 0
+            nonce: 0,
+            callbackAddress: address(0),
+            callbackData: ""
         });
 
         // take `bonds` because the rate is 0.
-        terms.take(term, bonds, lender, borrowOffer, sig(borrowOffer, borrowerSK));
+        terms.take(term, bonds, lender, borrowOffer, sig(borrowOffer, borrowerSK), address(0), hex"");
     }
 }

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -128,15 +128,16 @@ abstract contract BaseTest is Test {
             loanToken: term.loanToken,
             collaterals: term.collaterals,
             maturity: block.timestamp + 100,
-            offerStart: block.timestamp,
-            offerExpiry: block.timestamp + 200,
-            rate: 0,
+            start: block.timestamp,
+            expiry: block.timestamp + 200,
+            startPrice: 1e18,
+            expiryPrice: 1e18,
             nonce: 0,
             callbackAddress: address(0),
             callbackData: ""
         });
 
         // take `bonds` because the rate is 0.
-        terms.take(term, bonds, lender, borrowOffer, sig(borrowOffer, borrowerSK), address(0), hex"");
+        terms.take(term, 0, bonds, lender, borrowOffer, sig(borrowOffer, borrowerSK), address(0), hex"");
     }
 }

--- a/test/LiquidationGasTest.sol
+++ b/test/LiquidationGasTest.sol
@@ -10,13 +10,13 @@ contract LiquidationTest is BaseTest {
 
     /// forge-config: default.isolate = true
     function testLiquidateGas() public {
-        uint numCollaterals = 10;
-        uint lltv = 0.75e18;
+        uint256 numCollaterals = 10;
+        uint256 lltv = 0.75e18;
 
         // Create collaterals
 
         Collateral[] memory collaterals = new Collateral[](numCollaterals);
-        for (uint i = 0; i < collaterals.length; i++) {
+        for (uint256 i = 0; i < collaterals.length; i++) {
             ERC20 collat = new ERC20("collat", "collat");
             collat.approve(address(terms), type(uint256).max);
             collaterals[i] = Collateral({token: address(collat), lltv: lltv, oracle: address(new Oracle())});
@@ -39,10 +39,9 @@ contract LiquidationTest is BaseTest {
             terms.supplyCollateral(term, collaterals[i].token, collateral, borrower);
         }
 
-
         deal(address(loanToken), lender, 1e3 * 1e18);
 
-        uint maxDebt = collateral * numCollaterals * lltv / 1e18;
+        uint256 maxDebt = collateral * numCollaterals * lltv / 1e18;
 
         // Create and take offer
 
@@ -63,18 +62,17 @@ contract LiquidationTest is BaseTest {
         terms.take(term, maxDebt, lender, borrowOffer, sig(borrowOffer, borrowerSK));
 
         // Setup liquidation
-        for (uint i = 0; i < numCollaterals; i++) {
+        for (uint256 i = 0; i < numCollaterals; i++) {
             Oracle(collaterals[i].oracle).setPrice(1e36 - 1);
         }
         deal(address(loanToken), address(this), 1e3 * 1e18);
 
         // Setup seizures
 
-        Seizure[] memory seizures = new Seizure[](collaterals.length);
-        seizures[0] = Seizure({repaidBonds: 0, seizedAssets: 1});
+        Seizure[] memory seizures = new Seizure[](1);
+        seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 0, seizedAssets: 1});
 
         terms.liquidate(term, seizures, borrower, "");
         // console.log("g %s", vm.lastCallGas().gasTotalUsed);
     }
-
 }

--- a/test/LiquidationGasTest.sol
+++ b/test/LiquidationGasTest.sol
@@ -73,6 +73,6 @@ contract LiquidationTest is BaseTest {
         seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 0, seizedAssets: 1});
 
         terms.liquidate(term, seizures, borrower, "");
-        // console.log("g %s", vm.lastCallGas().gasTotalUsed);
+        console.log("g %s", vm.lastCallGas().gasTotalUsed);
     }
 }

--- a/test/LiquidationGasTest.sol
+++ b/test/LiquidationGasTest.sol
@@ -11,6 +11,7 @@ contract LiquidationTest is BaseTest {
     /// forge-config: default.isolate = true
     function testLiquidateGas() public {
         uint256 numCollaterals = 10;
+        uint numSeizures = 10;
         uint256 lltv = 0.75e18;
 
         // Create collaterals
@@ -71,8 +72,10 @@ contract LiquidationTest is BaseTest {
 
         // Setup seizures
 
-        Seizure[] memory seizures = new Seizure[](1);
-        seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 0, seizedAssets: 1});
+        Seizure[] memory seizures = new Seizure[](numSeizures);
+        for (uint256 i = 0; i < numSeizures; i++) {
+            seizures[i] = Seizure({collateralIndex: i, repaidBonds: 0, seizedAssets: 1});
+        }
 
         terms.liquidate(term, seizures, borrower, "");
         console.log("g %s", vm.lastCallGas().gasTotalUsed);

--- a/test/LiquidationGasTest.sol
+++ b/test/LiquidationGasTest.sol
@@ -11,7 +11,7 @@ contract LiquidationTest is BaseTest {
     /// forge-config: default.isolate = true
     function testLiquidateGas() public {
         uint256 numCollaterals = 10;
-        uint numSeizures = 10;
+        uint256 numSeizures = 10;
         uint256 lltv = 0.75e18;
 
         // Create collaterals

--- a/test/LiquidationGasTest.sol
+++ b/test/LiquidationGasTest.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
+pragma solidity ^0.8.0;
+
+import "./BaseTest.sol";
+
+contract LiquidationTest is BaseTest {
+    Term internal term;
+    bytes32 internal id;
+
+    /// forge-config: default.isolate = true
+    function testLiquidateGas() public {
+        uint numCollaterals = 10;
+        uint lltv = 0.75e18;
+
+        // Create collaterals
+
+        Collateral[] memory collaterals = new Collateral[](numCollaterals);
+        for (uint i = 0; i < collaterals.length; i++) {
+            ERC20 collat = new ERC20("collat", "collat");
+            collat.approve(address(terms), type(uint256).max);
+            collaterals[i] = Collateral({token: address(collat), lltv: lltv, oracle: address(new Oracle())});
+        }
+        collaterals = sortCollaterals(collaterals);
+
+        // Populate term
+
+        term.loanToken = address(loanToken);
+        term.maturity = block.timestamp + 100;
+
+        uint256 collateral = 1e18;
+        for (uint256 i = 0; i < collaterals.length; i++) {
+            term.collaterals.push(collaterals[i]);
+        }
+
+        for (uint256 i = 0; i < collaterals.length; i++) {
+            deal(address(collaterals[i].token), address(this), collateral);
+
+            terms.supplyCollateral(term, collaterals[i].token, collateral, borrower);
+        }
+
+
+        deal(address(loanToken), lender, 1e3 * 1e18);
+
+        uint maxDebt = collateral * numCollaterals * lltv / 1e18;
+
+        // Create and take offer
+
+        id = toId(term);
+        Offer memory borrowOffer = Offer({
+            buy: false,
+            offering: borrower,
+            assets: maxDebt,
+            loanToken: term.loanToken,
+            collaterals: term.collaterals,
+            offerStart: block.timestamp,
+            offerExpiry: block.timestamp + 100,
+            maturity: block.timestamp + 100,
+            rate: 0,
+            nonce: 0
+        });
+
+        terms.take(term, maxDebt, lender, borrowOffer, sig(borrowOffer, borrowerSK));
+
+        // Setup liquidation
+        for (uint i = 0; i < numCollaterals; i++) {
+            Oracle(collaterals[i].oracle).setPrice(1e36 - 1);
+        }
+        deal(address(loanToken), address(this), 1e3 * 1e18);
+
+        // Setup seizures
+
+        Seizure[] memory seizures = new Seizure[](collaterals.length);
+        seizures[0] = Seizure({repaidBonds: 0, seizedAssets: 1});
+
+        terms.liquidate(term, seizures, borrower, "");
+        // console.log("g %s", vm.lastCallGas().gasTotalUsed);
+    }
+
+}

--- a/test/LiquidationGasTest.sol
+++ b/test/LiquidationGasTest.sol
@@ -53,16 +53,17 @@ contract LiquidationTest is BaseTest {
             assets: maxDebt,
             loanToken: term.loanToken,
             collaterals: term.collaterals,
-            offerStart: block.timestamp,
-            offerExpiry: block.timestamp + 100,
+            start: block.timestamp,
+            expiry: block.timestamp + 100,
+            startPrice: 1e18,
+            expiryPrice: 1e18,
             maturity: block.timestamp + 100,
-            rate: 0,
             nonce: 0,
             callbackAddress: address(0),
             callbackData: ""
         });
 
-        terms.take(term, maxDebt, lender, borrowOffer, sig(borrowOffer, borrowerSK), address(0), hex"");
+        terms.take(term, 0, maxDebt, lender, borrowOffer, sig(borrowOffer, borrowerSK), address(0), hex"");
 
         // Setup liquidation
         for (uint256 i = 0; i < numCollaterals; i++) {

--- a/test/LiquidationGasTest.sol
+++ b/test/LiquidationGasTest.sol
@@ -56,10 +56,12 @@ contract LiquidationTest is BaseTest {
             offerExpiry: block.timestamp + 100,
             maturity: block.timestamp + 100,
             rate: 0,
-            nonce: 0
+            nonce: 0,
+            callbackAddress: address(0),
+            callbackData: ""
         });
 
-        terms.take(term, maxDebt, lender, borrowOffer, sig(borrowOffer, borrowerSK));
+        terms.take(term, maxDebt, lender, borrowOffer, sig(borrowOffer, borrowerSK), address(0), hex"");
 
         // Setup liquidation
         for (uint256 i = 0; i < numCollaterals; i++) {

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -13,12 +13,16 @@ contract LiquidationTest is BaseTest {
     address internal recordedLiquidator;
     bytes internal recordedData;
 
+    Oracle internal oracle2;
+
     function setUp() public override {
         super.setUp();
 
+        oracle2 = new Oracle();
+
         Collateral[] memory collaterals = new Collateral[](2);
         collaterals[0] = Collateral({token: address(collateralToken1), lltv: 0.75e18, oracle: address(oracle)});
-        collaterals[1] = Collateral({token: address(collateralToken2), lltv: 0.75e18, oracle: address(oracle)});
+        collaterals[1] = Collateral({token: address(collateralToken2), lltv: 0.75e18, oracle: address(oracle2)});
         collaterals = sortCollaterals(collaterals);
 
         // Populate collaterals one by one to avoid the unsupported memory-to-storage array assignment that breaks the
@@ -42,6 +46,7 @@ contract LiquidationTest is BaseTest {
     function testLiquidateNoOp() public {
         setupBond(term, 100);
         oracle.setPrice(0);
+        oracle2.setPrice(0);
 
         terms.liquidate(term, new Seizure[](0), borrower, "");
     }
@@ -49,6 +54,7 @@ contract LiquidationTest is BaseTest {
     function testLiquidateInconsistentInput() public {
         setupBond(term, 100);
         oracle.setPrice(0);
+        oracle2.setPrice(0);
 
         Seizure[] memory seizures = new Seizure[](1);
         seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 1, seizedAssets: 1});
@@ -61,6 +67,7 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(1e36 - 1);
+        oracle2.setPrice(1e36 - 1);
         deal(address(loanToken), address(this), 1);
 
         // Test
@@ -76,6 +83,7 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(1e36 - 1);
+        oracle2.setPrice(1e36 - 1);
         deal(address(loanToken), address(this), 1);
 
         // Test
@@ -91,6 +99,7 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(0.5e36);
+        oracle2.setPrice(0.5e36);
         deal(address(loanToken), address(this), 1);
 
         // Test
@@ -107,6 +116,7 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(1e36 - 1);
+        oracle2.setPrice(1e36 - 1);
         deal(address(loanToken), address(this), 1);
 
         // Test
@@ -120,6 +130,26 @@ contract LiquidationTest is BaseTest {
         assertEq(recordedBorrower, borrower, "borrower");
         assertEq(recordedLiquidator, address(this), "liquidator");
         assertEq(recordedData, data, "data");
+    }
+
+    // Check that it is possible to seize all assets even if rounding overestimates bonds.
+    function testTotalRepaidTooHigh() public {
+        setupMaxBondWithCollaterals(term, 100, 100);
+        uint256 price = 1e36 * 1e18 / terms.LIQUIDATION_INCENTIVE_FACTOR() * 98 / 100;
+        uint256 price2 = 1e36 * 1e18 / terms.LIQUIDATION_INCENTIVE_FACTOR();
+        oracle.setPrice(price);
+        oracle2.setPrice(price2);
+        deal(address(loanToken), address(this), 100e18);
+
+        Seizure[] memory seizures = new Seizure[](2);
+        seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 0, seizedAssets: 100});
+        seizures[1] = Seizure({collateralIndex: 1, repaidBonds: 0, seizedAssets: 100});
+
+        // repaying all bonds would leave some assets behind
+        // seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 75, seizedAssets: 0});
+        // seizures[1] = Seizure({collateralIndex: 1, repaidBonds: 75, seizedAssets: 0});
+
+        terms.liquidate(term, seizures, borrower, "");
     }
 
     function onLiquidate(Seizure[] memory seizures, address borrower, address liquidator, bytes memory data) public {

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -47,7 +47,7 @@ contract LiquidationTest is BaseTest {
         setupBond(term, 100);
 
         vm.expectRevert("position is healthy");
-        terms.liquidate(term, new Seizure[](2), borrower, "");
+        terms.liquidate(term, new Seizure[](0), borrower, "");
     }
 
     function testLiquidateNoOp() public {

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -32,9 +32,15 @@ contract LiquidationTest is BaseTest {
         id = toId(term);
     }
 
-    function testLiquidateWrongSeizuresLength() public {
-        vm.expectRevert("should have all collats");
-        terms.liquidate(term, new Seizure[](0), borrower, "");
+    function testLiquidateWrongSeizuresOrder() public {
+        setupBond(term, 100);
+        oracle.setPrice(0);
+        Seizure[] memory seizures = new Seizure[](2);
+        seizures[0] = Seizure({collateralIndex: 1, repaidBonds: 0, seizedAssets: 100});
+        seizures[1] = Seizure({collateralIndex: 0, repaidBonds: 0, seizedAssets: 100});
+
+        vm.expectRevert("not in order");
+        terms.liquidate(term, seizures, borrower, "");
     }
 
     function testLiquidateHealthy() public {
@@ -48,16 +54,15 @@ contract LiquidationTest is BaseTest {
         setupBond(term, 100);
         oracle.setPrice(0);
 
-        terms.liquidate(term, new Seizure[](2), borrower, "");
+        terms.liquidate(term, new Seizure[](0), borrower, "");
     }
 
     function testLiquidateInconsistentInput() public {
         setupBond(term, 100);
         oracle.setPrice(0);
 
-        Seizure[] memory seizures = new Seizure[](2);
-        seizures[0] = Seizure({repaidBonds: 1, seizedAssets: 1});
-        seizures[1] = Seizure({repaidBonds: 0, seizedAssets: 100});
+        Seizure[] memory seizures = new Seizure[](1);
+        seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 1, seizedAssets: 1});
 
         vm.expectRevert("INCONSISTENT_INPUT");
         terms.liquidate(term, seizures, borrower, "");
@@ -70,9 +75,8 @@ contract LiquidationTest is BaseTest {
         deal(address(loanToken), address(this), 1);
 
         // Test
-        Seizure[] memory seizures = new Seizure[](2);
-        seizures[0] = Seizure({repaidBonds: 1, seizedAssets: 0});
-        seizures[1] = Seizure({repaidBonds: 0, seizedAssets: 0});
+        Seizure[] memory seizures = new Seizure[](1);
+        seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 1, seizedAssets: 0});
         terms.liquidate(term, seizures, borrower, "");
         assertEq(terms.debtOf(borrower, id), 99);
         assertEq(terms.collateralOf(borrower, id, term.collaterals[0].token), 133);
@@ -86,9 +90,8 @@ contract LiquidationTest is BaseTest {
         deal(address(loanToken), address(this), 1);
 
         // Test
-        Seizure[] memory seizures = new Seizure[](2);
-        seizures[0] = Seizure({repaidBonds: 0, seizedAssets: 1});
-        seizures[1] = Seizure({repaidBonds: 0, seizedAssets: 0});
+        Seizure[] memory seizures = new Seizure[](1);
+        seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 0, seizedAssets: 1});
         terms.liquidate(term, seizures, borrower, "");
         assertEq(loanToken.balanceOf(address(this)), 0);
         assertEq(terms.debtOf(borrower, id), 99);
@@ -102,9 +105,8 @@ contract LiquidationTest is BaseTest {
         deal(address(loanToken), address(this), 1);
 
         // Test
-        Seizure[] memory seizures = new Seizure[](2);
-        seizures[0] = Seizure({repaidBonds: 1, seizedAssets: 0});
-        seizures[1] = Seizure({repaidBonds: 0, seizedAssets: 0});
+        Seizure[] memory seizures = new Seizure[](1);
+        seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 1, seizedAssets: 0});
         terms.liquidate(term, seizures, borrower, "");
         assertEq(terms.collateralOf(borrower, id, term.collaterals[0].token), 132);
         // TODO assert bad debt
@@ -119,16 +121,13 @@ contract LiquidationTest is BaseTest {
         deal(address(loanToken), address(this), 1);
 
         // Test
-        Seizure[] memory seizures = new Seizure[](2);
-        seizures[0] = Seizure({repaidBonds: 1, seizedAssets: 0});
-        seizures[1] = Seizure({repaidBonds: 0, seizedAssets: 0});
+        Seizure[] memory seizures = new Seizure[](1);
+        seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 1, seizedAssets: 0});
         terms.liquidate(term, seizures, borrower, data);
 
-        assertEq(recordedSeizures.length, 2, "seizures length");
+        assertEq(recordedSeizures.length, 1, "seizures length");
         assertEq(recordedSeizures[0].repaidBonds, 1, "repaid bonds");
         assertEq(recordedSeizures[0].seizedAssets, 1, "seized assets");
-        assertEq(recordedSeizures[1].repaidBonds, 0, "repaid bonds");
-        assertEq(recordedSeizures[1].seizedAssets, 0, "seized assets");
         assertEq(recordedBorrower, borrower, "borrower");
         assertEq(recordedLiquidator, address(this), "liquidator");
         assertEq(recordedData, data, "data");

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -13,16 +13,12 @@ contract LiquidationTest is BaseTest {
     address internal recordedLiquidator;
     bytes internal recordedData;
 
-    Oracle internal oracle2;
-
     function setUp() public override {
         super.setUp();
 
-        oracle2 = new Oracle();
-
         Collateral[] memory collaterals = new Collateral[](2);
         collaterals[0] = Collateral({token: address(collateralToken1), lltv: 0.75e18, oracle: address(oracle)});
-        collaterals[1] = Collateral({token: address(collateralToken2), lltv: 0.75e18, oracle: address(oracle2)});
+        collaterals[1] = Collateral({token: address(collateralToken2), lltv: 0.75e18, oracle: address(oracle)});
         collaterals = sortCollaterals(collaterals);
 
         // Populate collaterals one by one to avoid the unsupported memory-to-storage array assignment that breaks the
@@ -46,7 +42,6 @@ contract LiquidationTest is BaseTest {
     function testLiquidateNoOp() public {
         setupBond(term, 100);
         oracle.setPrice(0);
-        oracle2.setPrice(0);
 
         terms.liquidate(term, new Seizure[](0), borrower, "");
     }
@@ -54,7 +49,6 @@ contract LiquidationTest is BaseTest {
     function testLiquidateInconsistentInput() public {
         setupBond(term, 100);
         oracle.setPrice(0);
-        oracle2.setPrice(0);
 
         Seizure[] memory seizures = new Seizure[](1);
         seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 1, seizedAssets: 1});
@@ -67,7 +61,6 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(1e36 - 1);
-        oracle2.setPrice(1e36 - 1);
         deal(address(loanToken), address(this), 1);
 
         // Test
@@ -83,7 +76,6 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(1e36 - 1);
-        oracle2.setPrice(1e36 - 1);
         deal(address(loanToken), address(this), 1);
 
         // Test
@@ -99,7 +91,6 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(0.5e36);
-        oracle2.setPrice(0.5e36);
         deal(address(loanToken), address(this), 1);
 
         // Test
@@ -116,7 +107,6 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(1e36 - 1);
-        oracle2.setPrice(1e36 - 1);
         deal(address(loanToken), address(this), 1);
 
         // Test
@@ -132,8 +122,12 @@ contract LiquidationTest is BaseTest {
         assertEq(recordedData, data, "data");
     }
 
-    // Check that it is possible to seize all assets even if rounding overestimates bonds.
+    // Check that it is not always possible to seize all assets due to roundings.
     function testTotalRepaidTooHigh() public {
+        Oracle oracle2 = new Oracle();
+        term.collaterals[1].oracle = address(oracle2);
+        id = toId(term);
+
         setupMaxBondWithCollaterals(term, 100, 100);
         uint256 price = 1e36 * 1e18 / terms.LIQUIDATION_INCENTIVE_FACTOR() * 98 / 100;
         uint256 price2 = 1e36 * 1e18 / terms.LIQUIDATION_INCENTIVE_FACTOR();
@@ -142,14 +136,19 @@ contract LiquidationTest is BaseTest {
         deal(address(loanToken), address(this), 100e18);
 
         Seizure[] memory seizures = new Seizure[](2);
+
+        // Seizing all collateral repays too much debt.
         seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 0, seizedAssets: 100});
         seizures[1] = Seizure({collateralIndex: 1, repaidBonds: 0, seizedAssets: 100});
 
-        // repaying all bonds would leave some assets behind
-        // seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 75, seizedAssets: 0});
-        // seizures[1] = Seizure({collateralIndex: 1, repaidBonds: 75, seizedAssets: 0});
-
+        vm.expectRevert(stdError.arithmeticError);
         terms.liquidate(term, seizures, borrower, "");
+
+        // Repaying all bonds can leave some assets behind
+        seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 75, seizedAssets: 0});
+        seizures[1] = Seizure({collateralIndex: 1, repaidBonds: 75, seizedAssets: 0});
+        terms.liquidate(term, seizures, borrower, "");
+        vm.assertGt(terms.collateralOf(borrower, id, term.collaterals[1].token), 0);
     }
 
     function onLiquidate(Seizure[] memory seizures, address borrower, address liquidator, bytes memory data) public {

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -32,17 +32,6 @@ contract LiquidationTest is BaseTest {
         id = toId(term);
     }
 
-    function testLiquidateWrongSeizuresOrder() public {
-        setupBond(term, 100);
-        oracle.setPrice(0);
-        Seizure[] memory seizures = new Seizure[](2);
-        seizures[0] = Seizure({collateralIndex: 1, repaidBonds: 0, seizedAssets: 100});
-        seizures[1] = Seizure({collateralIndex: 0, repaidBonds: 0, seizedAssets: 100});
-
-        vm.expectRevert("not in order");
-        terms.liquidate(term, seizures, borrower, "");
-    }
-
     function testLiquidateHealthy() public {
         setupBond(term, 100);
 


### PR DESCRIPTION
- small seizures array, saves about 20k gas with 10 collaterals and 1 seizure
- transfer collaterals after updating internal accounting to be reentrancy safe
- single debt update
- ~fix totalRepaid > debt~ there is still the issue that due to roundings, it may not be possible to both 1) completely repay a debt and 2) seize all collateral