### PR TITLE
fix: cap total repaid to debt

### DIFF
--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -200,6 +200,8 @@ contract Terms is ITerms {
         }
 
         uint256 originalDebt = debtOf[borrower][id];
+
+        if (totalRepaid > originalDebt) totalRepaid = originalDebt;
         debtOf[borrower][id] -= totalRepaid;
 
         // Realize bad debt

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -105,4 +105,37 @@ abstract contract BaseTest is Test {
         // take `bonds` because the rate is 0.
         terms.take(term, bonds, lender, borrowOffer, sig(borrowOffer, borrowerSK), address(0), hex"");
     }
+
+    function setupMaxBondWithCollaterals(Term memory term, uint256 collateral0, uint256 collateral1) internal {
+        uint256 maxDebt = (collateral0 * term.collaterals[0].lltv + collateral1 * term.collaterals[1].lltv) / 1e18;
+        setupBondWithCollaterals(term, maxDebt, collateral0, collateral1);
+    }
+
+    function setupBondWithCollaterals(Term memory term, uint256 bonds, uint256 collateral0, uint256 collateral1)
+        internal
+    {
+        deal(address(loanToken), lender, bonds);
+        deal(address(term.collaterals[0].token), address(this), collateral0);
+        deal(address(term.collaterals[1].token), address(this), collateral1);
+
+        terms.supplyCollateral(term, address(term.collaterals[0].token), collateral0, borrower);
+        terms.supplyCollateral(term, address(term.collaterals[1].token), collateral1, borrower);
+        Offer memory borrowOffer = Offer({
+            buy: false,
+            offering: borrower,
+            assets: bonds,
+            loanToken: term.loanToken,
+            collaterals: term.collaterals,
+            maturity: block.timestamp + 100,
+            offerStart: block.timestamp,
+            offerExpiry: block.timestamp + 200,
+            rate: 0,
+            nonce: 0,
+            callbackAddress: address(0),
+            callbackData: ""
+        });
+
+        // take `bonds` because the rate is 0.
+        terms.take(term, bonds, lender, borrowOffer, sig(borrowOffer, borrowerSK),address(0),hex"");
+    }
 }

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -136,6 +136,6 @@ abstract contract BaseTest is Test {
         });
 
         // take `bonds` because the rate is 0.
