### PR TITLE
Prevent multiple seizure of the same collateral

### DIFF
--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -11,6 +11,7 @@ import "./interfaces/ICallbacks.sol";
 
 contract Terms is ITerms {
     using MathLib for uint256;
+    using UtilsLib for uint256;
 
     /// CONSTANTS ///
 
@@ -158,14 +159,14 @@ contract Terms is ITerms {
         uint256 repayableDebt;
         uint256 maxDebt;
         bytes32 id = _id(term);
-        uint256[] memory prices = new uint256[](term.collaterals.length);
+        Price[] memory prices = new Price[](term.collaterals.length);
 
         for (uint256 i = 0; i < term.collaterals.length; i++) {
-            prices[i] = IOracle(term.collaterals[i].oracle).price();
+            prices[i].price = IOracle(term.collaterals[i].oracle).price().toUint248();
             {
                 address collateralToken = term.collaterals[i].token;
                 uint256 collateralQuoted =
-                    collateralOf[borrower][id][collateralToken].mulDivDown(prices[i], ORACLE_PRICE_SCALE);
+                    collateralOf[borrower][id][collateralToken].mulDivDown(prices[i].price, ORACLE_PRICE_SCALE);
                 maxDebt += collateralQuoted.mulDivDown(term.collaterals[i].lltv, 1e18);
                 repayableDebt += collateralQuoted.mulDivUp(1e18, LIQUIDATION_INCENTIVE_FACTOR);
             }
@@ -179,14 +180,18 @@ contract Terms is ITerms {
 
         for (uint256 i = 0; i < seizures.length; i++) {
             seizure = seizures[i];
+            require(!prices[seizure.collateralIndex].seen, "price already seen");
+            prices[seizure.collateralIndex].seen = true;
+            uint256 price = prices[seizure.collateralIndex].price;
             require(UtilsLib.exactlyOneZero(seizure.repaidBonds, seizure.seizedAssets), "INCONSISTENT_INPUT");
 
             if (seizure.seizedAssets > 0) {
-                seizure.repaidBonds = seizure.seizedAssets.mulDivUp(prices[seizure.collateralIndex], ORACLE_PRICE_SCALE)
-                    .mulDivUp(1e18, LIQUIDATION_INCENTIVE_FACTOR);
+                seizure.repaidBonds = seizure.seizedAssets.mulDivUp(price, ORACLE_PRICE_SCALE).mulDivUp(
+                    1e18, LIQUIDATION_INCENTIVE_FACTOR
+                );
             } else {
                 seizure.seizedAssets = seizure.repaidBonds.mulDivDown(LIQUIDATION_INCENTIVE_FACTOR, 1e18).mulDivDown(
-                    ORACLE_PRICE_SCALE, prices[seizure.collateralIndex]
+                    ORACLE_PRICE_SCALE, price
                 );
             }
 

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -11,7 +11,6 @@ import "./interfaces/ICallbacks.sol";
 
 contract Terms is ITerms {
     using MathLib for uint256;
-    using UtilsLib for uint256;
 
     /// CONSTANTS ///
 
@@ -162,7 +161,7 @@ contract Terms is ITerms {
         Price[] memory prices = new Price[](term.collaterals.length);
 
         for (uint256 i = 0; i < term.collaterals.length; i++) {
-            prices[i].price = IOracle(term.collaterals[i].oracle).price().toUint248();
+            prices[i].price = IOracle(term.collaterals[i].oracle).price();
             {
                 address collateralToken = term.collaterals[i].token;
                 uint256 collateralQuoted =

--- a/src/interfaces/ITerms.sol
+++ b/src/interfaces/ITerms.sol
@@ -39,7 +39,7 @@ struct Signature {
 }
 
 struct Price {
-    uint248 price;
+    uint256 price;
     bool seen;
 }
 

--- a/src/interfaces/ITerms.sol
+++ b/src/interfaces/ITerms.sol
@@ -38,6 +38,11 @@ struct Signature {
     bytes32 s;
 }
 
+struct Price {
+    uint248 price;
+    bool seen;
+}
+
 struct Seizure {
     // Index of the collateral in the term's collateral assets.
     uint256 collateralIndex;

--- a/src/libraries/UtilsLib.sol
+++ b/src/libraries/UtilsLib.sol
@@ -21,4 +21,10 @@ library UtilsLib {
             z := xor(x, mul(xor(x, y), lt(y, x)))
         }
     }
+
+    /// @dev Returns `x` safely cast to uint248.
+    function toUint248(uint256 x) internal pure returns (uint248) {
+        require(x <= type(uint248).max, "max uint248 exceeded");
+        return uint248(x);
+    }
 }

--- a/src/libraries/UtilsLib.sol
+++ b/src/libraries/UtilsLib.sol
@@ -21,10 +21,4 @@ library UtilsLib {
             z := xor(x, mul(xor(x, y), lt(y, x)))
         }
     }
-
-    /// @dev Returns `x` safely cast to uint248.
-    function toUint248(uint256 x) internal pure returns (uint248) {
-        require(x <= type(uint248).max, "max uint248 exceeded");
-        return uint248(x);
-    }
 }


### PR DESCRIPTION
Rationale:
- there is no point in allowing multiple seizure of the same collateral, it can only make things more complicated to understand or allow some weird rounding manipulation
- there is no loss in UX with this version, because it does not require the list to be sorted