### PR TITLE
refactor: oco first and merkle tree

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -14,6 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         conf:
+          - Hasher
           - MorphoV2
 
     steps:

--- a/certora/Hasher.conf
+++ b/certora/Hasher.conf
@@ -1,0 +1,10 @@
+{
+  "files": [
+    "certora/helpers/Hasher.sol"
+  ],
+  "verify": "Hasher:certora/Hasher.spec",
+  "solc": "solc-0.8.28",
+  "solc_via_ir": true,
+  "server": "production",
+  "msg": "MorphoV2 Hasher"
+}

--- a/certora/Hasher.spec
+++ b/certora/Hasher.spec
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+methods {
+    function usedKeccak256(bytes32, bytes32) external returns (bytes32) envfree;
+    function commutativeKeccak256(bytes32, bytes32) external returns (bytes32) envfree;
+}
+
+rule functionalEquivalenceKeccak256(bytes32 x, bytes32 y) {
+    assert(usedKeccak256(x, y) == commutativeKeccak256(x, y));
+}
+
+rule noRevertsUsedKeccak256(bytes32 x, bytes32 y) {
+    usedKeccak256@withrevert(x, y);
+    assert !lastReverted;
+}
+
+rule noRevertsCommutativeKeccak256(bytes32 x, bytes32 y) {
+    commutativeKeccak256@withrevert(x, y);
+    assert !lastReverted;
+}

