### PR TITLE
fix: remove warning on --deny-warnings syntax deprecation

### DIFF
--- a/.github/workflows/forge.yml
+++ b/.github/workflows/forge.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Check formatting
         run: forge fmt --check
       - name: Run Forge tests
-        run: forge test --deny-warnings
+        run: forge test --deny warnings


### PR DESCRIPTION
Avoids

```
Warning: `--deny-warnings` is being deprecated in favor of `--deny warnings`.
```
