### PR TITLE
realize bad debt first 2

### DIFF
--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -171,19 +171,17 @@ contract Terms is ITerms {
             collateralOf[borrower][id][collateralToken] -= seizure.seizedAssets;
         }
 
-        // Realize bad debt
-        uint256 badDebt;
+        repayableDebt = UtilsLib.min(repayableDebt, originalDebt);
+        totalRepaid = UtilsLib.min(totalRepaid, repayableDebt);
 
-        if (totalRepaid > originalDebt) totalRepaid = originalDebt;
-        if (repayableDebt < originalDebt) {
-            // Because roundings are not aligned the effective bad debt is either the remaining debt or the original
-            // debt minus the theoretical repayable debt.
-            badDebt = UtilsLib.min(originalDebt - totalRepaid, originalDebt - repayableDebt);
-            totalBonds[id] -= badDebt;
+        // Realize bad debt.
+        if (originalDebt > repayableDebt) {
+            debtOf[borrower][id] = repayableDebt;
+            totalBonds[id] -= originalDebt - repayableDebt;
         }
 
         withdrawable[id] += totalRepaid;
-        debtOf[borrower][id] = originalDebt - totalRepaid - badDebt;
+        debtOf[borrower][id] -= totalRepaid;
 
         for (uint256 i = 0; i < seizures.length; i++) {
             seizure = seizures[i];

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -150,6 +150,13 @@ contract Terms is ITerms {
         uint256 originalDebt = debtOf[borrower][id];
         require(originalDebt > maxDebt, "position is healthy");
 
+        // Realize bad debt.
+        if (originalDebt > repayableDebt) {
+            uint256 badDebt = originalDebt - repayableDebt;
+            debtOf[borrower][id] -= badDebt;
+            totalBonds[id] -= badDebt;
+        }
+
         uint256 totalRepaid;
         Seizure memory seizure;
 
@@ -171,15 +178,7 @@ contract Terms is ITerms {
             collateralOf[borrower][id][collateralToken] -= seizure.seizedAssets;
         }
 
-        repayableDebt = UtilsLib.min(repayableDebt, originalDebt);
-        totalRepaid = UtilsLib.min(totalRepaid, repayableDebt);
-
-        // Realize bad debt.
-        if (originalDebt > repayableDebt) {
-            debtOf[borrower][id] = repayableDebt;
-            totalBonds[id] -= originalDebt - repayableDebt;
-        }
-
+        totalRepaid = UtilsLib.min(totalRepaid, debtOf[borrower][id]);
         withdrawable[id] += totalRepaid;
         debtOf[borrower][id] -= totalRepaid;
 

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -122,7 +122,8 @@ contract LiquidationTest is BaseTest {
         assertEq(recordedData, data, "data");
     }
 
-    // Check that it is not always possible to seize all assets due to roundings.
+    // Check that due to roundings, even if there is bad debt it is not always possible to seize all assets or repay all
+    // debt.
     function testTotalRepaidTooHigh() public {
         Oracle oracle2 = new Oracle();
         term.collaterals[1].oracle = address(oracle2);
@@ -147,8 +148,8 @@ contract LiquidationTest is BaseTest {
         // Repaying all bonds can leave some assets behind
         seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 75, seizedAssets: 0});
         seizures[1] = Seizure({collateralIndex: 1, repaidBonds: 75, seizedAssets: 0});
+        vm.expectRevert(stdError.arithmeticError);
         terms.liquidate(term, seizures, borrower, "");
-        vm.assertGt(terms.collateralOf(borrower, id, term.collaterals[1].token), 0);
     }
 
     function onLiquidate(Seizure[] memory seizures, address borrower, address liquidator, bytes memory data) public {


### PR DESCRIPTION
Rationale is that the bad debt is really done first, and every computation after that is optional (by passing 0 length seizures) or is a no-op (assuming that 0 transfers are no-ops). I find it slightly easier to read

It should be functionally the same as #95:
- for the bad debt, it is the same computation, just moved up
- for the total repaid
  - if `originalDebt > repayableDebt` then there is some bad debt so the computation `totalRepaid = UtilsLib.min(totalRepaid, debtOf[borrower][id])` is the same as doing `totalRepaid = UtilsLib.min(totalRepaid, repayableDebt)`, and in the other PR `repayableDebt` stays the same even after the min in this case
  - otherwise, there is no bad debt, so the computation `totalRepaid = UtilsLib.min(totalRepaid, debtOf[borrower][id])` is the same as doing `totalRepaid = UtilsLib.min(totalRepaid, originalDebt)`, and in the other PR `repayableDebt` is equal to `originalDebt`
  
