### PR TITLE
fix: cap repaid bonds to original debt

### DIFF
--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -173,6 +173,7 @@ contract Terms is ITerms {
         // Realize bad debt
         uint256 badDebt;
 
+        if (totalRepaid > originalDebt) totalRepaid = originalDebt;
         if (repayableDebt < originalDebt) {
             // Because roundings are not aligned the effective bad debt is either the remaining debt or the original
             // debt minus the theoretical repayable debt.

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -103,4 +103,35 @@ abstract contract BaseTest is Test {
         // take `bonds` because the rate is 0.
         terms.take(term, bonds, lender, borrowOffer, sig(borrowOffer, borrowerSK));
     }
+
+    function setupMaxBondWithCollaterals(Term memory term, uint256 collateral0, uint256 collateral1) internal {
+        uint256 maxDebt = (collateral0 * term.collaterals[0].lltv + collateral1 * term.collaterals[1].lltv) / 1e18;
+        setupBondWithCollaterals(term, maxDebt, collateral0, collateral1);
+    }
+
+    function setupBondWithCollaterals(Term memory term, uint256 bonds, uint256 collateral0, uint256 collateral1)
+        internal
+    {
+        deal(address(loanToken), lender, bonds);
+        deal(address(term.collaterals[0].token), address(this), collateral0);
+        deal(address(term.collaterals[1].token), address(this), collateral1);
+
+        terms.supplyCollateral(term, address(term.collaterals[0].token), collateral0, borrower);
+        terms.supplyCollateral(term, address(term.collaterals[1].token), collateral1, borrower);
+        Offer memory borrowOffer = Offer({
+            buy: false,
+            offering: borrower,
+            assets: bonds,
+            loanToken: term.loanToken,
+            collaterals: term.collaterals,
+            maturity: block.timestamp + 100,
+            offerStart: block.timestamp,
+            offerExpiry: block.timestamp + 200,
+            rate: 0,
+            nonce: 0
+        });
+
+        // take `bonds` because the rate is 0.
+        terms.take(term, bonds, lender, borrowOffer, sig(borrowOffer, borrowerSK));
+    }
 }

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -13,12 +13,16 @@ contract LiquidationTest is BaseTest {
     address internal recordedLiquidator;
     bytes internal recordedData;
 
+    Oracle internal oracle2;
+
     function setUp() public override {
         super.setUp();
 
+        oracle2 = new Oracle();
+
         Collateral[] memory collaterals = new Collateral[](2);
         collaterals[0] = Collateral({token: address(collateralToken1), lltv: 0.75e18, oracle: address(oracle)});
-        collaterals[1] = Collateral({token: address(collateralToken2), lltv: 0.75e18, oracle: address(oracle)});
+        collaterals[1] = Collateral({token: address(collateralToken2), lltv: 0.75e18, oracle: address(oracle2)});
         collaterals = sortCollaterals(collaterals);
 
         // Populate collaterals one by one to avoid the unsupported memory-to-storage array assignment that breaks the
@@ -42,6 +46,7 @@ contract LiquidationTest is BaseTest {
     function testLiquidateNoOp() public {
         setupBond(term, 100);
         oracle.setPrice(0);
+        oracle2.setPrice(0);
 
         terms.liquidate(term, new Seizure[](0), borrower, "");
     }
@@ -49,6 +54,7 @@ contract LiquidationTest is BaseTest {
     function testLiquidateInconsistentInput() public {
         setupBond(term, 100);
         oracle.setPrice(0);
+        oracle2.setPrice(0);
 
         Seizure[] memory seizures = new Seizure[](1);
         seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 1, seizedAssets: 1});
@@ -61,6 +67,7 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(1e36 - 1);
+        oracle2.setPrice(1e36 - 1);
         deal(address(loanToken), address(this), 1);
 
         // Test
@@ -76,6 +83,7 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(1e36 - 1);
+        oracle2.setPrice(1e36 - 1);
         deal(address(loanToken), address(this), 1);
 
         // Test
@@ -91,6 +99,7 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(0.5e36);
+        oracle2.setPrice(0.5e36);
         deal(address(loanToken), address(this), 1);
 
         // Test
@@ -107,6 +116,7 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(1e36 - 1);
+        oracle2.setPrice(1e36 - 1);
         deal(address(loanToken), address(this), 1);
 
         // Test
@@ -120,6 +130,26 @@ contract LiquidationTest is BaseTest {
         assertEq(recordedBorrower, borrower, "borrower");
         assertEq(recordedLiquidator, address(this), "liquidator");
         assertEq(recordedData, data, "data");
+    }
+
+    // Check that it is possible to seize all assets even if rounding overestimates bonds.
+    function testTotalRepaidTooHigh() public {
+        setupMaxBondWithCollaterals(term, 100, 100);
+        uint256 price = 1e36 * 1e18 / terms.LIQUIDATION_INCENTIVE_FACTOR() * 98 / 100;
+        uint256 price2 = 1e36 * 1e18 / terms.LIQUIDATION_INCENTIVE_FACTOR();
+        oracle.setPrice(price);
+        oracle2.setPrice(price2);
+        deal(address(loanToken), address(this), 100e18);
+
+        Seizure[] memory seizures = new Seizure[](2);
+        seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 0, seizedAssets: 100});
+        seizures[1] = Seizure({collateralIndex: 1, repaidBonds: 0, seizedAssets: 100});
+
+        // repaying all bonds would leave some assets behind
+        // seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 75, seizedAssets: 0});
+        // seizures[1] = Seizure({collateralIndex: 1, repaidBonds: 75, seizedAssets: 0});
+
+        terms.liquidate(term, seizures, borrower, "");
     }
 
     function onLiquidate(Seizure[] memory seizures, address borrower, address liquidator, bytes memory data) public {


### PR DESCRIPTION
It is possible to be in a state of bad debt such that for one collateral,
* if you try to repay all bonds, not all the collateral is seized.
* if you try to seize all the collateral, the repaid bonds are overestimated and `originalDebt - totalRepaid` underflows.