--- a/certora/helpers/Hasher.sol
+++ b/certora/helpers/Hasher.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
+pragma solidity ^0.8.0;
+
+import {MathLib} from "../../src/libraries/MathLib.sol";
+
+// Comparing the used implementation with the reference implementation found at
+// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/765b288a6a273f8c267adcd409094212dbd5e3cb/contracts/utils/cryptography/MerkleProof.sol#L57-L63
+contract Hasher {
+    function usedKeccak256(bytes32 x, bytes32 y) external pure returns (bytes32) {
+        return keccak256(MathLib.sort(x, y));
+    }
+
+    function commutativeKeccak256(bytes32 a, bytes32 b) public pure returns (bytes32) {
+        return a < b ? efficientKeccak256(a, b) : efficientKeccak256(b, a);
+    }
+
+    function efficientKeccak256(bytes32 a, bytes32 b) public pure returns (bytes32 value) {
+        assembly ("memory-safe") {
+            mstore(0x00, a)
+            mstore(0x20, b)
+            value := keccak256(0x00, 0x40)
+        }
+    }
+}

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -15,9 +15,7 @@ contract MorphoV2 is IMorphoV2 {
     /// CONSTANTS ///
 
     bytes32 public constant DOMAIN_TYPEHASH = keccak256("EIP712Domain(uint256 chainId,address verifyingContract)");
-    bytes32 public constant OFFER_TYPEHASH = keccak256(
-        "Offer(bool lend,address offering,uint256 assets,address loanToken,Collateral[] collaterals,uint256 maturity,uint256 start,uint256 expiry,uint256 startPrice,uint256 expiryPrice,uint256 nonce)"
-    );
+    bytes32 public constant ROOT_TYPEHASH = keccak256("bytes32 root");
     uint256 public constant ORACLE_PRICE_SCALE = 1e36;
     uint256 public constant LIQUIDATION_INCENTIVE_FACTOR = 1.15e18;
 
@@ -41,24 +39,23 @@ contract MorphoV2 is IMorphoV2 {
     /// @dev If one wants to match two offers without taking a position, they can batch take them and not have a
     /// position at the end.
     function take(
-        Obligation memory obligation,
         uint256 assets,
         uint256 obligationUnits,
         address taker,
         Offer memory offer,
         Signature memory sig,
+        bytes32 root,
+        bytes32[] memory proof,
         address takerCallbackAddress,
         bytes memory takerCallbackData
     ) public {
         require(assets == 0 || obligationUnits == 0, "inconsistent input");
         require(block.timestamp >= offer.start, "offer not started");
         require(block.timestamp <= offer.expiry, "offer expired");
-        require(obligation.maturity >= block.timestamp, "maturity");
-        require(offer.loanToken == obligation.loanToken, "Loan tokens do not match");
-        require(offer.maturity == obligation.maturity, "Maturities do not match");
+        require(offer.obligation.maturity >= block.timestamp, "maturity");
         require(offer.start < offer.expiry || offer.expiryPrice == offer.startPrice, "inconsistent prices");
-        require(signatureIsValid(offer, sig), "Invalid signature");
-        _checkCollateralInclusion(obligation, offer);
+        require(signer(root, sig) == offer.offering, "invalid signature");
+        require(MathLib.isLeaf(root, keccak256(abi.encode(offer)), proof), "invalid proof");
 
         (
             address buyer,
@@ -81,7 +78,7 @@ contract MorphoV2 is IMorphoV2 {
 
         require((consumed[offer.offering][offer.nonce] += assets) <= offer.assets, "consumed");
 
-        bytes32 id = _id(obligation);
+        bytes32 id = _id(offer.obligation);
 
         uint256 repaid = UtilsLib.min(debtOf[buyer][id], obligationUnits);
         uint256 bought = obligationUnits - repaid;
@@ -101,16 +98,16 @@ contract MorphoV2 is IMorphoV2 {
         totalUnits[id] -= withdrawn;
 
         if (buyerCallbackAddress != address(0)) {
-            ICallbacks(buyerCallbackAddress).onTake(obligation, buyer, assets, buyerCallbackData);
+            ICallbacks(buyerCallbackAddress).onTake(offer.obligation, buyer, assets, buyerCallbackData);
         }
 
-        SafeTransferLib.safeTransferFrom(offer.loanToken, buyer, seller, assets);
+        SafeTransferLib.safeTransferFrom(offer.obligation.loanToken, buyer, seller, assets);
 
         if (sellerCallbackAddress != address(0)) {
-            ICallbacks(sellerCallbackAddress).onTake(obligation, seller, assets, sellerCallbackData);
+            ICallbacks(sellerCallbackAddress).onTake(offer.obligation, seller, assets, sellerCallbackData);
         }
 
-        require(_isHealthy(obligation, seller), "Seller is unhealthy");
+        require(_isHealthy(offer.obligation, seller), "Seller is unhealthy");
     }
 
     /// @dev Will revert if there is no withdrawable funds.
@@ -238,28 +235,11 @@ contract MorphoV2 is IMorphoV2 {
         return keccak256(abi.encode(obligation));
     }
 
-    function _checkCollateralInclusion(Obligation memory obligation, Offer memory offer) internal pure {
-        Collateral[] memory subset = offer.buy ? obligation.collaterals : offer.collaterals;
-        Collateral[] memory superset = offer.buy ? offer.collaterals : obligation.collaterals;
-
-        uint256 j = 0;
-        for (uint256 i = 0; i < subset.length; i++) {
-            // Relies on the fact that the collaterals are sorted.
-            // Note that we actually never check that.
-            // If they are not, the matching could fail.
-            while (superset[j].token != subset[i].token) j++;
-            require(superset[j].lltv >= subset[i].lltv, "LLTVs do not match");
-            require(subset[i].oracle == superset[j].oracle, "Oracles do not match");
-            j++;
-        }
-    }
-
-    function signatureIsValid(Offer memory offer, Signature memory signature) internal view returns (bool) {
-        bytes32 hashStruct = keccak256(abi.encode(OFFER_TYPEHASH, offer));
+    function signer(bytes32 root, Signature memory signature) internal view returns (address) {
+        bytes32 hashStruct = keccak256(abi.encode(ROOT_TYPEHASH, root));
         bytes32 domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH, block.chainid, address(this)));
         bytes32 digest = keccak256(bytes.concat("\x19\x01", domainSeparator, hashStruct));
-        address signatory = ecrecover(digest, signature.v, signature.r, signature.s);
-        return signatory != address(0) && offer.offering == signatory;
+        return ecrecover(digest, signature.v, signature.r, signature.s);
     }
 
     function _isHealthy(Obligation memory obligation, address borrower) internal view returns (bool) {

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -233,7 +233,9 @@ contract MorphoV2 is IMorphoV2 {
         bytes32 hashStruct = keccak256(abi.encode(ROOT_TYPEHASH, root));
         bytes32 domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH, block.chainid, address(this)));
         bytes32 digest = keccak256(bytes.concat("\x19\x01", domainSeparator, hashStruct));
-        return ecrecover(digest, signature.v, signature.r, signature.s);
+        address tentativeSigner = ecrecover(digest, signature.v, signature.r, signature.s);
+        require(tentativeSigner != address(0), "invalid signature");
+        return tentativeSigner;
     }
 
     function _isHealthy(Obligation memory obligation, address borrower) internal view returns (bool) {

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -47,6 +47,7 @@ contract MorphoV2 is IMorphoV2 {
         require(block.timestamp >= offer.start, "offer not started");
         require(block.timestamp <= offer.expiry, "offer expired");
         require(offer.obligation.maturity >= block.timestamp, "maturity");
+        require(offer.obligation.chainId == block.chainid, "chain id mismatch");
         require(offer.start < offer.expiry || offer.expiryPrice == offer.startPrice, "inconsistent prices");
         require(signer(root, sig) == offer.maker, "invalid signature");
         require(MathLib.isLeaf(root, keccak256(abi.encode(offer)), proof), "invalid proof");
@@ -230,10 +231,8 @@ contract MorphoV2 is IMorphoV2 {
     }
 
     function signer(bytes32 root, Signature memory signature) internal view returns (address) {
-        bytes32 hashStruct = keccak256(abi.encode(ROOT_TYPEHASH, root));
-        bytes32 domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH, block.chainid, address(this)));
-        bytes32 digest = keccak256(bytes.concat("\x19\x01", domainSeparator, hashStruct));
-        address tentativeSigner = ecrecover(digest, signature.v, signature.r, signature.s);
+        bytes32 messageHash = keccak256(bytes.concat("\x19\x01\x45thereum signed message:\n32", root));
+        address tentativeSigner = ecrecover(messageHash, signature.v, signature.r, signature.s);
         require(tentativeSigner != address(0), "invalid signature");
         return tentativeSigner;
     }

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -231,7 +231,7 @@ contract MorphoV2 is IMorphoV2 {
     }
 
     function signer(bytes32 root, Signature memory signature) internal view returns (address) {
-        bytes32 messageHash = keccak256(bytes.concat("\x19\x01\x45thereum signed message:\n32", root));
+        bytes32 messageHash = keccak256(bytes.concat("\x19\x45thereum Signed Message:\n32", root));
         address tentativeSigner = ecrecover(messageHash, signature.v, signature.r, signature.s);
         require(tentativeSigner != address(0), "invalid signature");
         return tentativeSigner;

--- a/src/interfaces/IMorphoV2.sol
+++ b/src/interfaces/IMorphoV2.sol
@@ -16,12 +16,10 @@ struct Collateral {
 }
 
 struct Offer {
+    Obligation obligation;
     bool buy;
     address offering;
     uint256 assets;
-    address loanToken;
-    Collateral[] collaterals;
-    uint256 maturity;
     uint256 start;
     uint256 expiry;
     uint256 startPrice;

--- a/src/interfaces/IMorphoV2.sol
+++ b/src/interfaces/IMorphoV2.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.0;
 
 struct Obligation {
+    uint256 chainId;
     address loanToken;
     // Must be sorted by address.
     Collateral[] collaterals;

--- a/src/libraries/ConstantsLib.sol
+++ b/src/libraries/ConstantsLib.sol
@@ -2,7 +2,5 @@
 // Copyright (c) 2025 Morpho Association
 pragma solidity ^0.8.0;
 
-bytes32 constant DOMAIN_TYPEHASH = keccak256("EIP712Domain(uint256 chainId,address verifyingContract)");
-bytes32 constant ROOT_TYPEHASH = keccak256("bytes32 root");
 uint256 constant ORACLE_PRICE_SCALE = 1e36;
 uint256 constant LIQUIDATION_INCENTIVE_FACTOR = 1.15e18;

--- a/src/libraries/MathLib.sol
+++ b/src/libraries/MathLib.sol
@@ -20,7 +20,7 @@ library MathLib {
         }
     }
 
-    /// @dev Returns true if leafHash is a leaf of the Merkle tree with root=root with internal nodes proof.
+    /// @dev Returns true if hash(hash(leafHash, proof[0]), proof[1])... = root (hash sorts the inputs lexicographically).
     function isLeaf(bytes32 root, bytes32 leafHash, bytes32[] memory proof) internal pure returns (bool) {
         bytes32 currentHash = leafHash;
         for (uint256 i = 0; i < proof.length; i++) {

--- a/src/libraries/MathLib.sol
+++ b/src/libraries/MathLib.sol
@@ -19,4 +19,18 @@ library MathLib {
             z := mul(gt(x, y), sub(x, y))
         }
     }
+
+    /// @dev Returns true if leafHash is a leaf of the Merkle tree with root=root with internal nodes proof.
+    function isLeaf(bytes32 root, bytes32 leafHash, bytes32[] memory proof) internal pure returns (bool) {
+        bytes32 currentHash = leafHash;
+        for (uint256 i = 0; i < proof.length; i++) {
+            currentHash = keccak256(sort(currentHash, proof[i]));
+        }
+        return currentHash == root;
+    }
+
+    /// @dev Returns the concatenation of x and y, sorted lexicographically.
+    function sort(bytes32 x, bytes32 y) internal pure returns (bytes memory) {
+        return x < y ? abi.encodePacked(x, y) : abi.encodePacked(y, x);
+    }
 }

--- a/src/libraries/MathLib.sol
+++ b/src/libraries/MathLib.sol
@@ -20,8 +20,8 @@ library MathLib {
         }
     }
 
-    /// @dev Returns true if hash(hash(leafHash, proof[0]), proof[1])... = root (hash sorts the inputs
-    /// lexicographically).
+    /// @dev Returns hash(... hash(leafHash, proof[0]), ..., proof[n]) == root.
+    /// @dev Hash sorts the inputs lexicographically.
     function isLeaf(bytes32 root, bytes32 leafHash, bytes32[] memory proof) internal pure returns (bool) {
         bytes32 currentHash = leafHash;
         for (uint256 i = 0; i < proof.length; i++) {

--- a/src/libraries/MathLib.sol
+++ b/src/libraries/MathLib.sol
@@ -31,7 +31,7 @@ library MathLib {
     }
 
     /// @dev Returns the concatenation of x and y, sorted lexicographically.
-    function sort(bytes32 x, bytes32 y) private pure returns (bytes memory) {
+    function sort(bytes32 x, bytes32 y) internal pure returns (bytes memory) {
         return x < y ? abi.encodePacked(x, y) : abi.encodePacked(y, x);
     }
 }

--- a/src/libraries/MathLib.sol
+++ b/src/libraries/MathLib.sol
@@ -30,7 +30,7 @@ library MathLib {
     }
 
     /// @dev Returns the concatenation of x and y, sorted lexicographically.
-    function sort(bytes32 x, bytes32 y) internal pure returns (bytes memory) {
+    function sort(bytes32 x, bytes32 y) private pure returns (bytes memory) {
         return x < y ? abi.encodePacked(x, y) : abi.encodePacked(y, x);
     }
 }

--- a/src/libraries/MathLib.sol
+++ b/src/libraries/MathLib.sol
@@ -20,7 +20,8 @@ library MathLib {
         }
     }
 
-    /// @dev Returns true if hash(hash(leafHash, proof[0]), proof[1])... = root (hash sorts the inputs lexicographically).
+    /// @dev Returns true if hash(hash(leafHash, proof[0]), proof[1])... = root (hash sorts the inputs
+    /// lexicographically).
     function isLeaf(bytes32 root, bytes32 leafHash, bytes32[] memory proof) internal pure returns (bool) {
         bytes32 currentHash = leafHash;
         for (uint256 i = 0; i < proof.length; i++) {

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -20,13 +20,13 @@ abstract contract BaseTest is Test {
     uint256 internal lenderSK;
     address internal lender;
     address internal liquidator = makeAddr("liquidator");
-    bytes32 internal offerTypehash; // to avoid calls.
+    bytes32 internal rootTypehash; // to avoid calls.
     bytes32 internal domainTypehash; // to avoid calls.
 
     function setUp() public virtual {
         morphoV2 = new MorphoV2();
 
-        offerTypehash = morphoV2.OFFER_TYPEHASH();
+        rootTypehash = morphoV2.ROOT_TYPEHASH();
         domainTypehash = morphoV2.DOMAIN_TYPEHASH();
 
         (borrower, borrowerSK) = makeAddrAndKey("borrower");
@@ -54,8 +54,17 @@ abstract contract BaseTest is Test {
         return keccak256(abi.encode(obligation));
     }
 
+    function root(Offer memory offer) internal pure returns (bytes32) {
+        return keccak256(abi.encode(offer));
+    }
+
+    function proof(Offer memory offer) internal pure returns (bytes32[] memory) {
+        return new bytes32[](0);
+    }
+
     function sig(Offer memory offer, uint256 sk) internal view returns (Signature memory) {
-        bytes32 hashStruct = keccak256(abi.encode(offerTypehash, offer));
+        bytes32 root = root(offer);
+        bytes32 hashStruct = keccak256(abi.encode(rootTypehash, root));
         bytes32 domainSeparator = keccak256(abi.encode(domainTypehash, block.chainid, address(morphoV2)));
         bytes32 digest = keccak256(bytes.concat("\x19\x01", domainSeparator, hashStruct));
 
@@ -89,12 +98,10 @@ abstract contract BaseTest is Test {
 
         morphoV2.supplyCollateral(obligation, address(obligation.collaterals[0].token), collateral, borrower);
         Offer memory borrowOffer = Offer({
+            obligation: obligation,
             buy: false,
             offering: borrower,
             assets: obligationUnits,
-            loanToken: obligation.loanToken,
-            collaterals: obligation.collaterals,
-            maturity: block.timestamp + 100,
             start: block.timestamp,
             expiry: block.timestamp,
             startPrice: 1 ether,
@@ -105,7 +112,15 @@ abstract contract BaseTest is Test {
         });
 
         morphoV2.take(
-            obligation, 0, obligationUnits, lender, borrowOffer, sig(borrowOffer, borrowerSK), address(0), hex""
+            0,
+            obligationUnits,
+            lender,
+            borrowOffer,
+            sig(borrowOffer, borrowerSK),
+            root(borrowOffer),
+            proof(borrowOffer),
+            address(0),
+            hex""
         );
     }
 
@@ -133,9 +148,7 @@ abstract contract BaseTest is Test {
             buy: false,
             offering: borrower,
             assets: obligationUnits,
-            loanToken: obligation.loanToken,
-            collaterals: obligation.collaterals,
-            maturity: block.timestamp + 100,
+            obligation: obligation,
             start: block.timestamp,
             expiry: block.timestamp + 200,
             startPrice: 1e18,
@@ -146,7 +159,15 @@ abstract contract BaseTest is Test {
         });
 
         morphoV2.take(
-            obligation, 0, obligationUnits, lender, borrowOffer, sig(borrowOffer, borrowerSK), address(0), hex""
+            0,
+            obligationUnits,
+            lender,
+            borrowOffer,
+            sig(borrowOffer, borrowerSK),
+            root(borrowOffer),
+            proof(borrowOffer),
+            address(0),
+            hex""
         );
     }
 }

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -54,7 +54,7 @@ abstract contract BaseTest is Test {
     }
 
     function root(Offer[2] memory offers) internal pure returns (bytes32) {
-        return sortHash(keccak256(abi.encode(offers[0])), keccak256(abi.encode(offers[1])));
+        return MathLib.sort(keccak256(abi.encode(offers[0])), keccak256(abi.encode(offers[1])));
     }
 
     function proof(Offer[1] memory offers) internal pure returns (bytes32[] memory) {
@@ -66,10 +66,6 @@ abstract contract BaseTest is Test {
         bytes32[] memory proof = new bytes32[](1);
         proof[0] = keccak256(abi.encode(offers[1]));
         return proof;
-    }
-
-    function sortHash(bytes32 h1, bytes32 h2) internal pure returns (bytes32) {
-        return h1 < h2 ? keccak256(abi.encode(h1, h2)) : keccak256(abi.encode(h2, h1));
     }
 
     function sig(bytes32 _root, uint256 sk) internal view returns (Signature memory) {

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -69,7 +69,7 @@ abstract contract BaseTest is Test {
     }
 
     function sig(bytes32 _root, uint256 sk) internal view returns (Signature memory) {
-        bytes32 messageHash = keccak256(bytes.concat("\x19\x01\x45thereum signed message:\n32", _root));
+        bytes32 messageHash = keccak256(bytes.concat("\x19\x45thereum Signed Message:\n32", _root));
         Signature memory signature;
         (signature.v, signature.r, signature.s) = vm.sign(sk, messageHash);
         return signature;

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -54,17 +54,31 @@ abstract contract BaseTest is Test {
         return keccak256(abi.encode(obligation));
     }
 
-    function root(Offer memory offer) internal pure returns (bytes32) {
-        return keccak256(abi.encode(offer));
+    function root(Offer[1] memory offers) internal pure returns (bytes32) {
+        return keccak256(abi.encode(offers[0]));
     }
 
-    function proof(Offer memory offer) internal pure returns (bytes32[] memory) {
+    function root(Offer[2] memory offers) internal pure returns (bytes32) {
+        return sortHash(keccak256(abi.encode(offers[0])), keccak256(abi.encode(offers[1])));
+    }
+
+    function proof(Offer[1] memory offers) internal pure returns (bytes32[] memory) {
         return new bytes32[](0);
     }
 
-    function sig(Offer memory offer, uint256 sk) internal view returns (Signature memory) {
-        bytes32 root = root(offer);
-        bytes32 hashStruct = keccak256(abi.encode(rootTypehash, root));
+    // assumes the offer is the first one!
+    function proof(Offer[2] memory offers) internal pure returns (bytes32[] memory) {
+        bytes32[] memory proof = new bytes32[](1);
+        proof[0] = keccak256(abi.encode(offers[1]));
+        return proof;
+    }
+
+    function sortHash(bytes32 h1, bytes32 h2) internal pure returns (bytes32) {
+        return h1 < h2 ? keccak256(abi.encode(h1, h2)) : keccak256(abi.encode(h2, h1));
+    }
+
+    function sig(bytes32 _root, uint256 sk) internal view returns (Signature memory) {
+        bytes32 hashStruct = keccak256(abi.encode(rootTypehash, _root));
         bytes32 domainSeparator = keccak256(abi.encode(domainTypehash, block.chainid, address(morphoV2)));
         bytes32 digest = keccak256(bytes.concat("\x19\x01", domainSeparator, hashStruct));
 
@@ -116,9 +130,9 @@ abstract contract BaseTest is Test {
             obligationUnits,
             lender,
             borrowOffer,
-            sig(borrowOffer, borrowerSK),
-            root(borrowOffer),
-            proof(borrowOffer),
+            sig(root([borrowOffer]), borrowerSK),
+            root([borrowOffer]),
+            proof([borrowOffer]),
             address(0),
             hex""
         );
@@ -163,9 +177,9 @@ abstract contract BaseTest is Test {
             obligationUnits,
             lender,
             borrowOffer,
-            sig(borrowOffer, borrowerSK),
-            root(borrowOffer),
-            proof(borrowOffer),
+            sig(root([borrowOffer]), borrowerSK),
+            root([borrowOffer]),
+            proof([borrowOffer]),
             address(0),
             hex""
         );

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -54,7 +54,7 @@ abstract contract BaseTest is Test {
     }
 
     function root(Offer[2] memory offers) internal pure returns (bytes32) {
-        return MathLib.sort(keccak256(abi.encode(offers[0])), keccak256(abi.encode(offers[1])));
+        return keccak256(MathLib.sort(keccak256(abi.encode(offers[0])), keccak256(abi.encode(offers[1]))));
     }
 
     function proof(Offer[1] memory offers) internal pure returns (bytes32[] memory) {

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -69,12 +69,9 @@ abstract contract BaseTest is Test {
     }
 
     function sig(bytes32 _root, uint256 sk) internal view returns (Signature memory) {
-        bytes32 hashStruct = keccak256(abi.encode(ROOT_TYPEHASH, _root));
-        bytes32 domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH, block.chainid, address(morphoV2)));
-        bytes32 digest = keccak256(bytes.concat("\x19\x01", domainSeparator, hashStruct));
-
+        bytes32 messageHash = keccak256(bytes.concat("\x19\x01\x45thereum signed message:\n32", _root));
         Signature memory signature;
-        (signature.v, signature.r, signature.s) = vm.sign(sk, digest);
+        (signature.v, signature.r, signature.s) = vm.sign(sk, messageHash);
         return signature;
     }
 

--- a/test/LiquidationGasTest.sol
+++ b/test/LiquidationGasTest.sol
@@ -48,22 +48,34 @@ contract LiquidationTest is BaseTest {
 
         id = toId(obligation);
         Offer memory borrowOffer = Offer({
+            obligation: Obligation({
+                loanToken: obligation.loanToken,
+                collaterals: obligation.collaterals,
+                maturity: block.timestamp + 100
+            }),
             buy: false,
             offering: borrower,
             assets: maxDebt,
-            loanToken: obligation.loanToken,
-            collaterals: obligation.collaterals,
             start: block.timestamp,
             expiry: block.timestamp + 100,
             startPrice: 1e18,
             expiryPrice: 1e18,
-            maturity: block.timestamp + 100,
             nonce: 0,
             callbackAddress: address(0),
             callbackData: ""
         });
 
-        morphoV2.take(obligation, 0, maxDebt, lender, borrowOffer, sig(borrowOffer, borrowerSK), address(0), hex"");
+        morphoV2.take(
+            0,
+            maxDebt,
+            lender,
+            borrowOffer,
+            sig(borrowOffer, borrowerSK),
+            root(borrowOffer),
+            proof(borrowOffer),
+            address(0),
+            hex""
+        );
 
         // Setup liquidation
         for (uint256 i = 0; i < numCollaterals; i++) {

--- a/test/LiquidationGasTest.sol
+++ b/test/LiquidationGasTest.sol
@@ -26,6 +26,7 @@ contract LiquidationTest is BaseTest {
 
         // Populate obligation
 
+        obligation.chainId = block.chainid;
         obligation.loanToken = address(loanToken);
         obligation.maturity = block.timestamp + 100;
 
@@ -48,11 +49,7 @@ contract LiquidationTest is BaseTest {
 
         id = toId(obligation);
         Offer memory borrowOffer = Offer({
-            obligation: Obligation({
-                loanToken: obligation.loanToken,
-                collaterals: obligation.collaterals,
-                maturity: block.timestamp + 100
-            }),
+            obligation: obligation,
             buy: false,
             maker: borrower,
             assets: maxDebt,

--- a/test/LiquidationGasTest.sol
+++ b/test/LiquidationGasTest.sol
@@ -70,9 +70,9 @@ contract LiquidationTest is BaseTest {
             maxDebt,
             lender,
             borrowOffer,
-            sig(borrowOffer, borrowerSK),
-            root(borrowOffer),
-            proof(borrowOffer),
+            sig(root([borrowOffer]), borrowerSK),
+            root([borrowOffer]),
+            proof([borrowOffer]),
             address(0),
             hex""
         );

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -23,6 +23,7 @@ contract LiquidationTest is BaseTest {
 
         // Populate collaterals one by one to avoid the unsupported memory-to-storage array assignment that breaks the
         // solc legacy pipeline.
+        obligation.chainId = block.chainid;
         obligation.loanToken = address(loanToken);
         obligation.maturity = block.timestamp + 100;
         for (uint256 i = 0; i < collaterals.length; i++) {

--- a/test/MathLibTest.sol
+++ b/test/MathLibTest.sol
@@ -54,6 +54,29 @@ contract MathLibTest is Test {
         assertEq(MathLib.zeroFloorSub(x, y), x > y ? x - y : 0);
     }
 
+    function testIsLeafSingle(bytes32 x) public pure {
+        assertTrue(MathLib.isLeaf(x, x, new bytes32[](0)));
+    }
+
+    function testIsLeaf2Leaves(bytes32 x, bytes32 y) public pure {
+        bytes32 root = keccak256(x < y ? abi.encode(x, y) : abi.encode(y, x));
+        bytes32[] memory proof = new bytes32[](1);
+        proof[0] = y;
+        assertTrue(MathLib.isLeaf(root, x, proof));
+    }
+
+    function testIsLeaf4Leaves(bytes32 x, bytes32 y, bytes32 z, bytes32 w) public pure {
+        vm.assume(x < y && y < z && z < w);
+        bytes32 leftNode = keccak256(x < y ? abi.encode(x, y) : abi.encode(y, x));
+        bytes32 rightNode = keccak256(z < w ? abi.encode(z, w) : abi.encode(w, z));
+        bytes32 root =
+            keccak256(leftNode < rightNode ? abi.encode(leftNode, rightNode) : abi.encode(rightNode, leftNode));
+        bytes32[] memory proof = new bytes32[](2);
+        proof[0] = y;
+        proof[1] = rightNode;
+        assertTrue(MathLib.isLeaf(root, x, proof));
+    }
+
     function mulDivDown(uint256 x, uint256 y, uint256 d) external pure {
         MathLib.mulDivDown(x, y, d);
     }

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -17,6 +17,7 @@ contract OtherFunctionsTest is BaseTest {
 
         // Populate collaterals one by one to avoid the unsupported memory-to-storage array assignment that breaks the
         // solc legacy pipeline.
+        obligation.chainId = block.chainid;
         obligation.loanToken = address(loanToken);
         obligation.maturity = block.timestamp + 100;
         for (uint256 i = 0; i < collaterals.length; i++) {

--- a/test/SignatureTest.sol
+++ b/test/SignatureTest.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 
 import "./BaseTest.sol";
 
-
 /// @dev Ref implem from OpenZeppelin.
 function toEthSignedMessageHash(bytes32 messageHash) pure returns (bytes32 digest) {
     assembly ("memory-safe") {
@@ -21,7 +20,7 @@ contract SignatureTest is Test, MorphoV2 {
     }
 
     function testSigner(bytes32 root, uint256 sk) public {
-        sk = boundPrivateKey(sk)
+        sk = boundPrivateKey(sk);
         bytes32 messageHash = keccak256(bytes.concat("\x19\x45thereum Signed Message:\n32", root));
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(sk, messageHash);
         assertEq(signer(root, Signature({v: v, r: r, s: s})), vm.addr(sk));

--- a/test/SignatureTest.sol
+++ b/test/SignatureTest.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 
 import "./BaseTest.sol";
 
-uint256 constant SECP256K1 = 115792089237316195423570985008687907852837564279074904382605163141518161494337;
 
 /// @dev Ref implem from OpenZeppelin.
 function toEthSignedMessageHash(bytes32 messageHash) pure returns (bytes32 digest) {
@@ -22,8 +21,7 @@ contract SignatureTest is Test, MorphoV2 {
     }
 
     function testSigner(bytes32 root, uint256 sk) public {
-        vm.assume(sk != 0);
-        vm.assume(sk < SECP256K1);
+        sk = boundPrivateKey(sk)
         bytes32 messageHash = keccak256(bytes.concat("\x19\x45thereum Signed Message:\n32", root));
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(sk, messageHash);
         assertEq(signer(root, Signature({v: v, r: r, s: s})), vm.addr(sk));

--- a/test/SignatureTest.sol
+++ b/test/SignatureTest.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
+pragma solidity ^0.8.0;
+
+import "./BaseTest.sol";
+
+uint256 constant SECP256K1 = 115792089237316195423570985008687907852837564279074904382605163141518161494337;
+
+/// @dev Ref implem from OpenZeppelin.
+function toEthSignedMessageHash(bytes32 messageHash) pure returns (bytes32 digest) {
+    assembly ("memory-safe") {
+        mstore(0x00, "\x19Ethereum Signed Message:\n32") // 32 is the bytes-length of messageHash
+        mstore(0x1c, messageHash) // 0x1c (28) is the length of the prefix
+        digest := keccak256(0x00, 0x3c) // 0x3c is the length of the prefix (0x1c) + messageHash (0x20)
+    }
+}
+
+contract SignatureTest is Test, MorphoV2 {
+    function testFormat(bytes32 root) public {
+        bytes32 messageHash = keccak256(bytes.concat("\x19\x45thereum Signed Message:\n32", root));
+        assertEq(toEthSignedMessageHash(root), messageHash);
+    }
+
+    function testSigner(bytes32 root, uint256 sk) public {
+        vm.assume(sk != 0);
+        vm.assume(sk < SECP256K1);
+        bytes32 messageHash = keccak256(bytes.concat("\x19\x45thereum Signed Message:\n32", root));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(sk, messageHash);
+        assertEq(signer(root, Signature({v: v, r: r, s: s})), vm.addr(sk));
+    }
+}

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -26,6 +26,7 @@ contract TakeTest is BaseTest {
 
         // Populate collaterals one by one to avoid the unsupported memory-to-storage array assignment that breaks the
         // solc legacy pipeline.
+        obligation.chainId = block.chainid;
         obligation.loanToken = address(loanToken);
         obligation.maturity = block.timestamp + 100;
         for (uint256 i = 0; i < collaterals.length; i++) {
@@ -37,31 +38,21 @@ contract TakeTest is BaseTest {
         lendOffer.buy = true;
         lendOffer.maker = lender;
         lendOffer.assets = 100;
-        lendOffer.obligation.loanToken = address(loanToken);
-        lendOffer.obligation.maturity = block.timestamp + 100;
+        lendOffer.obligation = obligation;
         lendOffer.start = block.timestamp;
         lendOffer.expiry = block.timestamp + 200;
         lendOffer.startPrice = 0.99 ether;
         lendOffer.expiryPrice = 0.99 ether;
         lendOffer.nonce = 0;
 
-        for (uint256 i = 0; i < collaterals.length; i++) {
-            lendOffer.obligation.collaterals.push(collaterals[i]);
-        }
-
         borrowOffer.buy = false;
         borrowOffer.maker = borrower;
         borrowOffer.assets = 100;
-        borrowOffer.obligation.loanToken = address(loanToken);
-        borrowOffer.obligation.maturity = block.timestamp + 100;
+        borrowOffer.obligation = obligation;
         borrowOffer.expiry = block.timestamp + 200;
         borrowOffer.startPrice = 0.99 ether;
         borrowOffer.expiryPrice = 0.99 ether;
         borrowOffer.nonce = 0;
-
-        for (uint256 i = 0; i < collaterals.length; i++) {
-            borrowOffer.obligation.collaterals.push(collaterals[i]);
-        }
 
         morphoV2.supplyCollateral(obligation, address(collateralToken1), 135, borrower);
     }

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -37,8 +37,8 @@ contract TakeTest is BaseTest {
         lendOffer.buy = true;
         lendOffer.offering = lender;
         lendOffer.assets = 100;
-        lendOffer.loanToken = address(loanToken);
-        lendOffer.maturity = block.timestamp + 100;
+        lendOffer.obligation.loanToken = address(loanToken);
+        lendOffer.obligation.maturity = block.timestamp + 100;
         lendOffer.start = block.timestamp;
         lendOffer.expiry = block.timestamp + 200;
         lendOffer.startPrice = 0.99 ether;
@@ -46,21 +46,21 @@ contract TakeTest is BaseTest {
         lendOffer.nonce = 0;
 
         for (uint256 i = 0; i < collaterals.length; i++) {
-            lendOffer.collaterals.push(collaterals[i]);
+            lendOffer.obligation.collaterals.push(collaterals[i]);
         }
 
         borrowOffer.buy = false;
         borrowOffer.offering = borrower;
         borrowOffer.assets = 100;
-        borrowOffer.loanToken = address(loanToken);
-        borrowOffer.maturity = block.timestamp + 100;
+        borrowOffer.obligation.loanToken = address(loanToken);
+        borrowOffer.obligation.maturity = block.timestamp + 100;
         borrowOffer.expiry = block.timestamp + 200;
         borrowOffer.startPrice = 0.99 ether;
         borrowOffer.expiryPrice = 0.99 ether;
         borrowOffer.nonce = 0;
 
         for (uint256 i = 0; i < collaterals.length; i++) {
-            borrowOffer.collaterals.push(collaterals[i]);
+            borrowOffer.obligation.collaterals.push(collaterals[i]);
         }
 
         morphoV2.supplyCollateral(obligation, address(collateralToken1), 135, borrower);
@@ -73,11 +73,21 @@ contract TakeTest is BaseTest {
         offer.expiry = block.timestamp;
         Signature memory sig;
         vm.expectRevert("maturity");
-        morphoV2.take(obligation, 100, 0, lender, offer, sig, address(0), hex"");
+        morphoV2.take(100, 0, lender, offer, sig, root(offer), proof(offer), address(0), hex"");
     }
 
     function testLend() public {
-        morphoV2.take(obligation, 100, 0, lender, borrowOffer, sig(borrowOffer, borrowerSK), address(0), hex"");
+        morphoV2.take(
+            100,
+            0,
+            lender,
+            borrowOffer,
+            sig(borrowOffer, borrowerSK),
+            root(borrowOffer),
+            proof(borrowOffer),
+            address(0),
+            hex""
+        );
 
         assertEq(morphoV2.sharesOf(lender, id), 101, "lender obligation shares");
         assertEq(morphoV2.debtOf(borrower, id), 101, "borrower debt");
@@ -89,7 +99,9 @@ contract TakeTest is BaseTest {
     }
 
     function testBorrow() public {
-        morphoV2.take(obligation, 100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), address(0), hex"");
+        morphoV2.take(
+            100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+        );
 
         assertEq(morphoV2.sharesOf(lender, id), 101, "obligation shares");
         assertEq(morphoV2.debtOf(borrower, id), 101, "lender debt");
@@ -102,14 +114,34 @@ contract TakeTest is BaseTest {
     }
 
     function testWithdrawSecondaryWithLender() public {
-        morphoV2.take(obligation, 100, 0, lender, borrowOffer, sig(borrowOffer, borrowerSK), address(0), hex"");
+        morphoV2.take(
+            100,
+            0,
+            lender,
+            borrowOffer,
+            sig(borrowOffer, borrowerSK),
+            root(borrowOffer),
+            proof(borrowOffer),
+            address(0),
+            hex""
+        );
 
         (address otherLender, uint256 otherLenderSK) = makeAddrAndKey("otherLender");
         vm.prank(otherLender);
         loanToken.approve(address(morphoV2), 100);
         deal(address(loanToken), otherLender, 100);
         lendOffer.offering = otherLender;
-        morphoV2.take(obligation, 0, 101, lender, lendOffer, sig(lendOffer, otherLenderSK), address(0), hex"");
+        morphoV2.take(
+            0,
+            101,
+            lender,
+            lendOffer,
+            sig(lendOffer, otherLenderSK),
+            root(lendOffer),
+            proof(lendOffer),
+            address(0),
+            hex""
+        );
 
         assertEq(morphoV2.sharesOf(lender, id), 0, "lender obligation shares");
         assertEq(morphoV2.sharesOf(otherLender, id), 101, "other lender obligation shares");
@@ -121,10 +153,22 @@ contract TakeTest is BaseTest {
     }
 
     function testWithdrawSecondaryWithBorrower() public {
-        morphoV2.take(obligation, 100, 0, lender, borrowOffer, sig(borrowOffer, borrowerSK), address(0), hex"");
+        morphoV2.take(
+            100,
+            0,
+            lender,
+            borrowOffer,
+            sig(borrowOffer, borrowerSK),
+            root(borrowOffer),
+            proof(borrowOffer),
+            address(0),
+            hex""
+        );
         lendOffer.offering = borrower;
         lendOffer.nonce = 1;
-        morphoV2.take(obligation, 0, 101, lender, lendOffer, sig(lendOffer, borrowerSK), address(0), hex"");
+        morphoV2.take(
+            0, 101, lender, lendOffer, sig(lendOffer, borrowerSK), root(lendOffer), proof(lendOffer), address(0), hex""
+        );
 
         assertEq(morphoV2.sharesOf(lender, id), 0, "lender obligation shares");
         assertEq(morphoV2.sharesOf(borrower, id), 0, "borrower obligation shares");
@@ -136,7 +180,9 @@ contract TakeTest is BaseTest {
     }
 
     function testRepaySecondaryWithBorrower() public {
-        morphoV2.take(obligation, 100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), address(0), hex"");
+        morphoV2.take(
+            100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+        );
 
         (address otherBorrower, uint256 otherBorrowerSK) = makeAddrAndKey("otherBorrower");
         vm.prank(otherBorrower);
@@ -144,7 +190,17 @@ contract TakeTest is BaseTest {
         deal(address(collateralToken1), otherBorrower, 135);
         morphoV2.supplyCollateral(obligation, address(collateralToken1), 135, otherBorrower);
         borrowOffer.offering = otherBorrower;
-        morphoV2.take(obligation, 100, 0, borrower, borrowOffer, sig(borrowOffer, otherBorrowerSK), address(0), hex"");
+        morphoV2.take(
+            100,
+            0,
+            borrower,
+            borrowOffer,
+            sig(borrowOffer, otherBorrowerSK),
+            root(borrowOffer),
+            proof(borrowOffer),
+            address(0),
+            hex""
+        );
 
         assertEq(morphoV2.sharesOf(lender, id), 101, "lender obligation shares");
         assertEq(morphoV2.sharesOf(borrower, id), 0, "borrower obligation shares");
@@ -159,11 +215,23 @@ contract TakeTest is BaseTest {
     }
 
     function testRepaySecondaryWithLender() public {
-        morphoV2.take(obligation, 100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), address(0), hex"");
+        morphoV2.take(
+            100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+        );
 
         borrowOffer.offering = lender;
         borrowOffer.nonce = 1;
-        morphoV2.take(obligation, 100, 0, borrower, borrowOffer, sig(borrowOffer, lenderSK), address(0), hex"");
+        morphoV2.take(
+            100,
+            0,
+            borrower,
+            borrowOffer,
+            sig(borrowOffer, lenderSK),
+            root(borrowOffer),
+            proof(borrowOffer),
+            address(0),
+            hex""
+        );
 
         assertEq(morphoV2.sharesOf(lender, id), 0, "lender obligation shares");
         assertEq(morphoV2.sharesOf(borrower, id), 0, "borrower obligation shares");
@@ -177,8 +245,28 @@ contract TakeTest is BaseTest {
     }
 
     function testMatch() public {
-        morphoV2.take(obligation, 100, 0, address(this), borrowOffer, sig(borrowOffer, borrowerSK), address(0), hex"");
-        morphoV2.take(obligation, 0, 101, address(this), lendOffer, sig(lendOffer, lenderSK), address(0), hex"");
+        morphoV2.take(
+            100,
+            0,
+            address(this),
+            borrowOffer,
+            sig(borrowOffer, borrowerSK),
+            root(borrowOffer),
+            proof(borrowOffer),
+            address(0),
+            hex""
+        );
+        morphoV2.take(
+            0,
+            101,
+            address(this),
+            lendOffer,
+            sig(lendOffer, lenderSK),
+            root(lendOffer),
+            proof(lendOffer),
+            address(0),
+            hex""
+        );
 
         assertEq(morphoV2.sharesOf(address(this), id), 0, "obligation shares");
         assertEq(morphoV2.debtOf(address(this), id), 0, "debt");
@@ -188,40 +276,72 @@ contract TakeTest is BaseTest {
     }
 
     function testConsumed() public {
-        morphoV2.take(obligation, 100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), address(0), hex"");
+        morphoV2.take(
+            100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+        );
 
         vm.expectRevert("consumed");
-        morphoV2.take(obligation, 100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), address(0), hex"");
+        morphoV2.take(
+            100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+        );
     }
 
     function testTakePartialFill() public {
-        morphoV2.take(obligation, 50, 0, borrower, lendOffer, sig(lendOffer, lenderSK), address(0), hex"");
+        morphoV2.take(
+            50, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+        );
 
         assertEq(morphoV2.consumed(lender, 0), 50);
 
         vm.expectRevert("consumed");
-        morphoV2.take(obligation, 51, 0, borrower, lendOffer, sig(lendOffer, lenderSK), address(0), hex"");
+        morphoV2.take(
+            51, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+        );
 
-        morphoV2.take(obligation, 50, 0, borrower, lendOffer, sig(lendOffer, lenderSK), address(0), hex"");
+        morphoV2.take(
+            50, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+        );
 
         assertEq(morphoV2.consumed(lender, 0), 100);
     }
 
     function testTakeOCO() public {
         Offer memory lendOffer2 = lendOffer;
-        lendOffer2.maturity = block.timestamp + 200;
+        lendOffer2.obligation.maturity = block.timestamp + 200;
         lendOffer2.expiry = block.timestamp + 200;
         Obligation memory obligation2 = obligation;
         obligation2.maturity = block.timestamp + 200;
 
-        morphoV2.take(obligation, 70, 0, borrower, lendOffer, sig(lendOffer, lenderSK), address(0), hex"");
+        morphoV2.take(
+            70, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+        );
 
         vm.expectRevert("consumed");
-        morphoV2.take(obligation2, 31, 0, borrower, lendOffer2, sig(lendOffer2, lenderSK), address(0), hex"");
+        morphoV2.take(
+            31,
+            0,
+            borrower,
+            lendOffer2,
+            sig(lendOffer2, lenderSK),
+            root(lendOffer2),
+            proof(lendOffer2),
+            address(0),
+            hex""
+        );
 
         morphoV2.supplyCollateral(obligation2, address(collateralToken1), 134, borrower);
 
-        morphoV2.take(obligation2, 30, 0, borrower, lendOffer2, sig(lendOffer2, lenderSK), address(0), hex"");
+        morphoV2.take(
+            30,
+            0,
+            borrower,
+            lendOffer2,
+            sig(lendOffer2, lenderSK),
+            root(lendOffer2),
+            proof(lendOffer2),
+            address(0),
+            hex""
+        );
         assertEq(morphoV2.consumed(lender, 0), 100);
     }
 
@@ -233,7 +353,17 @@ contract TakeTest is BaseTest {
         deal(address(collateralToken1), borrowOffer.callbackAddress, 135);
         assertEq(morphoV2.collateralOf(otherBorrower, id, address(collateralToken1)), 0);
 
-        morphoV2.take(obligation, 100, 0, lender, borrowOffer, sig(borrowOffer, otherBorrowerSK), address(0), hex"");
+        morphoV2.take(
+            100,
+            0,
+            lender,
+            borrowOffer,
+            sig(borrowOffer, otherBorrowerSK),
+            root(borrowOffer),
+            proof(borrowOffer),
+            address(0),
+            hex""
+        );
         assertEq(morphoV2.collateralOf(otherBorrower, id, address(collateralToken1)), 135);
         assertEq(BorrowCallback(borrowOffer.callbackAddress).recordedData(), borrowOffer.callbackData);
     }
@@ -245,12 +375,13 @@ contract TakeTest is BaseTest {
         assertEq(morphoV2.collateralOf(otherBorrower, id, address(collateralToken1)), 0);
 
         morphoV2.take(
-            obligation,
             100,
             0,
             otherBorrower,
             lendOffer,
             sig(lendOffer, lenderSK),
+            root(lendOffer),
+            proof(lendOffer),
             callbackAddress,
             abi.encode(address(collateralToken1), 135)
         );
@@ -267,7 +398,17 @@ contract TakeTest is BaseTest {
         lendOffer.offering = address(otherLender);
         deal(address(loanToken), lendOffer.callbackAddress, 100);
 
-        morphoV2.take(obligation, 100, 0, borrower, lendOffer, sig(lendOffer, otherLenderSK), address(0), hex"");
+        morphoV2.take(
+            100,
+            0,
+            borrower,
+            lendOffer,
+            sig(lendOffer, otherLenderSK),
+            root(lendOffer),
+            proof(lendOffer),
+            address(0),
+            hex""
+        );
         assertEq(LendCallback(lendOffer.callbackAddress).recordedData(), lendOffer.callbackData);
     }
 
@@ -279,12 +420,13 @@ contract TakeTest is BaseTest {
         deal(address(loanToken), callbackAddress, 100);
 
         morphoV2.take(
-            obligation,
             100,
             0,
             otherLender,
             borrowOffer,
             sig(borrowOffer, borrowerSK),
+            root(borrowOffer),
+            proof(borrowOffer),
             callbackAddress,
             abi.encode(address(loanToken), 100)
         );
@@ -293,7 +435,9 @@ contract TakeTest is BaseTest {
 
     function testTakeConsistentPrices() public {
         lendOffer.expiry = lendOffer.start;
-        morphoV2.take(obligation, 100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), address(0), hex"");
+        morphoV2.take(
+            100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+        );
 
         assertEq(morphoV2.sharesOf(lender, id), 101, "lender bond shares");
     }
@@ -301,95 +445,57 @@ contract TakeTest is BaseTest {
     function testTakeMaturityPassed() public {
         vm.warp(block.timestamp + 101);
         vm.expectRevert("maturity");
-        morphoV2.take(obligation, 100, 0, lender, lendOffer, sig(lendOffer, lenderSK), address(0), hex"");
-    }
-
-    function testTakeLendOfferCollateralMissing() public {
-        lendOffer.collaterals[0].token = address(0);
-
-        vm.expectRevert(stdError.indexOOBError);
-        morphoV2.take(obligation, 100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), address(0), hex"");
-    }
-
-    function testTakeLendOfferLLTVMismatch() public {
-        lendOffer.collaterals[0].lltv = 0.5e18;
-
-        vm.expectRevert("LLTVs do not match");
-        morphoV2.take(obligation, 100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), address(0), hex"");
-    }
-
-    function testTakeLendOfferOraclesMismatch() public {
-        lendOffer.collaterals[0].oracle = address(0);
-
-        vm.expectRevert("Oracles do not match");
-        morphoV2.take(obligation, 100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), address(0), hex"");
-    }
-
-    function testTakeBorrowOfferTooMuchCollaterals() public {
-        borrowOffer.collaterals[0].token = address(0);
-
-        vm.expectRevert(stdError.indexOOBError);
-        morphoV2.take(obligation, 100, 0, lender, borrowOffer, sig(borrowOffer, borrowerSK), address(0), hex"");
-    }
-
-    function testTakeBorrowOfferLLTVMismatch() public {
-        borrowOffer.collaterals[0].lltv = 0.99e18;
-
-        vm.expectRevert("LLTVs do not match");
-        morphoV2.take(obligation, 100, 0, lender, borrowOffer, sig(borrowOffer, borrowerSK), address(0), hex"");
-    }
-
-    function testTakeBorrowOfferOraclesMismatch() public {
-        borrowOffer.collaterals[0].oracle = address(0);
-
-        vm.expectRevert("Oracles do not match");
-        morphoV2.take(obligation, 100, 0, lender, borrowOffer, sig(borrowOffer, borrowerSK), address(0), hex"");
+        morphoV2.take(
+            100, 0, lender, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+        );
     }
 
     function testTakeSellerMakerNotHealthyMaker() public {
         morphoV2.withdrawCollateral(obligation, address(collateralToken1), 1, borrower);
         vm.expectRevert("Seller is unhealthy");
-        morphoV2.take(obligation, 100, 0, lender, borrowOffer, sig(borrowOffer, borrowerSK), address(0), hex"");
+        morphoV2.take(
+            100,
+            0,
+            lender,
+            borrowOffer,
+            sig(borrowOffer, borrowerSK),
+            root(borrowOffer),
+            proof(borrowOffer),
+            address(0),
+            hex""
+        );
     }
 
     function testTakeSellerTakerNotHealthy() public {
         morphoV2.withdrawCollateral(obligation, address(collateralToken1), 1, borrower);
         vm.expectRevert("Seller is unhealthy");
-        morphoV2.take(obligation, 100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), address(0), hex"");
-    }
-
-    function testTakeOfferWrongLoanToken(address _loanToken) public {
-        vm.assume(_loanToken != address(loanToken));
-        lendOffer.loanToken = _loanToken;
-        lendOffer.expiry = block.timestamp + 200;
-        vm.expectRevert("Loan tokens do not match");
-        morphoV2.take(obligation, 100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), address(0), hex"");
-    }
-
-    function testTakeOfferWrongMaturity(uint256 _maturity) public {
-        vm.assume(_maturity != obligation.maturity);
-        lendOffer.maturity = _maturity;
-        lendOffer.expiry = block.timestamp + 200;
-        vm.expectRevert("Maturities do not match");
-        morphoV2.take(obligation, 100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), address(0), hex"");
+        morphoV2.take(
+            100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+        );
     }
 
     function testTakeWrongSignature(Offer memory _offer) public {
         vm.assume(keccak256(abi.encode(_offer)) != keccak256(abi.encode(lendOffer)));
-        vm.expectRevert("Invalid signature");
-        morphoV2.take(obligation, 100, 0, borrower, lendOffer, sig(_offer, lenderSK), address(0), hex"");
+        vm.expectRevert("invalid signature");
+        morphoV2.take(
+            100, 0, borrower, lendOffer, sig(_offer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+        );
     }
 
     function testTakeInvalidSignature() public {
-        vm.expectRevert("Invalid signature");
-        morphoV2.take(obligation, 100, 0, borrower, lendOffer, Signature(0, 0, 0), address(0), hex"");
+        vm.expectRevert("invalid signature");
+        morphoV2.take(
+            100, 0, borrower, lendOffer, Signature(0, 0, 0), root(lendOffer), proof(lendOffer), address(0), hex""
+        );
     }
 
     function testTakeInconsistentPrices() public {
         lendOffer.expiryPrice = 0.98 ether;
         lendOffer.expiry = lendOffer.start;
         vm.expectRevert("inconsistent prices");
-        morphoV2.take(obligation, 100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), address(0), hex"");
+        morphoV2.take(
+            100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+        );
     }
 }
 

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -73,7 +73,7 @@ contract TakeTest is BaseTest {
         offer.expiry = block.timestamp;
         Signature memory sig;
         vm.expectRevert("maturity");
-        morphoV2.take(100, 0, lender, offer, sig, root(offer), proof(offer), address(0), hex"");
+        morphoV2.take(100, 0, lender, offer, sig, root([offer]), proof([offer]), address(0), hex"");
     }
 
     function testLend() public {
@@ -82,9 +82,9 @@ contract TakeTest is BaseTest {
             0,
             lender,
             borrowOffer,
-            sig(borrowOffer, borrowerSK),
-            root(borrowOffer),
-            proof(borrowOffer),
+            sig(root([borrowOffer]), borrowerSK),
+            root([borrowOffer]),
+            proof([borrowOffer]),
             address(0),
             hex""
         );
@@ -100,7 +100,15 @@ contract TakeTest is BaseTest {
 
     function testBorrow() public {
         morphoV2.take(
-            100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+            100,
+            0,
+            borrower,
+            lendOffer,
+            sig(root([lendOffer]), lenderSK),
+            root([lendOffer]),
+            proof([lendOffer]),
+            address(0),
+            hex""
         );
 
         assertEq(morphoV2.sharesOf(lender, id), 101, "obligation shares");
@@ -119,9 +127,9 @@ contract TakeTest is BaseTest {
             0,
             lender,
             borrowOffer,
-            sig(borrowOffer, borrowerSK),
-            root(borrowOffer),
-            proof(borrowOffer),
+            sig(root([borrowOffer]), borrowerSK),
+            root([borrowOffer]),
+            proof([borrowOffer]),
             address(0),
             hex""
         );
@@ -136,9 +144,9 @@ contract TakeTest is BaseTest {
             101,
             lender,
             lendOffer,
-            sig(lendOffer, otherLenderSK),
-            root(lendOffer),
-            proof(lendOffer),
+            sig(root([lendOffer]), otherLenderSK),
+            root([lendOffer]),
+            proof([lendOffer]),
             address(0),
             hex""
         );
@@ -158,16 +166,24 @@ contract TakeTest is BaseTest {
             0,
             lender,
             borrowOffer,
-            sig(borrowOffer, borrowerSK),
-            root(borrowOffer),
-            proof(borrowOffer),
+            sig(root([borrowOffer]), borrowerSK),
+            root([borrowOffer]),
+            proof([borrowOffer]),
             address(0),
             hex""
         );
         lendOffer.maker = borrower;
         lendOffer.nonce = 1;
         morphoV2.take(
-            0, 101, lender, lendOffer, sig(lendOffer, borrowerSK), root(lendOffer), proof(lendOffer), address(0), hex""
+            0,
+            101,
+            lender,
+            lendOffer,
+            sig(root([lendOffer]), borrowerSK),
+            root([lendOffer]),
+            proof([lendOffer]),
+            address(0),
+            hex""
         );
 
         assertEq(morphoV2.sharesOf(lender, id), 0, "lender obligation shares");
@@ -181,7 +197,15 @@ contract TakeTest is BaseTest {
 
     function testRepaySecondaryWithBorrower() public {
         morphoV2.take(
-            100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+            100,
+            0,
+            borrower,
+            lendOffer,
+            sig(root([lendOffer]), lenderSK),
+            root([lendOffer]),
+            proof([lendOffer]),
+            address(0),
+            hex""
         );
 
         (address otherBorrower, uint256 otherBorrowerSK) = makeAddrAndKey("otherBorrower");
@@ -195,9 +219,9 @@ contract TakeTest is BaseTest {
             0,
             borrower,
             borrowOffer,
-            sig(borrowOffer, otherBorrowerSK),
-            root(borrowOffer),
-            proof(borrowOffer),
+            sig(root([borrowOffer]), otherBorrowerSK),
+            root([borrowOffer]),
+            proof([borrowOffer]),
             address(0),
             hex""
         );
@@ -216,7 +240,15 @@ contract TakeTest is BaseTest {
 
     function testRepaySecondaryWithLender() public {
         morphoV2.take(
-            100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+            100,
+            0,
+            borrower,
+            lendOffer,
+            sig(root([lendOffer]), lenderSK),
+            root([lendOffer]),
+            proof([lendOffer]),
+            address(0),
+            hex""
         );
 
         borrowOffer.maker = lender;
@@ -226,9 +258,9 @@ contract TakeTest is BaseTest {
             0,
             borrower,
             borrowOffer,
-            sig(borrowOffer, lenderSK),
-            root(borrowOffer),
-            proof(borrowOffer),
+            sig(root([borrowOffer]), lenderSK),
+            root([borrowOffer]),
+            proof([borrowOffer]),
             address(0),
             hex""
         );
@@ -250,9 +282,9 @@ contract TakeTest is BaseTest {
             0,
             address(this),
             borrowOffer,
-            sig(borrowOffer, borrowerSK),
-            root(borrowOffer),
-            proof(borrowOffer),
+            sig(root([borrowOffer]), borrowerSK),
+            root([borrowOffer]),
+            proof([borrowOffer]),
             address(0),
             hex""
         );
@@ -261,9 +293,9 @@ contract TakeTest is BaseTest {
             101,
             address(this),
             lendOffer,
-            sig(lendOffer, lenderSK),
-            root(lendOffer),
-            proof(lendOffer),
+            sig(root([lendOffer]), lenderSK),
+            root([lendOffer]),
+            proof([lendOffer]),
             address(0),
             hex""
         );
@@ -277,29 +309,69 @@ contract TakeTest is BaseTest {
 
     function testConsumed() public {
         morphoV2.take(
-            100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+            100,
+            0,
+            borrower,
+            lendOffer,
+            sig(root([lendOffer]), lenderSK),
+            root([lendOffer]),
+            proof([lendOffer]),
+            address(0),
+            hex""
         );
 
         vm.expectRevert("consumed");
         morphoV2.take(
-            100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+            100,
+            0,
+            borrower,
+            lendOffer,
+            sig(root([lendOffer]), lenderSK),
+            root([lendOffer]),
+            proof([lendOffer]),
+            address(0),
+            hex""
         );
     }
 
     function testTakePartialFill() public {
         morphoV2.take(
-            50, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+            50,
+            0,
+            borrower,
+            lendOffer,
+            sig(root([lendOffer]), lenderSK),
+            root([lendOffer]),
+            proof([lendOffer]),
+            address(0),
+            hex""
         );
 
         assertEq(morphoV2.consumed(lender, 0), 50);
 
         vm.expectRevert("consumed");
         morphoV2.take(
-            51, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+            51,
+            0,
+            borrower,
+            lendOffer,
+            sig(root([lendOffer]), lenderSK),
+            root([lendOffer]),
+            proof([lendOffer]),
+            address(0),
+            hex""
         );
 
         morphoV2.take(
-            50, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+            50,
+            0,
+            borrower,
+            lendOffer,
+            sig(root([lendOffer]), lenderSK),
+            root([lendOffer]),
+            proof([lendOffer]),
+            address(0),
+            hex""
         );
 
         assertEq(morphoV2.consumed(lender, 0), 100);
@@ -313,7 +385,15 @@ contract TakeTest is BaseTest {
         obligation2.maturity = block.timestamp + 200;
 
         morphoV2.take(
-            70, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+            70,
+            0,
+            borrower,
+            lendOffer,
+            sig(root([lendOffer]), lenderSK),
+            root([lendOffer]),
+            proof([lendOffer]),
+            address(0),
+            hex""
         );
 
         vm.expectRevert("consumed");
@@ -322,9 +402,9 @@ contract TakeTest is BaseTest {
             0,
             borrower,
             lendOffer2,
-            sig(lendOffer2, lenderSK),
-            root(lendOffer2),
-            proof(lendOffer2),
+            sig(root([lendOffer2]), lenderSK),
+            root([lendOffer2]),
+            proof([lendOffer2]),
             address(0),
             hex""
         );
@@ -336,9 +416,9 @@ contract TakeTest is BaseTest {
             0,
             borrower,
             lendOffer2,
-            sig(lendOffer2, lenderSK),
-            root(lendOffer2),
-            proof(lendOffer2),
+            sig(root([lendOffer2]), lenderSK),
+            root([lendOffer2]),
+            proof([lendOffer2]),
             address(0),
             hex""
         );
@@ -358,9 +438,9 @@ contract TakeTest is BaseTest {
             0,
             lender,
             borrowOffer,
-            sig(borrowOffer, otherBorrowerSK),
-            root(borrowOffer),
-            proof(borrowOffer),
+            sig(root([borrowOffer]), otherBorrowerSK),
+            root([borrowOffer]),
+            proof([borrowOffer]),
             address(0),
             hex""
         );
@@ -379,9 +459,9 @@ contract TakeTest is BaseTest {
             0,
             otherBorrower,
             lendOffer,
-            sig(lendOffer, lenderSK),
-            root(lendOffer),
-            proof(lendOffer),
+            sig(root([lendOffer]), lenderSK),
+            root([lendOffer]),
+            proof([lendOffer]),
             callbackAddress,
             abi.encode(address(collateralToken1), 135)
         );
@@ -403,9 +483,9 @@ contract TakeTest is BaseTest {
             0,
             borrower,
             lendOffer,
-            sig(lendOffer, otherLenderSK),
-            root(lendOffer),
-            proof(lendOffer),
+            sig(root([lendOffer]), otherLenderSK),
+            root([lendOffer]),
+            proof([lendOffer]),
             address(0),
             hex""
         );
@@ -424,9 +504,9 @@ contract TakeTest is BaseTest {
             0,
             otherLender,
             borrowOffer,
-            sig(borrowOffer, borrowerSK),
-            root(borrowOffer),
-            proof(borrowOffer),
+            sig(root([borrowOffer]), borrowerSK),
+            root([borrowOffer]),
+            proof([borrowOffer]),
             callbackAddress,
             abi.encode(address(loanToken), 100)
         );
@@ -436,7 +516,15 @@ contract TakeTest is BaseTest {
     function testTakeConsistentPrices() public {
         lendOffer.expiry = lendOffer.start;
         morphoV2.take(
-            100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+            100,
+            0,
+            borrower,
+            lendOffer,
+            sig(root([lendOffer]), lenderSK),
+            root([lendOffer]),
+            proof([lendOffer]),
+            address(0),
+            hex""
         );
 
         assertEq(morphoV2.sharesOf(lender, id), 101, "lender bond shares");
@@ -446,7 +534,15 @@ contract TakeTest is BaseTest {
         vm.warp(block.timestamp + 101);
         vm.expectRevert("maturity");
         morphoV2.take(
-            100, 0, lender, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+            100,
+            0,
+            lender,
+            lendOffer,
+            sig(root([lendOffer]), lenderSK),
+            root([lendOffer]),
+            proof([lendOffer]),
+            address(0),
+            hex""
         );
     }
 
@@ -458,9 +554,9 @@ contract TakeTest is BaseTest {
             0,
             lender,
             borrowOffer,
-            sig(borrowOffer, borrowerSK),
-            root(borrowOffer),
-            proof(borrowOffer),
+            sig(root([borrowOffer]), borrowerSK),
+            root([borrowOffer]),
+            proof([borrowOffer]),
             address(0),
             hex""
         );
@@ -470,22 +566,38 @@ contract TakeTest is BaseTest {
         morphoV2.withdrawCollateral(obligation, address(collateralToken1), 1, borrower);
         vm.expectRevert("Seller is unhealthy");
         morphoV2.take(
-            100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+            100,
+            0,
+            borrower,
+            lendOffer,
+            sig(root([lendOffer]), lenderSK),
+            root([lendOffer]),
+            proof([lendOffer]),
+            address(0),
+            hex""
         );
     }
 
-    function testTakeWrongSignature(Offer memory _offer) public {
-        vm.assume(keccak256(abi.encode(_offer)) != keccak256(abi.encode(lendOffer)));
+    function testTakeWrongSignature(bytes32 wrongRoot) public {
+        vm.assume(wrongRoot != root([lendOffer]));
         vm.expectRevert("invalid signature");
         morphoV2.take(
-            100, 0, borrower, lendOffer, sig(_offer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+            100,
+            0,
+            borrower,
+            lendOffer,
+            sig(wrongRoot, lenderSK),
+            root([lendOffer]),
+            proof([lendOffer]),
+            address(0),
+            hex""
         );
     }
 
     function testTakeInvalidSignature() public {
         vm.expectRevert("invalid signature");
         morphoV2.take(
-            100, 0, borrower, lendOffer, Signature(0, 0, 0), root(lendOffer), proof(lendOffer), address(0), hex""
+            100, 0, borrower, lendOffer, Signature(0, 0, 0), root([lendOffer]), proof([lendOffer]), address(0), hex""
         );
     }
 
@@ -494,7 +606,54 @@ contract TakeTest is BaseTest {
         lendOffer.expiry = lendOffer.start;
         vm.expectRevert("inconsistent prices");
         morphoV2.take(
-            100, 0, borrower, lendOffer, sig(lendOffer, lenderSK), root(lendOffer), proof(lendOffer), address(0), hex""
+            100,
+            0,
+            borrower,
+            lendOffer,
+            sig(root([lendOffer]), lenderSK),
+            root([lendOffer]),
+            proof([lendOffer]),
+            address(0),
+            hex""
+        );
+    }
+
+    function testTakeInvalidProofOneLeaf(bytes32[] memory proof) public {
+        vm.assume(proof.length >= 1);
+        vm.expectRevert("invalid proof");
+        morphoV2.take(
+            100, 0, borrower, lendOffer, sig(root([lendOffer]), lenderSK), root([lendOffer]), proof, address(0), hex""
+        );
+    }
+
+    function testTakeInvalidProofTwoLeaves(Offer memory otherOffer, bytes32[] memory proof) public {
+        vm.assume(proof.length >= 1);
+        vm.assume(proof[0] != keccak256(abi.encode(otherOffer)));
+        vm.expectRevert("invalid proof");
+        morphoV2.take(
+            100,
+            0,
+            borrower,
+            lendOffer,
+            sig(root([lendOffer, otherOffer]), lenderSK),
+            root([lendOffer, otherOffer]),
+            proof,
+            address(0),
+            hex""
+        );
+    }
+
+    function testTakeTwoLeaves(Offer memory otherOffer) public {
+        morphoV2.take(
+            100,
+            0,
+            borrower,
+            lendOffer,
+            sig(root([lendOffer, otherOffer]), lenderSK),
+            root([lendOffer, otherOffer]),
+            proof([lendOffer, otherOffer]),
+            address(0),
+            hex""
         );
     }
 }


### PR DESCRIPTION
The current offer structure is not fully satisfying for these reasons:
- there is an overlap between them and OCO. And in particular OCO can do everything the offers can do.
- forcing a lender to be ok with any subset of collateral / a borrower to be ok with any superset (same for LLTV etc.) can be detrimental.
- we need things such as #45 for the secondary.

So we switch to "OCO only". To avoid the maker to make a lot of signatures, we allow to sign a merkle root. The mempool will use some form of compression to avoid the maker to publish a ton of data.