-        terms.take(term, bonds, lender, borrowOffer, sig(borrowOffer, borrowerSK),address(0),hex"");
+        terms.take(term, bonds, lender, borrowOffer, sig(borrowOffer, borrowerSK), address(0), hex"");
     }
 }

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -19,7 +19,6 @@ contract LiquidationTest is BaseTest {
         Collateral[] memory collaterals = new Collateral[](2);
         collaterals[0] = Collateral({token: address(collateralToken1), lltv: 0.75e18, oracle: address(oracle)});
         collaterals[1] = Collateral({token: address(collateralToken2), lltv: 0.75e18, oracle: address(oracle)});
-
         collaterals = sortCollaterals(collaterals);
 
         // Populate collaterals one by one to avoid the unsupported memory-to-storage array assignment that breaks the
@@ -68,7 +67,6 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(1e36 - 1);
-
         deal(address(loanToken), address(this), 1);
 
         // Test

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -13,12 +13,17 @@ contract LiquidationTest is BaseTest {
     address internal recordedLiquidator;
     bytes internal recordedData;
 
+    Oracle internal oracle2;
+
     function setUp() public override {
         super.setUp();
 
+        oracle2 = new Oracle();
+
         Collateral[] memory collaterals = new Collateral[](2);
         collaterals[0] = Collateral({token: address(collateralToken1), lltv: 0.75e18, oracle: address(oracle)});
-        collaterals[1] = Collateral({token: address(collateralToken2), lltv: 0.75e18, oracle: address(oracle)});
+        collaterals[1] = Collateral({token: address(collateralToken2), lltv: 0.75e18, oracle: address(oracle2)});
+
         collaterals = sortCollaterals(collaterals);
 
         // Populate collaterals one by one to avoid the unsupported memory-to-storage array assignment that breaks the
@@ -47,6 +52,8 @@ contract LiquidationTest is BaseTest {
     function testLiquidateNoOp() public {
         setupBond(term, 100);
         oracle.setPrice(0);
+        oracle2.setPrice(0);
+
 
         terms.liquidate(term, new Seizure[](2), borrower, "");
     }
@@ -54,6 +61,7 @@ contract LiquidationTest is BaseTest {
     function testLiquidateInconsistentInput() public {
         setupBond(term, 100);
         oracle.setPrice(0);
+        oracle2.setPrice(0);
 
         Seizure[] memory seizures = new Seizure[](2);
         seizures[0] = Seizure({repaidBonds: 1, seizedAssets: 1});
@@ -67,6 +75,8 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(1e36 - 1);
+        oracle2.setPrice(1e36 - 1);
+
         deal(address(loanToken), address(this), 1);
 
         // Test
@@ -83,6 +93,7 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(1e36 - 1);
+        oracle2.setPrice(1e36 - 1);
         deal(address(loanToken), address(this), 1);
 
         // Test
@@ -99,6 +110,7 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(0.5e36);
+        oracle2.setPrice(0.5e36);
         deal(address(loanToken), address(this), 1);
 
         // Test
@@ -116,6 +128,7 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(1e36 - 1);
+        oracle2.setPrice(1e36 - 1);
         deal(address(loanToken), address(this), 1);
 
         // Test
@@ -132,6 +145,30 @@ contract LiquidationTest is BaseTest {
         assertEq(recordedBorrower, borrower, "borrower");
         assertEq(recordedLiquidator, address(this), "liquidator");
         assertEq(recordedData, data, "data");
+    }
+
+    // Check that it is possible to seize all assets even if rounding overestimates repaid bonds.
+    function testTotalRepaidTooHigh() public {
+        setupMaxBondWithCollaterals(term, 100, 100);
+        uint256 price = 1e36 * 1e18 / terms.LIQUIDATION_INCENTIVE_FACTOR() * 98 / 100;
+        uint256 price2 = 1e36 * 1e18 / terms.LIQUIDATION_INCENTIVE_FACTOR();
+        oracle.setPrice(price);
+        oracle2.setPrice(price2);
+        deal(address(loanToken), address(this), 100e18);
+
+        Seizure[] memory seizures = new Seizure[](2);
+        seizures[0] = Seizure({repaidBonds: 0, seizedAssets: 100});
+        seizures[1] = Seizure({repaidBonds: 0, seizedAssets: 100});
+
+        // repaying all bonds this way would leave some assets behind
+        // seizures[0] = Seizure({repaidBonds: 75, seizedAssets: 0});
+        // seizures[1] = Seizure({repaidBonds: 75, seizedAssets: 0});
+
+        terms.liquidate(term, seizures, borrower, "");
+
+        assertEq(terms.debtOf(borrower, id), 0, "debt");
+        assertEq(terms.collateralOf(borrower, id, term.collaterals[0].token), 0, "collateral 0");
+        assertEq(terms.collateralOf(borrower, id, term.collaterals[1].token), 0, "collateral 1");
     }
 
     function onLiquidate(Seizure[] memory seizures, address borrower, address liquidator, bytes memory data) public {

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -54,7 +54,6 @@ contract LiquidationTest is BaseTest {
         oracle.setPrice(0);
         oracle2.setPrice(0);
 
-
         terms.liquidate(term, new Seizure[](2), borrower, "");
     }
 

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -13,16 +13,12 @@ contract LiquidationTest is BaseTest {
     address internal recordedLiquidator;
     bytes internal recordedData;
 
-    Oracle internal oracle2;
-
     function setUp() public override {
         super.setUp();
 
-        oracle2 = new Oracle();
-
         Collateral[] memory collaterals = new Collateral[](2);
         collaterals[0] = Collateral({token: address(collateralToken1), lltv: 0.75e18, oracle: address(oracle)});
-        collaterals[1] = Collateral({token: address(collateralToken2), lltv: 0.75e18, oracle: address(oracle2)});
+        collaterals[1] = Collateral({token: address(collateralToken2), lltv: 0.75e18, oracle: address(oracle)});
 
         collaterals = sortCollaterals(collaterals);
 
@@ -52,7 +48,6 @@ contract LiquidationTest is BaseTest {
     function testLiquidateNoOp() public {
         setupBond(term, 100);
         oracle.setPrice(0);
-        oracle2.setPrice(0);
 
         terms.liquidate(term, new Seizure[](2), borrower, "");
     }
@@ -60,7 +55,6 @@ contract LiquidationTest is BaseTest {
     function testLiquidateInconsistentInput() public {
         setupBond(term, 100);
         oracle.setPrice(0);
-        oracle2.setPrice(0);
 
         Seizure[] memory seizures = new Seizure[](2);
         seizures[0] = Seizure({repaidBonds: 1, seizedAssets: 1});
@@ -74,7 +68,6 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(1e36 - 1);
-        oracle2.setPrice(1e36 - 1);
 
         deal(address(loanToken), address(this), 1);
 
@@ -92,7 +85,6 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(1e36 - 1);
-        oracle2.setPrice(1e36 - 1);
         deal(address(loanToken), address(this), 1);
 
         // Test
@@ -109,7 +101,6 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(0.5e36);
-        oracle2.setPrice(0.5e36);
         deal(address(loanToken), address(this), 1);
 
         // Test
@@ -127,7 +118,6 @@ contract LiquidationTest is BaseTest {
         // Setup
         setupBond(term, 100);
         oracle.setPrice(1e36 - 1);
-        oracle2.setPrice(1e36 - 1);
         deal(address(loanToken), address(this), 1);
 
         // Test
@@ -148,6 +138,9 @@ contract LiquidationTest is BaseTest {
 
     // Check that it is possible to seize all assets even if rounding overestimates repaid bonds.
     function testTotalRepaidTooHigh() public {
+        Oracle oracle2 = new Oracle();
+        term.collaterals[1].oracle = address(oracle2);
+
         setupMaxBondWithCollaterals(term, 100, 100);
         uint256 price = 1e36 * 1e18 / terms.LIQUIDATION_INCENTIVE_FACTOR() * 98 / 100;
         uint256 price2 = 1e36 * 1e18 / terms.LIQUIDATION_INCENTIVE_FACTOR();


### PR DESCRIPTION
It is possible to be in a state of bad debt such that for one collateral,
* if you try to repay all bonds, not all the collateral is seized.
* if you try to seize all the collateral, the repaid bonds are overestimated and `originalDebt - totalRepaid` underflows.