### PR TITLE
merge storage mappings to reduce keccak computations

### DIFF
--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -26,7 +26,7 @@ contract Terms is ITerms {
     struct User {
         uint256 debt;
         uint256 shares;
-        mapping (address => uint256) collateral;
+        mapping(address => uint256) collateral;
     }
 
     struct Loan {
@@ -86,8 +86,7 @@ contract Terms is ITerms {
             uint256 repaid = UtilsLib.min(buyUser.debt, bonds);
             uint256 bought = bonds - repaid;
             uint256 boughtShares = bought.mulDivDown(loan.shares + 1, loan.bonds + 1);
-            uint256 withdrawn =
-                UtilsLib.min(sellUser.shares.mulDivDown(loan.bonds + 1, loan.shares + 1), bonds);
+            uint256 withdrawn = UtilsLib.min(sellUser.shares.mulDivDown(loan.bonds + 1, loan.shares + 1), bonds);
             uint256 withdrawnShares = withdrawn.mulDivUp(loan.shares + 1, loan.bonds + 1);
 
             buyUser.debt -= repaid;
@@ -100,10 +99,9 @@ contract Terms is ITerms {
             loan.bonds += bought;
             loan.bonds -= withdrawn;
 
-        if (buyerCallbackAddress != address(0)) {
-            ICallbacks(buyerCallbackAddress).onTake(term, buyer, assets, buyerCallbackData);
-        }
-
+            if (buyerCallbackAddress != address(0)) {
+                ICallbacks(buyerCallbackAddress).onTake(term, buyer, assets, buyerCallbackData);
+            }
         }
         SafeTransferLib.safeTransferFrom(offer.loanToken, buyer, seller, assets);
 
@@ -309,5 +307,4 @@ contract Terms is ITerms {
     function loanShares(bytes32 termId) external view returns (uint256) {
         return loans[termId].shares;
     }
-
 }

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -26,14 +26,14 @@ contract Terms is ITerms {
     struct User {
         uint256 debt;
         uint256 bondShares;
-        mapping (address collateralAddress => uint256) collateral;
+        mapping (address => uint256) collateral;
     }
 
     struct Loan {
         uint256 withdrawable;
         uint256 totalBonds;
         uint256 totalShares;
-        mapping(address userAddress => User) users;
+        mapping(address => User) users;
     }
 
     mapping(bytes32 termId => Loan) public loans;
@@ -62,33 +62,32 @@ contract Terms is ITerms {
         require((consumed[offer.offering][offer.nonce] += assets) <= offer.assets, "consumed");
 
 
-        (address buyerAddress, address sellerAddress) = offer.buy ? (offer.offering, onBehalf) : (onBehalf, offer.offering);
+        (address buyer, address seller) = offer.buy ? (offer.offering, onBehalf) : (onBehalf, offer.offering);
         Loan storage loan = loans[_id(term)];
-        User storage buyer = loan.users[buyerAddress];
-        User storage seller = loan.users[sellerAddress];
+        User storage buyUser = loan.users[buyer];
+        User storage sellUser = loan.users[seller];
         {
-            uint256 repaid = UtilsLib.min(buyer.debt, bonds);
+            uint256 repaid = UtilsLib.min(buyUser.debt, bonds);
             uint256 bought = bonds - repaid;
             uint256 boughtShares = bought.mulDivDown(loan.totalShares + 1, loan.totalBonds + 1);
             uint256 withdrawn =
-                UtilsLib.min(seller.bondShares.mulDivDown(loan.totalBonds + 1, loan.totalShares + 1), bonds);
+                UtilsLib.min(sellUser.bondShares.mulDivDown(loan.totalBonds + 1, loan.totalShares + 1), bonds);
             uint256 withdrawnShares = withdrawn.mulDivUp(loan.totalShares + 1, loan.totalBonds + 1);
 
-            buyer.debt -= repaid;
-            buyer.bondShares += boughtShares;
-            seller.bondShares -= withdrawnShares;
-            seller.debt += bonds - withdrawn;
+            buyUser.debt -= repaid;
+            buyUser.bondShares += boughtShares;
+            sellUser.bondShares -= withdrawnShares;
+            sellUser.debt += bonds - withdrawn;
 
             loan.totalShares += boughtShares;
             loan.totalShares -= withdrawnShares;
             loan.totalBonds += bought;
             loan.totalBonds -= withdrawn;
 
-            require(_isHealthy(term, sellerAddress), "Seller is unhealthy");
+            require(_isHealthy(term, seller), "Seller is unhealthy");
 
         }
-
-        SafeTransferLib.safeTransferFrom(offer.loanToken, buyerAddress, sellerAddress, assets);
+        SafeTransferLib.safeTransferFrom(offer.loanToken, buyer, seller, assets);
     }
 
     /// @dev Will revert if there is no withdrawable funds.
@@ -117,17 +116,17 @@ contract Terms is ITerms {
         SafeTransferLib.safeTransferFrom(term.loanToken, msg.sender, address(this), bonds);
     }
 
-    function supplyCollateral(Term memory term, address collateralAddress, uint256 assets, address onBehalf) external {
-        loans[_id(term)].users[onBehalf].collateral[collateralAddress] += assets;
-        SafeTransferLib.safeTransferFrom(collateralAddress, msg.sender, address(this), assets);
+    function supplyCollateral(Term memory term, address collateral, uint256 assets, address onBehalf) external {
+        loans[_id(term)].users[onBehalf].collateral[collateral] += assets;
+        SafeTransferLib.safeTransferFrom(collateral, msg.sender, address(this), assets);
     }
 
-    function withdrawCollateral(Term memory term, address collateralAddress, uint256 assets, address onBehalf) external {
-        loans[_id(term)].users[onBehalf].collateral[collateralAddress] -= assets;
+    function withdrawCollateral(Term memory term, address collateral, uint256 assets, address onBehalf) external {
+        loans[_id(term)].users[onBehalf].collateral[collateral] -= assets;
 
         require(_isHealthy(term, onBehalf), "Unhealthy borrower");
 
-        SafeTransferLib.safeTransfer(collateralAddress, msg.sender, assets);
+        SafeTransferLib.safeTransfer(collateral, msg.sender, assets);
     }
 
     struct Vars {
@@ -135,15 +134,15 @@ contract Terms is ITerms {
         uint256 repayableDebt;
     }
 
-    /// @notice Execute the given collection of `seizures` on the given `term` of the given `borrowerAddress`.
+    /// @notice Execute the given collection of `seizures` on the given `term` of the given `borrower`.
     /// @dev On each seizure either `repaidAmounts` or `seizedAssets` should be equal to zero.
     /// @param term The term of the bond.
     /// @param seizures An array of amounts of debt to repay or assets to seize with the index of the collateral in the
     /// term's collateral assets.
-    /// @param borrowerAddress The debtor of the loan.
+    /// @param borrower The debtor of the loan.
     /// @param data Arbitrary data to pass to the callback. Pass empty data if not needed.
     /// @return A collection of the actual amounts of debt repaid or asset seized with the collateral index.
-    function liquidate(Term memory term, Seizure[] memory seizures, address borrowerAddress, bytes calldata data)
+    function liquidate(Term memory term, Seizure[] memory seizures, address borrower, bytes calldata data)
         external
         returns (Seizure[] memory)
     {
@@ -151,16 +150,16 @@ contract Terms is ITerms {
 
         Vars memory vars;
         Loan storage loan = loans[_id(term)];
-        User storage borrower = loan.users[borrowerAddress];
+        User storage borrowUser = loan.users[borrower];
 
         for (uint256 i = 0; i < term.collaterals.length; i++) {
             uint256 price = IOracle(term.collaterals[i].oracle).price();
             uint256 collateralQuoted =
-                borrower.collateral[term.collaterals[i].token].mulDivDown(price, ORACLE_PRICE_SCALE);
+                borrowUser.collateral[term.collaterals[i].token].mulDivDown(price, ORACLE_PRICE_SCALE);
             vars.maxDebt += collateralQuoted.mulDivDown(term.collaterals[i].lltv, 1e18);
             vars.repayableDebt += collateralQuoted.mulDivUp(1e18, LIQUIDATION_INCENTIVE_FACTOR);
         }
-        require(borrower.debt > vars.maxDebt, "position is healthy");
+        require(borrowUser.debt > vars.maxDebt, "position is healthy");
 
         uint256 totalRepaid;
 
@@ -181,27 +180,27 @@ contract Terms is ITerms {
                 }
 
                 totalRepaid += seizures[i].repaidBonds;
-                borrower.collateral[term.collaterals[i].token] -= seizures[i].seizedAssets;
+                borrowUser.collateral[term.collaterals[i].token] -= seizures[i].seizedAssets;
 
                 SafeTransferLib.safeTransfer(term.collaterals[i].token, msg.sender, seizures[i].seizedAssets);
             }
         }
 
-        uint256 originalDebt = borrower.debt;
-        borrower.debt -= totalRepaid;
+        uint256 originalDebt = borrowUser.debt;
+        borrowUser.debt -= totalRepaid;
 
         // Realize bad debt
         if (vars.repayableDebt < originalDebt) {
             // Because roundings are not aligned the effective bad debt is either the remaining debt or the original
             // debt minus the theoretical repayable debt.
-            uint256 badDebt = UtilsLib.min(borrower.debt, originalDebt - vars.repayableDebt);
-            borrower.debt -= badDebt;
+            uint256 badDebt = UtilsLib.min(borrowUser.debt, originalDebt - vars.repayableDebt);
+            borrowUser.debt -= badDebt;
             loan.totalBonds -= badDebt;
         }
 
         loan.withdrawable += totalRepaid;
 
-        if (data.length > 0) IMorphoLiquidationCallback(msg.sender).onLiquidate(seizures, borrowerAddress, msg.sender, data);
+        if (data.length > 0) IMorphoLiquidationCallback(msg.sender).onLiquidate(seizures, borrower, msg.sender, data);
 
         SafeTransferLib.safeTransferFrom(term.loanToken, msg.sender, address(this), totalRepaid);
 
@@ -242,10 +241,10 @@ contract Terms is ITerms {
         require(signatory != address(0) && offer.offering == signatory, "Invalid signature");
     }
 
-    function _isHealthy(Term memory term, address borrowerAddress) internal view returns (bool) {
-        User storage borrower = loans[_id(term)].users[borrowerAddress];
+    function _isHealthy(Term memory term, address borrower) internal view returns (bool) {
+        User storage borrowUser = loans[_id(term)].users[borrower];
 
-        uint256 debt = borrower.debt;
+        uint256 debt = borrowUser.debt;
         if (debt == 0) {
             return true;
         } else {
@@ -253,7 +252,7 @@ contract Terms is ITerms {
             for (uint256 i = 0; i < term.collaterals.length; i++) {
                 uint256 price = IOracle(term.collaterals[i].oracle).price();
                 uint256 collateralQuoted =
-                    borrower.collateral[term.collaterals[i].token].mulDivDown(price, ORACLE_PRICE_SCALE);
+                    borrowUser.collateral[term.collaterals[i].token].mulDivDown(price, ORACLE_PRICE_SCALE);
                 maxDebt += collateralQuoted.mulDivDown(term.collaterals[i].lltv, 1e18);
             }
 
@@ -263,16 +262,16 @@ contract Terms is ITerms {
 
     // GETTER FUNCTIONS //
 
-    function debtOf(address borrowerAddress, bytes32 termId) external view returns (uint256) {
-        return loans[termId].users[borrowerAddress].debt;
+    function debtOf(address borrower, bytes32 termId) external view returns (uint256) {
+        return loans[termId].users[borrower].debt;
     }
 
-    function bondSharesOf(address borrowerAddress, bytes32 termId) external view returns (uint256) {
-        return loans[termId].users[borrowerAddress].bondShares;
+    function bondSharesOf(address borrower, bytes32 termId) external view returns (uint256) {
+        return loans[termId].users[borrower].bondShares;
     }
 
-    function collateralOf(address borrowerAddress, bytes32 termId, address collateral) external view returns (uint256) {
-        return loans[termId].users[borrowerAddress].collateral[collateral];
+    function collateralOf(address borrower, bytes32 termId, address collateral) external view returns (uint256) {
+        return loans[termId].users[borrower].collateral[collateral];
     }
 
     function withdrawable(bytes32 termId) external view returns (uint256) {

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -23,12 +23,20 @@ contract Terms is ITerms {
 
     /// STORAGE ///
 
-    mapping(address => mapping(bytes32 => uint256)) public bondSharesOf;
-    mapping(address => mapping(bytes32 => uint256)) public debtOf;
-    mapping(bytes32 => uint256) public withdrawable;
-    mapping(bytes32 => uint256) public totalBonds;
-    mapping(bytes32 => uint256) public totalShares;
-    mapping(address => mapping(bytes32 => mapping(address => uint256))) public collateralOf;
+    struct User {
+        uint256 debt;
+        uint256 bondShares;
+        mapping (address collateralAddress => uint256) collateral;
+    }
+
+    struct Loan {
+        uint256 withdrawable;
+        uint256 totalBonds;
+        uint256 totalShares;
+        mapping(address userAddress => User) users;
+    }
+
+    mapping(bytes32 termId => Loan) public loans;
 
     /// @dev Multiple offers can have the same nonce. This allows to implement easy and efficient batch-cancelling and
     /// OCO (One-Cancels-the-Other) orders. Note that OCO orders work better if all offers have the same amount,
@@ -53,70 +61,73 @@ contract Terms is ITerms {
 
         require((consumed[offer.offering][offer.nonce] += assets) <= offer.assets, "consumed");
 
-        (address buyer, address seller) = offer.buy ? (offer.offering, onBehalf) : (onBehalf, offer.offering);
-        bytes32 id = _id(term);
 
+        (address buyerAddress, address sellerAddress) = offer.buy ? (offer.offering, onBehalf) : (onBehalf, offer.offering);
+        Loan storage loan = loans[_id(term)];
+        User storage buyer = loan.users[buyerAddress];
+        User storage seller = loan.users[sellerAddress];
         {
-            uint256 repaid = UtilsLib.min(debtOf[buyer][id], bonds);
+            uint256 repaid = UtilsLib.min(buyer.debt, bonds);
             uint256 bought = bonds - repaid;
-            uint256 boughtShares = bought.mulDivDown(totalShares[id] + 1, totalBonds[id] + 1);
+            uint256 boughtShares = bought.mulDivDown(loan.totalShares + 1, loan.totalBonds + 1);
             uint256 withdrawn =
-                UtilsLib.min(bondSharesOf[seller][id].mulDivDown(totalBonds[id] + 1, totalShares[id] + 1), bonds);
-            uint256 withdrawnShares = withdrawn.mulDivUp(totalShares[id] + 1, totalBonds[id] + 1);
+                UtilsLib.min(seller.bondShares.mulDivDown(loan.totalBonds + 1, loan.totalShares + 1), bonds);
+            uint256 withdrawnShares = withdrawn.mulDivUp(loan.totalShares + 1, loan.totalBonds + 1);
 
-            debtOf[buyer][id] -= repaid;
-            bondSharesOf[buyer][id] += boughtShares;
-            bondSharesOf[seller][id] -= withdrawnShares;
-            debtOf[seller][id] += bonds - withdrawn;
+            buyer.debt -= repaid;
+            buyer.bondShares += boughtShares;
+            seller.bondShares -= withdrawnShares;
+            seller.debt += bonds - withdrawn;
 
-            totalShares[id] += boughtShares;
-            totalShares[id] -= withdrawnShares;
-            totalBonds[id] += bought;
-            totalBonds[id] -= withdrawn;
+            loan.totalShares += boughtShares;
+            loan.totalShares -= withdrawnShares;
+            loan.totalBonds += bought;
+            loan.totalBonds -= withdrawn;
 
-            require(_isHealthy(term, seller), "Seller is unhealthy");
+            require(_isHealthy(term, sellerAddress), "Seller is unhealthy");
+
         }
 
-        SafeTransferLib.safeTransferFrom(offer.loanToken, buyer, seller, assets);
+        SafeTransferLib.safeTransferFrom(offer.loanToken, buyerAddress, sellerAddress, assets);
     }
 
     /// @dev Will revert if there is no withdrawable funds.
     function withdrawBond(Term memory term, uint256 bonds, uint256 shares, address onBehalf) external {
         require(UtilsLib.exactlyOneZero(bonds, shares), "INCONSISTENT_INPUT");
-        bytes32 id = _id(term);
+        Loan storage loan = loans[_id(term)];
 
-        if (bonds > 0) shares = bonds.mulDivUp(totalShares[id] + 1, totalBonds[id] + 1);
-        else bonds = shares.mulDivDown(totalBonds[id] + 1, totalShares[id] + 1);
+        if (bonds > 0) shares = bonds.mulDivUp(loan.totalShares + 1, loan.totalBonds + 1);
+        else bonds = shares.mulDivDown(loan.totalBonds + 1, loan.totalShares + 1);
 
-        bondSharesOf[onBehalf][id] -= shares;
-        withdrawable[id] -= bonds;
+        loan.users[onBehalf].bondShares -= shares;
+        loan.withdrawable -= bonds;
 
-        totalShares[id] -= shares;
-        totalBonds[id] -= bonds;
+        loan.totalShares -= shares;
+        loan.totalBonds -= bonds;
 
         SafeTransferLib.safeTransfer(term.loanToken, msg.sender, bonds);
     }
 
     function repayDebt(Term memory term, uint256 bonds, address onBehalf) external {
-        bytes32 id = _id(term);
+        Loan storage loan = loans[_id(term)];
 
-        debtOf[onBehalf][id] -= bonds;
-        withdrawable[id] += bonds;
+        loan.users[onBehalf].debt -= bonds;
+        loan.withdrawable += bonds;
 
         SafeTransferLib.safeTransferFrom(term.loanToken, msg.sender, address(this), bonds);
     }
 
-    function supplyCollateral(Term memory term, address collateral, uint256 assets, address onBehalf) external {
-        collateralOf[onBehalf][_id(term)][collateral] += assets;
-        SafeTransferLib.safeTransferFrom(collateral, msg.sender, address(this), assets);
+    function supplyCollateral(Term memory term, address collateralAddress, uint256 assets, address onBehalf) external {
+        loans[_id(term)].users[onBehalf].collateral[collateralAddress] += assets;
+        SafeTransferLib.safeTransferFrom(collateralAddress, msg.sender, address(this), assets);
     }
 
-    function withdrawCollateral(Term memory term, address collateral, uint256 assets, address onBehalf) external {
-        collateralOf[onBehalf][_id(term)][collateral] -= assets;
+    function withdrawCollateral(Term memory term, address collateralAddress, uint256 assets, address onBehalf) external {
+        loans[_id(term)].users[onBehalf].collateral[collateralAddress] -= assets;
 
         require(_isHealthy(term, onBehalf), "Unhealthy borrower");
 
-        SafeTransferLib.safeTransfer(collateral, msg.sender, assets);
+        SafeTransferLib.safeTransfer(collateralAddress, msg.sender, assets);
     }
 
     struct Vars {
@@ -124,31 +135,32 @@ contract Terms is ITerms {
         uint256 repayableDebt;
     }
 
-    /// @notice Execute the given collection of `seizures` on the given `term` of the given `borrower`.
+    /// @notice Execute the given collection of `seizures` on the given `term` of the given `borrowerAddress`.
     /// @dev On each seizure either `repaidAmounts` or `seizedAssets` should be equal to zero.
     /// @param term The term of the bond.
     /// @param seizures An array of amounts of debt to repay or assets to seize with the index of the collateral in the
     /// term's collateral assets.
-    /// @param borrower The debtor of the loan.
+    /// @param borrowerAddress The debtor of the loan.
     /// @param data Arbitrary data to pass to the callback. Pass empty data if not needed.
     /// @return A collection of the actual amounts of debt repaid or asset seized with the collateral index.
-    function liquidate(Term memory term, Seizure[] memory seizures, address borrower, bytes calldata data)
+    function liquidate(Term memory term, Seizure[] memory seizures, address borrowerAddress, bytes calldata data)
         external
         returns (Seizure[] memory)
     {
         require(seizures.length == term.collaterals.length, "should have all collats");
 
         Vars memory vars;
-        bytes32 id = _id(term);
+        Loan storage loan = loans[_id(term)];
+        User storage borrower = loan.users[borrowerAddress];
 
         for (uint256 i = 0; i < term.collaterals.length; i++) {
             uint256 price = IOracle(term.collaterals[i].oracle).price();
             uint256 collateralQuoted =
-                collateralOf[borrower][id][term.collaterals[i].token].mulDivDown(price, ORACLE_PRICE_SCALE);
+                borrower.collateral[term.collaterals[i].token].mulDivDown(price, ORACLE_PRICE_SCALE);
             vars.maxDebt += collateralQuoted.mulDivDown(term.collaterals[i].lltv, 1e18);
             vars.repayableDebt += collateralQuoted.mulDivUp(1e18, LIQUIDATION_INCENTIVE_FACTOR);
         }
-        require(debtOf[borrower][id] > vars.maxDebt, "position is healthy");
+        require(borrower.debt > vars.maxDebt, "position is healthy");
 
         uint256 totalRepaid;
 
@@ -169,27 +181,27 @@ contract Terms is ITerms {
                 }
 
                 totalRepaid += seizures[i].repaidBonds;
-                collateralOf[borrower][id][term.collaterals[i].token] -= seizures[i].seizedAssets;
+                borrower.collateral[term.collaterals[i].token] -= seizures[i].seizedAssets;
 
                 SafeTransferLib.safeTransfer(term.collaterals[i].token, msg.sender, seizures[i].seizedAssets);
             }
         }
 
-        uint256 originalDebt = debtOf[borrower][id];
-        debtOf[borrower][id] -= totalRepaid;
+        uint256 originalDebt = borrower.debt;
+        borrower.debt -= totalRepaid;
 
         // Realize bad debt
         if (vars.repayableDebt < originalDebt) {
             // Because roundings are not aligned the effective bad debt is either the remaining debt or the original
             // debt minus the theoretical repayable debt.
-            uint256 badDebt = UtilsLib.min(debtOf[borrower][id], originalDebt - vars.repayableDebt);
-            debtOf[borrower][id] -= badDebt;
-            totalBonds[id] -= badDebt;
+            uint256 badDebt = UtilsLib.min(borrower.debt, originalDebt - vars.repayableDebt);
+            borrower.debt -= badDebt;
+            loan.totalBonds -= badDebt;
         }
 
-        withdrawable[id] += totalRepaid;
+        loan.withdrawable += totalRepaid;
 
-        if (data.length > 0) IMorphoLiquidationCallback(msg.sender).onLiquidate(seizures, borrower, msg.sender, data);
+        if (data.length > 0) IMorphoLiquidationCallback(msg.sender).onLiquidate(seizures, borrowerAddress, msg.sender, data);
 
         SafeTransferLib.safeTransferFrom(term.loanToken, msg.sender, address(this), totalRepaid);
 
@@ -230,9 +242,10 @@ contract Terms is ITerms {
         require(signatory != address(0) && offer.offering == signatory, "Invalid signature");
     }
 
-    function _isHealthy(Term memory term, address borrower) internal view returns (bool) {
-        bytes32 id = _id(term);
-        uint256 debt = debtOf[borrower][id];
+    function _isHealthy(Term memory term, address borrowerAddress) internal view returns (bool) {
+        User storage borrower = loans[_id(term)].users[borrowerAddress];
+
+        uint256 debt = borrower.debt;
         if (debt == 0) {
             return true;
         } else {
@@ -240,11 +253,38 @@ contract Terms is ITerms {
             for (uint256 i = 0; i < term.collaterals.length; i++) {
                 uint256 price = IOracle(term.collaterals[i].oracle).price();
                 uint256 collateralQuoted =
-                    collateralOf[borrower][id][term.collaterals[i].token].mulDivDown(price, ORACLE_PRICE_SCALE);
+                    borrower.collateral[term.collaterals[i].token].mulDivDown(price, ORACLE_PRICE_SCALE);
                 maxDebt += collateralQuoted.mulDivDown(term.collaterals[i].lltv, 1e18);
             }
 
             return debt <= maxDebt;
         }
     }
+
+    // GETTER FUNCTIONS //
+
+    function debtOf(address borrowerAddress, bytes32 termId) external view returns (uint256) {
+        return loans[termId].users[borrowerAddress].debt;
+    }
+
+    function bondSharesOf(address borrowerAddress, bytes32 termId) external view returns (uint256) {
+        return loans[termId].users[borrowerAddress].bondShares;
+    }
+
+    function collateralOf(address borrowerAddress, bytes32 termId, address collateral) external view returns (uint256) {
+        return loans[termId].users[borrowerAddress].collateral[collateral];
+    }
+
+    function withdrawable(bytes32 termId) external view returns (uint256) {
+        return loans[termId].withdrawable;
+    }
+
+    function totalBonds(bytes32 termId) external view returns (uint256) {
+        return loans[termId].totalBonds;
+    }
+
+    function totalShares(bytes32 termId) external view returns (uint256) {
+        return loans[termId].totalShares;
+    }
+
 }

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -25,14 +25,14 @@ contract Terms is ITerms {
 
     struct User {
         uint256 debt;
-        uint256 bondShares;
+        uint256 shares;
         mapping (address => uint256) collateral;
     }
 
     struct Loan {
         uint256 withdrawable;
-        uint256 totalBonds;
-        uint256 totalShares;
+        uint256 bonds;
+        uint256 shares;
         mapping(address => User) users;
     }
 
@@ -69,20 +69,20 @@ contract Terms is ITerms {
         {
             uint256 repaid = UtilsLib.min(buyUser.debt, bonds);
             uint256 bought = bonds - repaid;
-            uint256 boughtShares = bought.mulDivDown(loan.totalShares + 1, loan.totalBonds + 1);
+            uint256 boughtShares = bought.mulDivDown(loan.shares + 1, loan.bonds + 1);
             uint256 withdrawn =
-                UtilsLib.min(sellUser.bondShares.mulDivDown(loan.totalBonds + 1, loan.totalShares + 1), bonds);
-            uint256 withdrawnShares = withdrawn.mulDivUp(loan.totalShares + 1, loan.totalBonds + 1);
+                UtilsLib.min(sellUser.shares.mulDivDown(loan.bonds + 1, loan.shares + 1), bonds);
+            uint256 withdrawnShares = withdrawn.mulDivUp(loan.shares + 1, loan.bonds + 1);
 
             buyUser.debt -= repaid;
-            buyUser.bondShares += boughtShares;
-            sellUser.bondShares -= withdrawnShares;
+            buyUser.shares += boughtShares;
+            sellUser.shares -= withdrawnShares;
             sellUser.debt += bonds - withdrawn;
 
-            loan.totalShares += boughtShares;
-            loan.totalShares -= withdrawnShares;
-            loan.totalBonds += bought;
-            loan.totalBonds -= withdrawn;
+            loan.shares += boughtShares;
+            loan.shares -= withdrawnShares;
+            loan.bonds += bought;
+            loan.bonds -= withdrawn;
 
             require(_isHealthy(term, seller), "Seller is unhealthy");
 
@@ -95,14 +95,14 @@ contract Terms is ITerms {
         require(UtilsLib.exactlyOneZero(bonds, shares), "INCONSISTENT_INPUT");
         Loan storage loan = loans[_id(term)];
 
-        if (bonds > 0) shares = bonds.mulDivUp(loan.totalShares + 1, loan.totalBonds + 1);
-        else bonds = shares.mulDivDown(loan.totalBonds + 1, loan.totalShares + 1);
+        if (bonds > 0) shares = bonds.mulDivUp(loan.shares + 1, loan.bonds + 1);
+        else bonds = shares.mulDivDown(loan.bonds + 1, loan.shares + 1);
 
-        loan.users[onBehalf].bondShares -= shares;
+        loan.users[onBehalf].shares -= shares;
         loan.withdrawable -= bonds;
 
-        loan.totalShares -= shares;
-        loan.totalBonds -= bonds;
+        loan.shares -= shares;
+        loan.bonds -= bonds;
 
         SafeTransferLib.safeTransfer(term.loanToken, msg.sender, bonds);
     }
@@ -195,7 +195,7 @@ contract Terms is ITerms {
             // debt minus the theoretical repayable debt.
             uint256 badDebt = UtilsLib.min(borrowUser.debt, originalDebt - vars.repayableDebt);
             borrowUser.debt -= badDebt;
-            loan.totalBonds -= badDebt;
+            loan.bonds -= badDebt;
         }
 
         loan.withdrawable += totalRepaid;
@@ -266,8 +266,8 @@ contract Terms is ITerms {
         return loans[termId].users[borrower].debt;
     }
 
-    function bondSharesOf(address borrower, bytes32 termId) external view returns (uint256) {
-        return loans[termId].users[borrower].bondShares;
+    function sharesOf(address borrower, bytes32 termId) external view returns (uint256) {
+        return loans[termId].users[borrower].shares;
     }
 
     function collateralOf(address borrower, bytes32 termId, address collateral) external view returns (uint256) {
@@ -278,12 +278,12 @@ contract Terms is ITerms {
         return loans[termId].withdrawable;
     }
 
-    function totalBonds(bytes32 termId) external view returns (uint256) {
-        return loans[termId].totalBonds;
+    function loanBonds(bytes32 termId) external view returns (uint256) {
+        return loans[termId].bonds;
     }
 
-    function totalShares(bytes32 termId) external view returns (uint256) {
-        return loans[termId].totalShares;
+    function loanShares(bytes32 termId) external view returns (uint256) {
+        return loans[termId].shares;
     }
 
 }

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -126,7 +126,7 @@ contract OtherFunctionsTest is BaseTest {
         vm.prank(lender);
         terms.withdrawBond(term, withdraw, 0, lender);
 
-        assertEq(terms.bondSharesOf(lender, id), bonds - withdraw, "bondSharesOf");
+        assertEq(terms.sharesOf(lender, id), bonds - withdraw, "sharesOf");
         assertEq(terms.withdrawable(id), 0, "withdrawable");
         assertEq(loanToken.balanceOf(address(terms)), 0, "balance of terms");
         assertEq(loanToken.balanceOf(lender), withdraw, "balance of lender");
@@ -143,7 +143,7 @@ contract OtherFunctionsTest is BaseTest {
         vm.prank(lender);
         terms.withdrawBond(term, 0, shares, lender);
 
-        assertEq(terms.bondSharesOf(lender, id), bonds - shares, "bondSharesOf");
+        assertEq(terms.sharesOf(lender, id), bonds - shares, "sharesOf");
         assertEq(terms.withdrawable(id), 0, "withdrawable");
         assertEq(loanToken.balanceOf(address(terms)), 0, "balance of terms");
         assertEq(loanToken.balanceOf(lender), shares, "balance of lender");

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -77,10 +77,10 @@ contract TakeTest is BaseTest {
     function testLend() public {
         terms.take(term, 100, lender, borrowOffer, sig(borrowOffer, borrowerSK));
 
-        assertEq(terms.bondSharesOf(lender, id), 101, "lender bond shares");
+        assertEq(terms.sharesOf(lender, id), 101, "lender shares");
         assertEq(terms.debtOf(borrower, id), 101, "borrower debt");
-        assertEq(terms.totalBonds(id), 101, "total bonds");
-        assertEq(terms.totalShares(id), 101, "total shares");
+        assertEq(terms.loanBonds(id), 101, "loan bonds");
+        assertEq(terms.loanShares(id), 101, "loan shares");
         assertEq(loanToken.balanceOf(borrower), 100, "borrower balance");
         assertEq(loanToken.balanceOf(lender), 0, "lender balance");
         assertEq(terms.consumed(borrower, 0), 100, "borrower nonce");
@@ -89,10 +89,10 @@ contract TakeTest is BaseTest {
     function testBorrow() public {
         terms.take(term, 100, borrower, lendOffer, sig(lendOffer, lenderSK));
 
-        assertEq(terms.bondSharesOf(lender, id), 101, "bond shares");
+        assertEq(terms.sharesOf(lender, id), 101, "lender shares");
         assertEq(terms.debtOf(borrower, id), 101, "lender debt");
-        assertEq(terms.totalBonds(id), 101, "total bonds");
-        assertEq(terms.totalShares(id), 101, "total shares");
+        assertEq(terms.loanBonds(id), 101, "loan bonds");
+        assertEq(terms.loanShares(id), 101, "loan shares");
         assertEq(loanToken.balanceOf(borrower), 100, "borrower balance");
         assertEq(loanToken.balanceOf(lender), 0, "lender balance");
         assertEq(terms.consumed(lender, 0), 100, "lender nonce");
@@ -108,10 +108,10 @@ contract TakeTest is BaseTest {
         lendOffer.offering = otherLender;
         terms.take(term, 100, lender, lendOffer, sig(lendOffer, otherLenderSK));
 
-        assertEq(terms.bondSharesOf(lender, id), 0, "lender bond shares");
-        assertEq(terms.bondSharesOf(otherLender, id), 101, "other lender bond shares");
-        assertEq(terms.totalBonds(id), 101, "total bonds");
-        assertEq(terms.totalShares(id), 101, "total shares");
+        assertEq(terms.sharesOf(lender, id), 0, "lender shares");
+        assertEq(terms.sharesOf(otherLender, id), 101, "other lender shares");
+        assertEq(terms.loanBonds(id), 101, "loan bonds");
+        assertEq(terms.loanShares(id), 101, "loan shares");
         assertEq(terms.consumed(otherLender, 0), 100, "other lender nonce");
         assertEq(loanToken.balanceOf(lender), 100, "lender balance");
         assertEq(loanToken.balanceOf(otherLender), 0, "other lender balance");
@@ -123,10 +123,10 @@ contract TakeTest is BaseTest {
         lendOffer.nonce = 1;
         terms.take(term, 100, lender, lendOffer, sig(lendOffer, borrowerSK));
 
-        assertEq(terms.bondSharesOf(lender, id), 0, "lender bond shares");
-        assertEq(terms.bondSharesOf(borrower, id), 0, "borrower bond shares");
-        assertEq(terms.totalBonds(id), 0, "total bonds");
-        assertEq(terms.totalShares(id), 0, "total shares");
+        assertEq(terms.sharesOf(lender, id), 0, "lender shares");
+        assertEq(terms.sharesOf(borrower, id), 0, "borrower shares");
+        assertEq(terms.loanBonds(id), 0, "loan bonds");
+        assertEq(terms.loanShares(id), 0, "loan shares");
         assertEq(terms.consumed(borrower, 1), 100, "borrower nonce");
         assertEq(loanToken.balanceOf(lender), 100, "lender balance");
         assertEq(loanToken.balanceOf(borrower), 0, "borrower balance");
@@ -143,13 +143,13 @@ contract TakeTest is BaseTest {
         borrowOffer.offering = otherBorrower;
         terms.take(term, 100, borrower, borrowOffer, sig(borrowOffer, otherBorrowerSK));
 
-        assertEq(terms.bondSharesOf(lender, id), 101, "lender bond shares");
-        assertEq(terms.bondSharesOf(borrower, id), 0, "borrower bond shares");
-        assertEq(terms.bondSharesOf(otherBorrower, id), 0, "other borrower bond shares");
+        assertEq(terms.sharesOf(lender, id), 101, "lender shares");
+        assertEq(terms.sharesOf(borrower, id), 0, "borrower shares");
+        assertEq(terms.sharesOf(otherBorrower, id), 0, "other borrower shares");
         assertEq(terms.debtOf(borrower, id), 0, "borrower debt");
         assertEq(terms.debtOf(otherBorrower, id), 101, "other borrower debt");
-        assertEq(terms.totalBonds(id), 101, "total bonds");
-        assertEq(terms.totalShares(id), 101, "total shares");
+        assertEq(terms.loanBonds(id), 101, "loan bonds");
+        assertEq(terms.loanShares(id), 101, "loan shares");
         assertEq(terms.consumed(otherBorrower, 0), 100, "other borrower nonce");
         assertEq(loanToken.balanceOf(borrower), 0, "borrower balance");
         assertEq(loanToken.balanceOf(otherBorrower), 100, "other borrower balance");
@@ -162,12 +162,12 @@ contract TakeTest is BaseTest {
         borrowOffer.nonce = 1;
         terms.take(term, 100, borrower, borrowOffer, sig(borrowOffer, lenderSK));
 
-        assertEq(terms.bondSharesOf(lender, id), 0, "lender bond shares");
-        assertEq(terms.bondSharesOf(borrower, id), 0, "borrower bond shares");
+        assertEq(terms.sharesOf(lender, id), 0, "lender shares");
+        assertEq(terms.sharesOf(borrower, id), 0, "borrower shares");
         assertEq(terms.debtOf(borrower, id), 0, "borrower debt");
         assertEq(terms.debtOf(lender, id), 0, "lender debt");
-        assertEq(terms.totalBonds(id), 0, "total bonds");
-        assertEq(terms.totalShares(id), 0, "total shares");
+        assertEq(terms.loanBonds(id), 0, "loan bonds");
+        assertEq(terms.loanShares(id), 0, "loan shares");
         assertEq(terms.consumed(lender, 1), 100, "lender nonce");
         assertEq(loanToken.balanceOf(borrower), 0, "borrower balance");
         assertEq(loanToken.balanceOf(lender), 100, "lender balance");
@@ -177,7 +177,7 @@ contract TakeTest is BaseTest {
         terms.take(term, 100, address(this), borrowOffer, sig(borrowOffer, borrowerSK));
         terms.take(term, 100, address(this), lendOffer, sig(lendOffer, lenderSK));
 
-        assertEq(terms.bondSharesOf(address(this), id), 0, "bond shares");
+        assertEq(terms.sharesOf(address(this), id), 0, "shares");
         assertEq(terms.debtOf(address(this), id), 0, "debt");
         assertEq(loanToken.balanceOf(address(this)), 100, "balance");
         assertEq(terms.consumed(lender, 0), 100, "lender nonce");


### PR DESCRIPTION
* simpler code
* save gas (eg 7k gas /1.2% in `testMatch`) note that the screenshots compares in the wrong direction so it looks like a gas loss

<img width="751" height="489" alt="image" src="https://github.com/user-attachments/assets/1208bd8d-e32b-4d3b-9ab1-5c31af1dece1" />
