### PR TITLE
feat: consume nonce

### DIFF
--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -297,6 +297,10 @@ contract MorphoV2 is IMorphoV2 {
         return seizures;
     }
 
+    function consumeNonce(uint256 nonce, uint256 amount) external {
+        consumed[msg.sender][nonce] += amount;
+    }
+
     /// INTERNAL ///
 
     function _id(Obligation memory obligation) internal pure returns (bytes32) {

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -153,4 +153,10 @@ contract OtherFunctionsTest is BaseTest {
         assertEq(loanToken.balanceOf(address(morphoV2)), 0, "balance of morphoV2");
         assertEq(loanToken.balanceOf(lender), shares, "balance of lender");
     }
+
+    function testConsumeNonce(address user, uint256 nonce, uint256 amount) public {
+        vm.prank(user);
+        morphoV2.consumeNonce(nonce, amount);
+        assertEq(morphoV2.consumed(user, nonce), amount, "consumed");
+    }
 }


### PR DESCRIPTION
avoids having to craft an offer and consume it to cancel a nonce