### PR TITLE
feat: ratification callback

### DIFF
--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -249,7 +249,6 @@ contract MorphoV2 is IMorphoV2 {
         return _ratified[abi.encode(offer)];
     }
 
-    /// @dev No ratification by callback, use multicall.
     /// @dev No ratification by signature, check the signature in the caller.
     function setRatified(Offer memory offer, bool newRatified) external {
         require(msg.sender == offer.maker || authorized[offer.maker][msg.sender], "ratification not authorized");

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -66,6 +66,7 @@ contract MorphoV2 is IMorphoV2 {
         require(msg.sender == taker || authorized[taker][msg.sender], "order not authorized");
         require(
             msg.sender == offer.maker
+            || (offer.ratifier != address(0) && authorized[offer.maker][offer.ratifier] && ICallbacks(offer.ratifier).onRatify(obligation,offer,sig))
                 || (sig.v != 0 && _signatureIsValid(abi.encode(OFFER_TYPEHASH, offer), sig, offer.maker))
                 || authorized[offer.maker][msg.sender] || _ratified[abi.encode(offer)],
             "offer not ratified"

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -66,8 +66,10 @@ contract MorphoV2 is IMorphoV2 {
         require(msg.sender == taker || authorized[taker][msg.sender], "order not authorized");
         require(
             msg.sender == offer.maker
-            || (offer.ratifier != address(0) && authorized[offer.maker][offer.ratifier] && ICallbacks(offer.ratifier).onRatify(obligation,offer,sig))
-                || (sig.v != 0 && _signatureIsValid(abi.encode(OFFER_TYPEHASH, offer), sig, offer.maker))
+                || (
+                    offer.ratifier != address(0) && authorized[offer.maker][offer.ratifier]
+                        && ICallbacks(offer.ratifier).onRatify(obligation, offer, sig)
+                ) || (sig.v != 0 && _signatureIsValid(abi.encode(OFFER_TYPEHASH, offer), sig, offer.maker))
                 || authorized[offer.maker][msg.sender] || _ratified[abi.encode(offer)],
             "offer not ratified"
         );

--- a/src/interfaces/ICallbacks.sol
+++ b/src/interfaces/ICallbacks.sol
@@ -2,9 +2,10 @@
 // Copyright (c) 2025 Morpho Association
 pragma solidity 0.8.28;
 
-import {Seizure, Obligation} from "./IMorphoV2.sol";
+import {Seizure, Obligation, Offer, Signature} from "./IMorphoV2.sol";
 
 interface ICallbacks {
     function onTake(Obligation memory obligation, address borrower, uint256 assets, bytes memory data) external;
     function onLiquidate(Seizure[] memory seizures, address borrower, address liquidator, bytes memory data) external;
+    function onRatify(Obligation memory obligation, Offer memory offer, Signature memory sig) external returns (bool);
 }

--- a/src/interfaces/IMorphoV2.sol
+++ b/src/interfaces/IMorphoV2.sol
@@ -29,6 +29,8 @@ struct Offer {
     uint256 nonce;
     address callbackAddress;
     bytes callbackData;
+    address ratifier;
+    bytes ratifierData;
 }
 
 struct Signature {

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -106,7 +106,9 @@ abstract contract BaseTest is Test {
             expiryPrice: 1 ether,
             nonce: 0,
             callbackAddress: address(0),
-            callbackData: ""
+            callbackData: "",
+            ratifier: address(0),
+            ratifierData: ""
         });
 
         morphoV2.take(
@@ -147,7 +149,9 @@ abstract contract BaseTest is Test {
             expiryPrice: 1e18,
             nonce: 0,
             callbackAddress: address(0),
-            callbackData: ""
+            callbackData: "",
+            ratifier: address(0),
+            ratifierData: ""
         });
 
         morphoV2.take(

--- a/test/LiquidationGasTest.sol
+++ b/test/LiquidationGasTest.sol
@@ -60,7 +60,9 @@ contract LiquidationTest is BaseTest {
             maturity: block.timestamp + 100,
             nonce: 0,
             callbackAddress: address(0),
-            callbackData: ""
+            callbackData: "",
+            ratifier: address(0),
+            ratifierData: ""
         });
 
         morphoV2.take(obligation, 0, maxDebt, lender, borrowOffer, sig(borrowOffer, borrowerSK), address(0), hex"");

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -420,7 +420,7 @@ contract TakeTest is BaseTest {
         morphoV2.take(obligation, 0, 0, taker, lendOffer, sig(lendOffer, lenderSK), address(0), hex"");
     }
 
-    function testOfferAuthorization(uint256 makerSK, address sender, uint256 otherSK) public {
+    function testOfferAuthorization(uint256 makerSK, address sender, uint256 otherSK, bytes32 data) public {
         makerSK = boundPrivateKey(makerSK);
         otherSK = boundPrivateKey(otherSK);
         vm.assume(otherSK != makerSK);
@@ -451,12 +451,25 @@ contract TakeTest is BaseTest {
         vm.prank(sender);
         morphoV2.take(obligation, 0, 0, sender, lendOffer, sig(lendOffer, otherSK), address(0), hex"");
 
-        vm.revertToStateAndDelete(snap);
+        vm.revertToState(snap);
 
         vm.prank(maker);
         morphoV2.setRatified(lendOffer, true);
         vm.prank(sender);
         morphoV2.take(obligation, 0, 0, sender, lendOffer, sig(lendOffer, otherSK), address(0), hex"");
+
+        vm.revertToStateAndDelete(snap);
+
+        RatifyCallback ratifier = new RatifyCallback();
+        lendOffer.ratifier = address(ratifier);
+        lendOffer.ratifierData = bytes.concat(data);
+
+        vm.prank(maker);
+        morphoV2.setAuthorized(address(ratifier), true);
+        vm.prank(sender);
+        morphoV2.take(obligation, 0, 0, sender, lendOffer, sig(lendOffer, otherSK), address(ratifier), hex"");
+        assertEq(bytes32(ratifier.recordedData()), data);
+
     }
 }
 
@@ -471,6 +484,7 @@ contract BorrowCallback is ICallbacks {
     }
 
     function onLiquidate(Seizure[] memory seizures, address borrower, address liquidator, bytes memory data) external {}
+    function onRatify(Obligation memory obligation, Offer memory offer, Signature memory sig) external returns (bool) {}
 }
 
 contract LendCallback is ICallbacks {
@@ -482,4 +496,18 @@ contract LendCallback is ICallbacks {
     }
 
     function onLiquidate(Seizure[] memory seizures, address borrower, address liquidator, bytes memory data) external {}
+    function onRatify(Obligation memory obligation, Offer memory offer, Signature memory sig) external returns (bool) {}
+}
+
+contract RatifyCallback is ICallbacks {
+    bytes public recordedData;
+
+    function onTake(Obligation memory obligation, address maker, uint256 assets, bytes memory data) external {}
+    function onLiquidate(Seizure[] memory seizures, address borrower, address liquidator, bytes memory data) external {}
+
+    function onRatify(Obligation memory, Offer memory offer, Signature memory) external returns (bool) {
+        recordedData = offer.ratifierData;
+        return true;
+
+    }
 }

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -469,7 +469,6 @@ contract TakeTest is BaseTest {
         vm.prank(sender);
         morphoV2.take(obligation, 0, 0, sender, lendOffer, sig(lendOffer, otherSK), address(ratifier), hex"");
         assertEq(bytes32(ratifier.recordedData()), data);
-
     }
 }
 
@@ -508,6 +507,5 @@ contract RatifyCallback is ICallbacks {
     function onRatify(Obligation memory, Offer memory offer, Signature memory) external returns (bool) {
         recordedData = offer.ratifierData;
         return true;
-
     }
 }


### PR DESCRIPTION
Add a ratification callback to #138.

If callback addresses need to be whitelisted by the router, ratifier addresses will need to be whitelisted as well. 

In #138 , the router has to (somehow) know that there is a whitelisted ratifier contract authorized by the offer. The taker also has to (somehow) know about this ratifier, and then the taker must do this multicall:
1. Call `ratifier.<someMethod>` to get the offer ratified.
2. Call `morpoV2.take`.

In this PR the router can check if `offer.ratifier` is whitelisted, and the taker can just call `take`. It also costs less gas (you don't write to the `_ratified` mapping).

(Why not merge the callback hook with the ratification hook? You would need to whitelist any combination of `(callback,ratifier)` and create a single contract that does the combination of both.)

