### PR TITLE
debt can be covered with loan asset

### DIFF
--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -9,7 +9,6 @@ import {MathLib} from "./libraries/MathLib.sol";
 import {IOracle} from "./interfaces/IOracle.sol";
 import {IMorphoV2, Obligation, Offer, Signature, Seizure} from "./interfaces/IMorphoV2.sol";
 import {ICallbacks} from "./interfaces/ICallbacks.sol";
-import "forge-std/console.sol";
 
 contract MorphoV2 is IMorphoV2 {
     using MathLib for uint256;
@@ -264,9 +263,6 @@ contract MorphoV2 is IMorphoV2 {
         }
 
         uint256 originalDebt = debtOf(borrower, id);
-        console.log("originalDebt", originalDebt);
-        console.log("coveredDebt", coveredDebtOf[borrower][id]);
-        console.log("maxDebt", maxDebt);
         require(originalDebt > maxDebt, "position is healthy");
 
         uint256 badDebt = originalDebt.zeroFloorSub(repayableDebt);

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -9,6 +9,7 @@ import {MathLib} from "./libraries/MathLib.sol";
 import {IOracle} from "./interfaces/IOracle.sol";
 import {IMorphoV2, Obligation, Offer, Signature, Seizure} from "./interfaces/IMorphoV2.sol";
 import {ICallbacks} from "./interfaces/ICallbacks.sol";
+import "forge-std/console.sol";
 
 contract MorphoV2 is IMorphoV2 {
     using MathLib for uint256;
@@ -16,7 +17,8 @@ contract MorphoV2 is IMorphoV2 {
     /// STORAGE ///
 
     mapping(address => mapping(bytes32 => uint256)) public sharesOf;
-    mapping(address => mapping(bytes32 => uint256)) public debtOf;
+    mapping(address => mapping(bytes32 => uint256)) public fullDebtOf;
+    mapping(address => mapping(bytes32 => uint256)) public coveredDebtOf;
     mapping(bytes32 => uint256) public withdrawable;
     mapping(bytes32 => uint256) public totalUnits;
     mapping(bytes32 => uint256) public totalShares;
@@ -143,19 +145,19 @@ contract MorphoV2 is IMorphoV2 {
             (consumed[offer.maker][offer.nonce] += (offer.buy ? buyerAssets : sellerAssets)) <= offer.assets, "consumed"
         );
 
-        if (debtOf[buyer][id] == 0 && sharesOf[seller][id] == 0) {
+        if (fullDebtOf[buyer][id] == 0 && sharesOf[seller][id] == 0) {
             sharesOf[buyer][id] += obligationShares;
-            debtOf[seller][id] += obligationUnits;
+            fullDebtOf[seller][id] += obligationUnits;
             totalShares[id] += obligationShares;
             totalUnits[id] += obligationUnits;
-        } else if (debtOf[buyer][id] == 0 && sharesOf[seller][id] > 0) {
+        } else if (fullDebtOf[buyer][id] == 0 && sharesOf[seller][id] > 0) {
             sharesOf[buyer][id] += obligationShares;
             sharesOf[seller][id] -= obligationShares;
-        } else if (debtOf[buyer][id] > 0 && sharesOf[seller][id] == 0) {
-            debtOf[buyer][id] -= obligationUnits;
-            debtOf[seller][id] += obligationUnits;
+        } else if (fullDebtOf[buyer][id] > 0 && sharesOf[seller][id] == 0) {
+            fullDebtOf[buyer][id] -= obligationUnits;
+            fullDebtOf[seller][id] += obligationUnits;
         } else {
-            debtOf[buyer][id] -= obligationUnits;
+            fullDebtOf[buyer][id] -= obligationUnits;
             sharesOf[seller][id] -= obligationShares;
             totalShares[id] -= obligationShares;
             totalUnits[id] -= obligationUnits;
@@ -183,6 +185,7 @@ contract MorphoV2 is IMorphoV2 {
     function withdraw(Obligation memory obligation, uint256 obligationUnits, uint256 shares, address onBehalf)
         external
     {
+        require(obligation.maturity < block.timestamp, "obligation maturity");
         require(UtilsLib.atMostOneNonZero(obligationUnits, shares), "INCONSISTENT_INPUT");
         bytes32 id = _id(obligation);
 
@@ -198,13 +201,22 @@ contract MorphoV2 is IMorphoV2 {
         SafeTransferLib.safeTransfer(obligation.loanToken, msg.sender, obligationUnits);
     }
 
-    function repay(Obligation memory obligation, uint256 obligationUnits, address onBehalf) external {
+    function coverDebt(Obligation memory obligation, uint256 assets, address onBehalf) external {
         bytes32 id = _id(obligation);
+        coveredDebtOf[onBehalf][id] += assets;
+        withdrawable[id] += assets;
+        SafeTransferLib.safeTransferFrom(obligation.loanToken, msg.sender, address(this), assets);
+    }
 
-        debtOf[onBehalf][id] -= obligationUnits;
-        withdrawable[id] += obligationUnits;
+    function uncoverDebt(Obligation memory obligation, uint256 assets, address onBehalf) external {
+        bytes32 id = _id(obligation);
+        coveredDebtOf[onBehalf][id] -= assets;
+        withdrawable[id] -= assets;
 
-        SafeTransferLib.safeTransferFrom(obligation.loanToken, msg.sender, address(this), obligationUnits);
+        if (obligation.maturity < block.timestamp) require(debtOf(onBehalf, id) == 0, "no debt");
+        else require(_isHealthy(obligation, onBehalf), "Unhealthy borrower");
+
+        SafeTransferLib.safeTransfer(obligation.loanToken, msg.sender, assets);
     }
 
     function supplyCollateral(Obligation memory obligation, address collateral, uint256 assets, address onBehalf)
@@ -226,6 +238,7 @@ contract MorphoV2 is IMorphoV2 {
 
     /// @notice Execute the given collection of `seizures` on the given `obligation` of the given `borrower`.
     /// @dev On each seizure either `repaid` or `seized` should be equal to zero.
+    /// @dev Covered debt cannot be liquidated.
     /// @param obligation The obligation.
     /// @param seizures An array of amounts of debt to repay or assets to seize with the index of the collateral in the
     /// obligation's collateral assets.
@@ -250,12 +263,15 @@ contract MorphoV2 is IMorphoV2 {
                 .mulDivUp(prices[i], ORACLE_PRICE_SCALE);
         }
 
-        uint256 originalDebt = debtOf[borrower][id];
+        uint256 originalDebt = debtOf(borrower, id);
+        console.log("originalDebt", originalDebt);
+        console.log("coveredDebt", coveredDebtOf[borrower][id]);
+        console.log("maxDebt", maxDebt);
         require(originalDebt > maxDebt, "position is healthy");
 
         uint256 badDebt = originalDebt.zeroFloorSub(repayableDebt);
         if (badDebt > 0) {
-            debtOf[borrower][id] -= badDebt;
+            fullDebtOf[borrower][id] -= badDebt;
             totalUnits[id] -= badDebt;
         }
 
@@ -279,7 +295,7 @@ contract MorphoV2 is IMorphoV2 {
         }
 
         withdrawable[id] += totalRepaid;
-        debtOf[borrower][id] -= totalRepaid;
+        coveredDebtOf[borrower][id] += totalRepaid;
 
         for (uint256 i = 0; i < seizures.length; i++) {
             Seizure memory seizure = seizures[i];
@@ -293,6 +309,11 @@ contract MorphoV2 is IMorphoV2 {
         SafeTransferLib.safeTransferFrom(obligation.loanToken, msg.sender, address(this), totalRepaid);
 
         return seizures;
+    }
+
+    /// @notice The debt of the borrower excluding the covered amount.
+    function debtOf(address borrower, bytes32 id) public view returns (uint256) {
+        return MathLib.zeroFloorSub(fullDebtOf[borrower][id], coveredDebtOf[borrower][id]);
     }
 
     /// INTERNAL ///
@@ -310,7 +331,7 @@ contract MorphoV2 is IMorphoV2 {
 
     function _isHealthy(Obligation memory obligation, address borrower) internal view returns (bool) {
         bytes32 id = _id(obligation);
-        uint256 debt = debtOf[borrower][id];
+        uint256 debt = debtOf(borrower, id);
         if (debt == 0) {
             return true;
         } else {

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -95,12 +95,25 @@ abstract contract BaseTest is Test {
     function setupObligation(Obligation memory obligation, uint256 obligationUnits) internal {
         uint256 collateral =
             (obligationUnits * 1e18 + obligation.collaterals[0].lltv - 1) / obligation.collaterals[0].lltv;
-        setupObligation(obligation, obligationUnits, collateral);
+        setupObligation(obligation, obligationUnits, collateral, obligation.maturity);
     }
 
-    function setupObligation(Obligation memory obligation, uint256 obligationUnits, uint256 collateral) internal {
+    function setupObligation(Obligation memory obligation, uint256 obligationUnits, uint256 offerMaturity) internal {
+        uint256 collateral =
+            (obligationUnits * 1e18 + obligation.collaterals[0].lltv - 1) / obligation.collaterals[0].lltv;
+        setupObligation(obligation, obligationUnits, collateral, offerMaturity);
+    }
+
+    function setupObligation(
+        Obligation memory obligation,
+        uint256 obligationUnits,
+        uint256 collateral,
+        uint256 offerMaturity
+    ) internal {
         deal(address(loanToken), lender, obligationUnits);
         deal(address(obligation.collaterals[0].token), address(this), collateral);
+
+        obligation.maturity = offerMaturity;
 
         morphoV2.supplyCollateral(obligation, address(obligation.collaterals[0].token), collateral, borrower);
         Offer memory borrowOffer = Offer({

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -68,7 +68,7 @@ contract OtherFunctionsTest is BaseTest {
         supply = bound(supply, minCollateral, 1e41);
         withdraw = bound(withdraw, 0, (supply - minCollateral) / 2);
         deal(address(collateralToken1), address(this), supply);
-        setupObligation(obligation, obligations, supply);
+        setupObligation(obligation, obligations, supply, obligation.maturity);
 
         // Test
         morphoV2.withdrawCollateral(obligation, address(collateralToken1), withdraw, borrower);
@@ -89,33 +89,121 @@ contract OtherFunctionsTest is BaseTest {
         supply = bound(supply, minCollateral, 1e41);
         withdraw = bound(withdraw, supply - minCollateral + 1, supply);
         deal(address(collateralToken1), address(this), supply);
-        setupObligation(obligation, obligations, supply);
+        setupObligation(obligation, obligations, supply, obligation.maturity);
 
         // Test
         vm.expectRevert("Unhealthy borrower");
         morphoV2.withdrawCollateral(obligation, address(collateralToken1), withdraw, borrower);
     }
 
-    function testRepay(uint256 obligations, uint256 repaid) public {
-        // Note that if this changes the values when the input is in the bounds, it will break withdraw tests.
-        obligations = bound(obligations, 0, MAX_TEST_AMOUNT);
-        repaid = bound(repaid, 0, obligations);
-        setupObligation(obligation, obligations);
+    function testWithdrawAnyCoverUntilMaturity(
+        uint256 obligationUnits,
+        uint256 covered,
+        uint256 withdrawn,
+        uint256 termLength,
+        uint256 skipped
+    ) public {
+        uint256 originalTimestamp = block.timestamp;
+        obligationUnits = bound(obligationUnits, 0, MAX_TEST_AMOUNT);
+        covered = bound(covered, 0, obligationUnits * 3);
+        withdrawn = bound(withdrawn, 0, covered);
+        termLength = bound(termLength, 1, 365 days);
+        skipped = bound(skipped, 0, termLength);
+        uint256 maturity = originalTimestamp + termLength;
 
-        vm.warp(block.timestamp + 99);
+        obligation.maturity = maturity;
+        _testCover(obligationUnits, covered, obligation.maturity);
 
-        deal(address(loanToken), address(borrower), repaid);
+        skip(skipped);
+        vm.prank(borrower);
+        morphoV2.uncoverDebt(obligation, withdrawn, borrower);
+
+        assertEq(morphoV2.coveredDebtOf(borrower, id), covered - withdrawn, "cover of");
+        assertEq(morphoV2.withdrawable(id), covered - withdrawn, "available cover");
+        assertEq(loanToken.balanceOf(address(morphoV2)), covered - withdrawn, "balance of morphoV2");
+        assertEq(loanToken.balanceOf(borrower), withdrawn, "balance of lender");
+    }
+
+    function testWithdrawExcessCoverAnyTime(
+        uint256 obligationUnits,
+        uint256 covered,
+        uint256 withdrawn,
+        uint256 termLength,
+        uint256 skipped
+    ) public {
+        uint256 originalTimestamp = block.timestamp;
+        obligationUnits = bound(obligationUnits, 0, MAX_TEST_AMOUNT);
+        covered = bound(covered, obligationUnits, obligationUnits * 3);
+        withdrawn = bound(withdrawn, 0, covered - obligationUnits);
+        termLength = bound(termLength, 1, 365 days);
+        skipped = bound(skipped, 0, termLength * 3);
+        uint256 maturity = originalTimestamp + termLength;
+
+        obligation.maturity = maturity;
+        _testCover(obligationUnits, covered, obligation.maturity);
+
+        skip(skipped);
+        vm.prank(borrower);
+        morphoV2.uncoverDebt(obligation, withdrawn, borrower);
+
+        assertEq(morphoV2.coveredDebtOf(borrower, id), covered - withdrawn, "cover of");
+        assertEq(morphoV2.withdrawable(id), covered - withdrawn, "available cover");
+        assertEq(loanToken.balanceOf(address(morphoV2)), covered - withdrawn, "balance of morphoV2");
+        assertEq(loanToken.balanceOf(borrower), withdrawn, "balance of lender");
+    }
+
+    function testWithdrawCoverUnhealthy(
+        uint256 obligationUnits,
+        uint256 covered,
+        uint256 withdrawn,
+        uint256 termLength
+    ) public {
+        uint256 originalTimestamp = block.timestamp;
+        obligationUnits = bound(obligationUnits, 1, MAX_TEST_AMOUNT);
+        covered = bound(covered, 1, obligationUnits);
+        withdrawn = bound(withdrawn, 1, covered);
+        termLength = bound(termLength, 1, 365 days);
+        uint256 maturity = originalTimestamp + termLength;
+
+        obligation.maturity = maturity;
+        _testCover(obligationUnits, covered, obligation.maturity);
+
+        deal(address(loanToken), borrower, obligationUnits - covered);
+        vm.prank(borrower);
+        morphoV2.coverDebt(obligation, obligationUnits - covered, borrower);
+        vm.prank(borrower);
+        morphoV2.withdrawCollateral(
+            obligation,
+            obligation.collaterals[0].token,
+            morphoV2.collateralOf(borrower, id, obligation.collaterals[0].token),
+            borrower
+        );
+        vm.expectRevert("Unhealthy borrower");
+        morphoV2.uncoverDebt(obligation, withdrawn, borrower);
+    }
+
+    function _testCover(uint256 obligationUnits, uint256 covered, uint256 maturity) public {
+        id = toId(obligation);
+
+        setupObligation(obligation, obligationUnits, maturity);
+
+        deal(address(loanToken), address(borrower), covered);
 
         vm.prank(borrower);
-        morphoV2.repay(obligation, repaid, borrower);
+        morphoV2.coverDebt(obligation, covered, borrower);
 
-        assertEq(morphoV2.debtOf(borrower, id), obligations - repaid);
-        assertEq(morphoV2.withdrawable(id), repaid);
-        assertEq(loanToken.balanceOf(address(morphoV2)), repaid);
-        assertEq(loanToken.balanceOf(borrower), 0);
+        if (obligationUnits > covered) {
+            assertEq(morphoV2.debtOf(borrower, id), obligationUnits - covered, "debt of");
+        } else {
+            assertEq(morphoV2.debtOf(borrower, id), 0, "debt of");
+        }
+        assertEq(morphoV2.withdrawable(id), covered, "available cover");
+        assertEq(loanToken.balanceOf(address(morphoV2)), covered, "balance of morphoV2");
+        assertEq(loanToken.balanceOf(borrower), 0, "balance of borrower");
     }
 
     function testWithdrawInconsistentInput() public {
+        vm.warp(obligation.maturity + 1);
         vm.expectRevert("INCONSISTENT_INPUT");
         morphoV2.withdraw(obligation, 1, 1, lender);
     }
@@ -124,32 +212,61 @@ contract OtherFunctionsTest is BaseTest {
         // Setup
         obligations = bound(obligations, 1, MAX_TEST_AMOUNT);
         withdraw = bound(withdraw, 1, obligations);
-        testRepay(obligations, withdraw);
+        _testCover(obligations, withdraw, obligation.maturity);
 
         // Test
+        vm.warp(obligation.maturity + 1);
         vm.prank(lender);
         morphoV2.withdraw(obligation, withdraw, 0, lender);
 
         assertEq(morphoV2.sharesOf(lender, id), obligations - withdraw, "obligationSharesOf");
-        assertEq(morphoV2.withdrawable(id), 0, "withdrawable");
+        assertEq(morphoV2.withdrawable(id), 0, "available cover");
         assertEq(morphoV2.totalShares(id), obligations - withdraw, "totalShares");
         assertEq(loanToken.balanceOf(address(morphoV2)), 0, "balance of morphoV2");
         assertEq(loanToken.balanceOf(lender), withdraw, "balance of lender");
+    }
+
+    function testWithdrawObligationsBeforeMaturity(
+        uint256 obligationUnits,
+        uint256 withdraw,
+        uint256 maturity,
+        uint256 skipDuration
+    ) public {
+        obligationUnits = bound(obligationUnits, 0, MAX_TEST_AMOUNT);
+        withdraw = bound(withdraw, 0, obligationUnits);
+        maturity = bound(maturity, block.timestamp, block.timestamp + 365 days);
+        skipDuration = bound(skipDuration, 0, maturity - block.timestamp);
+        obligation.maturity = maturity;
+
+        setupObligation(obligation, obligationUnits, maturity);
+
+        skip(skipDuration);
+
+        deal(address(loanToken), address(borrower), withdraw);
+
+        vm.prank(borrower);
+        morphoV2.coverDebt(obligation, withdraw, borrower);
+
+        // Test
+        vm.prank(lender);
+        vm.expectRevert("obligation maturity");
+        morphoV2.withdraw(obligation, withdraw, 0, lender);
     }
 
     function testWithdrawWithShares(uint256 obligations, uint256 shares) public {
         // Setup
         obligations = bound(obligations, 1, MAX_TEST_AMOUNT);
         shares = bound(shares, 1, obligations);
-        testRepay(obligations, shares);
+        _testCover(obligations, shares, obligation.maturity);
 
         // Test
         // TODO: sharesPrice != 1
+        vm.warp(obligation.maturity + 1);
         vm.prank(lender);
         morphoV2.withdraw(obligation, 0, shares, lender);
 
         assertEq(morphoV2.sharesOf(lender, id), obligations - shares, "obligationSharesOf");
-        assertEq(morphoV2.withdrawable(id), 0, "withdrawable");
+        assertEq(morphoV2.withdrawable(id), 0, "available cover");
         assertEq(loanToken.balanceOf(address(morphoV2)), 0, "balance of morphoV2");
         assertEq(loanToken.balanceOf(lender), shares, "balance of lender");
     }


### PR DESCRIPTION
See issue #87 

* loan asset immediately withdrawable at maturity
* loan asset cannot be liquidated
* loan asset treated separately from collaterals
* debt ignores covered amount

These invariants should hold:
```
  withdrawable - (sum_user coverOf[user])
= (sum_interaction repaid in postmaturity liq) - (sum_interaction withdrawn) 
= totalBonds - (sum_user fullDebtOf[user])
```
