### PR TITLE
Roundings in liquidate

### DIFF
--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -171,19 +171,17 @@ contract Terms is ITerms {
             collateralOf[borrower][id][collateralToken] -= seizure.seizedAssets;
         }
 
-        // Realize bad debt
-        uint256 badDebt;
+        repayableDebt = UtilsLib.min(repayableDebt, originalDebt);
+        totalRepaid = UtilsLib.min(totalRepaid, repayableDebt);
 
-        if (totalRepaid > originalDebt) totalRepaid = originalDebt;
-        if (repayableDebt < originalDebt) {
-            // Because roundings are not aligned the effective bad debt is either the remaining debt or the original
-            // debt minus the theoretical repayable debt.
-            badDebt = UtilsLib.min(originalDebt - totalRepaid, originalDebt - repayableDebt);
-            totalBonds[id] -= badDebt;
+        // Realize bad debt.
+        if (originalDebt > repayableDebt) {
+            debtOf[borrower][id] = repayableDebt;
+            totalBonds[id] -= originalDebt - repayableDebt;
         }
 
         withdrawable[id] += totalRepaid;
-        debtOf[borrower][id] = originalDebt - totalRepaid - badDebt;
+        debtOf[borrower][id] -= totalRepaid;
 
         for (uint256 i = 0; i < seizures.length; i++) {
             seizure = seizures[i];

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -174,10 +174,13 @@ contract Terms is ITerms {
             prices[i] = IOracle(term.collaterals[i].oracle).price();
             {
                 address collateralToken = term.collaterals[i].token;
-                uint256 collateralQuoted =
-                    collateralOf[borrower][id][collateralToken].mulDivDown(prices[i], ORACLE_PRICE_SCALE);
-                maxDebt += collateralQuoted.mulDivDown(term.collaterals[i].lltv, 1e18);
-                repayableDebt += collateralQuoted.mulDivUp(1e18, LIQUIDATION_INCENTIVE_FACTOR);
+                uint256 collateralAmount = collateralOf[borrower][id][collateralToken];
+                maxDebt += collateralAmount.mulDivDown(prices[i], ORACLE_PRICE_SCALE).mulDivDown(
+                    term.collaterals[i].lltv, 1e18
+                );
+                repayableDebt += collateralAmount.mulDivUp(prices[i], ORACLE_PRICE_SCALE).mulDivDown(
+                    1e18, LIQUIDATION_INCENTIVE_FACTOR
+                );
             }
         }
 

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -173,8 +173,7 @@ contract Terms is ITerms {
         for (uint256 i = 0; i < term.collaterals.length; i++) {
             prices[i] = IOracle(term.collaterals[i].oracle).price();
             {
-                address collateralToken = term.collaterals[i].token;
-                uint256 collateralAmount = collateralOf[borrower][id][collateralToken];
+                uint256 collateralAmount = collateralOf[borrower][id][term.collaterals[i].token];
                 maxDebt += collateralAmount.mulDivDown(prices[i], ORACLE_PRICE_SCALE).mulDivDown(
                     term.collaterals[i].lltv, 1e18
                 );
@@ -187,9 +186,8 @@ contract Terms is ITerms {
         uint256 originalDebt = debtOf[borrower][id];
         require(originalDebt > maxDebt, "position is healthy");
 
-        // Realize bad debt.
-        if (originalDebt > repayableDebt) {
-            uint256 badDebt = originalDebt - repayableDebt;
+        uint256 badDebt = originalDebt.zeroFloorSub(repayableDebt);
+        if (badDebt > 0) {
             debtOf[borrower][id] -= badDebt;
             totalBonds[id] -= badDebt;
         }

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -150,6 +150,13 @@ contract Terms is ITerms {
         uint256 originalDebt = debtOf[borrower][id];
         require(originalDebt > maxDebt, "position is healthy");
 
+        // Realize bad debt.
+        if (originalDebt > repayableDebt) {
+            uint256 badDebt = originalDebt - repayableDebt;
+            debtOf[borrower][id] -= badDebt;
+            totalBonds[id] -= badDebt;
+        }
+
         uint256 totalRepaid;
         Seizure memory seizure;
 
@@ -171,15 +178,7 @@ contract Terms is ITerms {
             collateralOf[borrower][id][collateralToken] -= seizure.seizedAssets;
         }
 
-        repayableDebt = UtilsLib.min(repayableDebt, originalDebt);
-        totalRepaid = UtilsLib.min(totalRepaid, repayableDebt);
-
-        // Realize bad debt.
-        if (originalDebt > repayableDebt) {
-            debtOf[borrower][id] = repayableDebt;
-            totalBonds[id] -= originalDebt - repayableDebt;
-        }
-
+        totalRepaid = UtilsLib.min(totalRepaid, debtOf[borrower][id]);
         withdrawable[id] += totalRepaid;
         debtOf[borrower][id] -= totalRepaid;
 

--- a/src/Terms.sol
+++ b/src/Terms.sol
@@ -178,7 +178,7 @@ contract Terms is ITerms {
                 maxDebt += collateralAmount.mulDivDown(prices[i], ORACLE_PRICE_SCALE).mulDivDown(
                     term.collaterals[i].lltv, 1e18
                 );
-                repayableDebt += collateralAmount.mulDivUp(prices[i], ORACLE_PRICE_SCALE).mulDivDown(
+                repayableDebt += collateralAmount.mulDivUp(prices[i], ORACLE_PRICE_SCALE).mulDivUp(
                     1e18, LIQUIDATION_INCENTIVE_FACTOR
                 );
             }

--- a/src/libraries/MathLib.sol
+++ b/src/libraries/MathLib.sol
@@ -12,4 +12,11 @@ library MathLib {
     function mulDivUp(uint256 x, uint256 y, uint256 d) internal pure returns (uint256) {
         return (x * y + (d - 1)) / d;
     }
+
+    /// @dev Returns max(0, x - y).
+    function zeroFloorSub(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        assembly {
+            z := mul(gt(x, y), sub(x, y))
+        }
+    }
 }

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -122,7 +122,8 @@ contract LiquidationTest is BaseTest {
         assertEq(recordedData, data, "data");
     }
 
-    // Check that it is not always possible to seize all assets due to roundings.
+    // Check that due to roundings, even if there is bad debt it is not always possible to seize all assets or repay all
+    // debt.
     function testTotalRepaidTooHigh() public {
         Oracle oracle2 = new Oracle();
         term.collaterals[1].oracle = address(oracle2);
@@ -147,8 +148,8 @@ contract LiquidationTest is BaseTest {
         // Repaying all bonds can leave some assets behind
         seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 75, seizedAssets: 0});
         seizures[1] = Seizure({collateralIndex: 1, repaidBonds: 75, seizedAssets: 0});
+        vm.expectRevert(stdError.arithmeticError);
         terms.liquidate(term, seizures, borrower, "");
-        vm.assertGt(terms.collateralOf(borrower, id, term.collaterals[1].token), 0);
     }
 
     function onLiquidate(Seizure[] memory seizures, address borrower, address liquidator, bytes memory data) public {

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -122,33 +122,23 @@ contract LiquidationTest is BaseTest {
         assertEq(recordedData, data, "data");
     }
 
-    // Check that due to roundings, even if there is bad debt it is not always possible to seize all assets or repay all
-    // debt.
-    function testTotalRepaidTooHigh() public {
+    // Check that if there is bad debt it is possible to seize all assets.
+    function testLiquidateAllWhenBadDebt() public {
         Oracle oracle2 = new Oracle();
         term.collaterals[1].oracle = address(oracle2);
         id = toId(term);
 
         setupMaxBondWithCollaterals(term, 100, 100);
-        uint256 price = 1e36 * 1e18 / terms.LIQUIDATION_INCENTIVE_FACTOR() * 98 / 100;
+        uint256 price = 1e36 * 1e18 / terms.LIQUIDATION_INCENTIVE_FACTOR() * 95 / 100;
         uint256 price2 = 1e36 * 1e18 / terms.LIQUIDATION_INCENTIVE_FACTOR();
         oracle.setPrice(price);
         oracle2.setPrice(price2);
         deal(address(loanToken), address(this), 100e18);
 
         Seizure[] memory seizures = new Seizure[](2);
-
-        // Seizing all collateral repays too much debt.
         seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 0, seizedAssets: 100});
         seizures[1] = Seizure({collateralIndex: 1, repaidBonds: 0, seizedAssets: 100});
 
-        vm.expectRevert(stdError.arithmeticError);
-        terms.liquidate(term, seizures, borrower, "");
-
-        // Repaying all bonds can leave some assets behind
-        seizures[0] = Seizure({collateralIndex: 0, repaidBonds: 75, seizedAssets: 0});
-        seizures[1] = Seizure({collateralIndex: 1, repaidBonds: 75, seizedAssets: 0});
-        vm.expectRevert(stdError.arithmeticError);
         terms.liquidate(term, seizures, borrower, "");
     }
 

--- a/test/MathLibTest.sol
+++ b/test/MathLibTest.sol
@@ -50,6 +50,10 @@ contract MathLibTest is Test {
         this.mulDivUp(x, y, d);
     }
 
+    function testZeroFloorSub(uint256 x, uint256 y) public pure {
+        assertEq(MathLib.zeroFloorSub(x, y), x > y ? x - y : 0);
+    }
+
     function mulDivDown(uint256 x, uint256 y, uint256 d) external pure {
         MathLib.mulDivDown(x, y, d);
     }


### PR DESCRIPTION
What this PR does:
- round up consistently in the computation of `repayableDebt`. The rationale is that rounding up or down doesn't give more guarantees that it will not realize multiple dust bad debts. But rounding up ensures that the computed `totalRepaid`, when passing `seizedAssets` as input, will be lower than `repayableDebt`
- move up the computation of the bad debt. This makes so, if there is bad debt, the `totalRepaid` cannot be more than the `repayableDebt`. This is because of the computation `debtOf[borrower][id] -= totalRepaid` and when there is bad debt `debtOf[borrower][id]` is equal to `repayableDebt`