### PR TITLE
feat: post-maturity liq (merged)

### DIFF
--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -229,8 +229,9 @@ contract MorphoV2 is IMorphoV2 {
         SafeTransferLib.safeTransfer(collateral, msg.sender, assets);
     }
 
-    /// @notice Execute the given collection of `seizures` on the given `obligation` of the given `borrower`.
     /// @dev On each seizure at least one of `repaid` or `seized` should be equal to zero.
+    /// @dev Accounts are liquidatable if they are unhealthy or of the maturity is reached.
+    /// @dev If an account is healthy, the LIF grows linearly from 1 at maturity to MAX_LIF at maturity + 15 minutes.
     /// @param obligation The obligation.
     /// @param seizures An array of amounts of debt to repay or assets to seize with the index of the collateral in the
     /// obligation's collateral assets.

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -249,7 +249,8 @@ contract MorphoV2 is IMorphoV2 {
 
     /// @dev On each seizure at least one of `repaid` or `seized` should be equal to zero.
     /// @dev Accounts are liquidatable if they are unhealthy or if the maturity is reached.
-    /// @dev If an account is healthy, the LIF grows linearly from 1 at maturity to MAX_LIF at maturity + AUCTION_DURATION.
+    /// @dev If an account is healthy, the LIF grows linearly from 1 at maturity to MAX_LIF at maturity +
+    /// AUCTION_DURATION.
     /// @param obligation The obligation.
     /// @param seizures An array of amounts of debt to repay or assets to seize with the index of the collateral in the
     /// obligation's collateral assets.

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -248,8 +248,8 @@ contract MorphoV2 is IMorphoV2 {
     }
 
     /// @dev On each seizure at least one of `repaid` or `seized` should be equal to zero.
-    /// @dev Accounts are liquidatable if they are unhealthy or of the maturity is reached.
-    /// @dev If an account is healthy, the LIF grows linearly from 1 at maturity to MAX_LIF at maturity + 15 minutes.
+    /// @dev Accounts are liquidatable if they are unhealthy or if the maturity is reached.
+    /// @dev If an account is healthy, the LIF grows linearly from 1 at maturity to MAX_LIF at maturity + AUCTION_DURATION.
     /// @param obligation The obligation.
     /// @param seizures An array of amounts of debt to repay or assets to seize with the index of the collateral in the
     /// obligation's collateral assets.

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 
 import {UtilsLib} from "./libraries/UtilsLib.sol";
 import {SafeTransferLib} from "./libraries/SafeTransferLib.sol";
-import {WAD, ORACLE_PRICE_SCALE, MAX_LIF, DUTCH_SPEED} from "./libraries/ConstantsLib.sol";
+import {WAD, ORACLE_PRICE_SCALE, MAX_LIF, AUCTION_DURATION} from "./libraries/ConstantsLib.sol";
 import {MathLib} from "./libraries/MathLib.sol";
 import {IOracle} from "./interfaces/IOracle.sol";
 import {IMorphoV2, Obligation, Offer, Signature, Seizure} from "./interfaces/IMorphoV2.sol";
@@ -230,7 +230,7 @@ contract MorphoV2 is IMorphoV2 {
     }
 
     /// @notice Execute the given collection of `seizures` on the given `obligation` of the given `borrower`.
-    /// @dev On each seizure either `repaid` or `seized` should be equal to zero.
+    /// @dev On each seizure at least one of `repaid` or `seized` should be equal to zero.
     /// @param obligation The obligation.
     /// @param seizures An array of amounts of debt to repay or assets to seize with the index of the collateral in the
     /// obligation's collateral assets.
@@ -259,7 +259,7 @@ contract MorphoV2 is IMorphoV2 {
 
         uint256 lif = originalDebt > maxDebt
             ? MAX_LIF
-            : UtilsLib.min(MAX_LIF, WAD + DUTCH_SPEED * (block.timestamp - obligation.maturity));
+            : UtilsLib.min(MAX_LIF, WAD + (MAX_LIF - WAD) * (block.timestamp - obligation.maturity) / AUCTION_DURATION);
 
         uint256 badDebt = originalDebt.zeroFloorSub(repayableDebt);
         if (badDebt > 0) {

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -259,7 +259,7 @@ contract MorphoV2 is IMorphoV2 {
 
         uint256 lif = originalDebt > maxDebt
             ? MAX_LIF
-            : UtilsLib.min(MAX_LIF, DUTCH_SPEED * (block.timestamp - obligation.maturity));
+            : UtilsLib.min(MAX_LIF, WAD + DUTCH_SPEED * (block.timestamp - obligation.maturity));
 
         uint256 badDebt = originalDebt.zeroFloorSub(repayableDebt);
         if (badDebt > 0) {

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 
 import {UtilsLib} from "./libraries/UtilsLib.sol";
 import {SafeTransferLib} from "./libraries/SafeTransferLib.sol";
-import {WAD, ORACLE_PRICE_SCALE, LIQUIDATION_INCENTIVE_FACTOR} from "./libraries/ConstantsLib.sol";
+import {WAD, ORACLE_PRICE_SCALE, MAX_LIF, DUTCH_SPEED} from "./libraries/ConstantsLib.sol";
 import {MathLib} from "./libraries/MathLib.sol";
 import {IOracle} from "./interfaces/IOracle.sol";
 import {IMorphoV2, Obligation, Offer, Signature, Seizure} from "./interfaces/IMorphoV2.sol";
@@ -250,13 +250,16 @@ contract MorphoV2 is IMorphoV2 {
             prices[i] = IOracle(obligation.collaterals[i].oracle).price();
             uint256 collateralAmount = collateralOf[borrower][id][obligation.collaterals[i].token];
             maxDebt += collateralAmount.mulDivDown(prices[i], ORACLE_PRICE_SCALE)
-                .mulDivDown(obligation.collaterals[i].lltv, 1e18);
-            repayableDebt += collateralAmount.mulDivUp(1e18, LIQUIDATION_INCENTIVE_FACTOR)
-                .mulDivUp(prices[i], ORACLE_PRICE_SCALE);
+                .mulDivDown(obligation.collaterals[i].lltv, WAD);
+            repayableDebt += collateralAmount.mulDivUp(WAD, MAX_LIF).mulDivUp(prices[i], ORACLE_PRICE_SCALE);
         }
 
         uint256 originalDebt = debtOf[borrower][id];
-        require(originalDebt > maxDebt, "position is healthy");
+        require(block.timestamp > obligation.maturity || originalDebt > maxDebt, "position is not liquidatable");
+
+        uint256 lif = originalDebt > maxDebt
+            ? MAX_LIF
+            : UtilsLib.min(MAX_LIF, DUTCH_SPEED * (block.timestamp - obligation.maturity));
 
         uint256 badDebt = originalDebt.zeroFloorSub(repayableDebt);
         if (badDebt > 0) {
@@ -271,11 +274,11 @@ contract MorphoV2 is IMorphoV2 {
             require(UtilsLib.atMostOneNonZero(seizure.repaid, seizure.seized), "INCONSISTENT_INPUT");
 
             if (seizure.seized > 0) {
-                seizure.repaid = seizure.seized.mulDivUp(1e18, LIQUIDATION_INCENTIVE_FACTOR)
-                    .mulDivUp(prices[seizure.collateralIndex], ORACLE_PRICE_SCALE);
+                seizure.repaid =
+                    seizure.seized.mulDivUp(WAD, lif).mulDivUp(prices[seizure.collateralIndex], ORACLE_PRICE_SCALE);
             } else {
-                seizure.seized = seizure.repaid.mulDivDown(ORACLE_PRICE_SCALE, prices[seizure.collateralIndex])
-                    .mulDivDown(LIQUIDATION_INCENTIVE_FACTOR, 1e18);
+                seizure.seized =
+                    seizure.repaid.mulDivDown(ORACLE_PRICE_SCALE, prices[seizure.collateralIndex]).mulDivDown(lif, WAD);
             }
 
             totalRepaid += seizure.repaid;
@@ -335,7 +338,7 @@ contract MorphoV2 is IMorphoV2 {
                 require(currentCollateralToken > previousCollateralToken, "collaterals not sorted");
                 uint256 price = IOracle(obligation.collaterals[i].oracle).price();
                 maxDebt += collateralOf[borrower][id][currentCollateralToken].mulDivDown(price, ORACLE_PRICE_SCALE)
-                    .mulDivDown(obligation.collaterals[i].lltv, 1e18);
+                    .mulDivDown(obligation.collaterals[i].lltv, WAD);
                 previousCollateralToken = currentCollateralToken;
             }
 

--- a/src/libraries/ConstantsLib.sol
+++ b/src/libraries/ConstantsLib.sol
@@ -5,4 +5,4 @@ pragma solidity ^0.8.0;
 uint256 constant WAD = 1e18;
 uint256 constant ORACLE_PRICE_SCALE = 1e36;
 uint256 constant MAX_LIF = 1.15e18;
-uint256 constant DUTCH_SPEED = MAX_LIF / 15 minutes;
+uint256 constant DUTCH_SPEED = (MAX_LIF - WAD) / 15 minutes;

--- a/src/libraries/ConstantsLib.sol
+++ b/src/libraries/ConstantsLib.sol
@@ -4,5 +4,5 @@ pragma solidity ^0.8.0;
 
 uint256 constant WAD = 1e18;
 uint256 constant ORACLE_PRICE_SCALE = 1e36;
-uint256 constant MAX_LIF = 1.15e18;
-uint256 constant DUTCH_SPEED = (MAX_LIF - WAD) / 15 minutes;
+uint256 constant MAX_LIF = 1.15e18; // Liquidation Incentive Factor
+uint256 constant AUCTION_DURATION = 15 minutes;

--- a/src/libraries/ConstantsLib.sol
+++ b/src/libraries/ConstantsLib.sol
@@ -4,4 +4,5 @@ pragma solidity ^0.8.0;
 
 uint256 constant WAD = 1e18;
 uint256 constant ORACLE_PRICE_SCALE = 1e36;
-uint256 constant LIQUIDATION_INCENTIVE_FACTOR = 1.15e18;
+uint256 constant MAX_LIF = 1.15e18;
+uint256 constant DUTCH_SPEED = MAX_LIF / 15 minutes;

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -2,7 +2,7 @@
 // Copyright (c) 2025 Morpho Association
 pragma solidity ^0.8.0;
 
-import {MAX_LIF, DUTCH_SPEED} from "../src/libraries/ConstantsLib.sol";
+import {MAX_LIF, AUCTION_DURATION} from "../src/libraries/ConstantsLib.sol";
 import {Obligation, Collateral, Seizure} from "../src/interfaces/IMorphoV2.sol";
 
 import {Oracle} from "./helpers/Oracle.sol";
@@ -181,7 +181,7 @@ contract LiquidationTest is BaseTest {
         delay = bound(delay, 0, 100 weeks);
 
         setupObligation(obligation, 100);
-        vm.warp(obligation.maturity + 15 minutes + 1 + delay); // + 1 because of the rounding. We could get rid of it.
+        vm.warp(obligation.maturity + 15 minutes + delay);
         deal(address(loanToken), address(this), 100);
         uint256 initialCollateral = morphoV2.collateralOf(borrower, id, obligation.collaterals[0].token);
 
@@ -197,11 +197,11 @@ contract LiquidationTest is BaseTest {
         );
     }
 
-    function testLiquidatePostMaturityPartialLIF(uint256 time) public {
-        time = bound(time, 1, 15 minutes + 1);
+    function testLiquidatePostMaturityPartialLIF(uint256 delay) public {
+        delay = bound(delay, 1, 15 minutes);
 
         setupObligation(obligation, 100);
-        vm.warp(obligation.maturity + time);
+        vm.warp(obligation.maturity + delay);
         deal(address(loanToken), address(this), 100);
         uint256 initialCollateral = morphoV2.collateralOf(borrower, id, obligation.collaterals[0].token);
 
@@ -209,7 +209,7 @@ contract LiquidationTest is BaseTest {
         seizures[0] = Seizure({collateralIndex: 0, repaid: 100, seized: 0});
         morphoV2.liquidate(obligation, seizures, borrower, "");
 
-        uint256 lif = 1e18 + DUTCH_SPEED * time;
+        uint256 lif = 1e18 + (MAX_LIF - 1e18) * delay / AUCTION_DURATION;
 
         assertEq(morphoV2.debtOf(borrower, id), 0, "debt");
         assertEq(

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -2,11 +2,13 @@
 // Copyright (c) 2025 Morpho Association
 pragma solidity ^0.8.0;
 
-import {MAX_LIF} from "../src/libraries/ConstantsLib.sol";
+import {MAX_LIF, DUTCH_SPEED} from "../src/libraries/ConstantsLib.sol";
 import {Obligation, Collateral, Seizure} from "../src/interfaces/IMorphoV2.sol";
 
 import {Oracle} from "./helpers/Oracle.sol";
 import {BaseTest} from "./BaseTest.sol";
+
+import "forge-std/console.sol";
 
 contract LiquidationTest is BaseTest {
     Obligation internal obligation;
@@ -32,10 +34,32 @@ contract LiquidationTest is BaseTest {
         id = toId(obligation);
     }
 
-    function testLiquidateHealthy() public {
+    function testLiquidateHealthyPreMaturity() public {
         setupObligation(obligation, 100);
 
         vm.expectRevert("position is not liquidatable");
+        morphoV2.liquidate(obligation, new Seizure[](0), borrower, "");
+    }
+
+    function testLiquidateUnhealthyPreMaturity() public {
+        setupObligation(obligation, 100);
+        oracle.setPrice(0);
+
+        morphoV2.liquidate(obligation, new Seizure[](0), borrower, "");
+    }
+
+    function testLiquidateHealthyPostMaturity() public {
+        setupObligation(obligation, 100);
+        obligation.maturity = block.timestamp - 1;
+
+        morphoV2.liquidate(obligation, new Seizure[](0), borrower, "");
+    }
+
+    function testLiquidateUnhealthyPostMaturity() public {
+        setupObligation(obligation, 100);
+        obligation.maturity = block.timestamp - 1;
+        oracle.setPrice(0);
+
         morphoV2.liquidate(obligation, new Seizure[](0), borrower, "");
     }
 
@@ -149,5 +173,49 @@ contract LiquidationTest is BaseTest {
         recordedBorrower = borrower;
         recordedLiquidator = liquidator;
         recordedData = data;
+    }
+
+    // post maturity liquidation
+
+    function testLiquidatePostMaturityFullLIF(uint256 delay) public {
+        delay = bound(delay, 0, 100 weeks);
+
+        setupObligation(obligation, 100);
+        vm.warp(obligation.maturity + 15 minutes + 1 + delay); // + 1 because of the rounding. We could get rid of it.
+        deal(address(loanToken), address(this), 100);
+        uint256 initialCollateral = morphoV2.collateralOf(borrower, id, obligation.collaterals[0].token);
+
+        Seizure[] memory seizures = new Seizure[](1);
+        seizures[0] = Seizure({collateralIndex: 0, repaid: 100, seized: 0});
+        morphoV2.liquidate(obligation, seizures, borrower, "");
+
+        assertEq(morphoV2.debtOf(borrower, id), 0, "debt");
+        assertEq(
+            morphoV2.collateralOf(borrower, id, obligation.collaterals[0].token),
+            initialCollateral - 100 * MAX_LIF / 1e18,
+            "collateral"
+        );
+    }
+
+    function testLiquidatePostMaturityPartialLIF(uint256 time) public {
+        time = bound(time, 1, 15 minutes + 1);
+
+        setupObligation(obligation, 100);
+        vm.warp(obligation.maturity + time);
+        deal(address(loanToken), address(this), 100);
+        uint256 initialCollateral = morphoV2.collateralOf(borrower, id, obligation.collaterals[0].token);
+
+        Seizure[] memory seizures = new Seizure[](1);
+        seizures[0] = Seizure({collateralIndex: 0, repaid: 100, seized: 0});
+        morphoV2.liquidate(obligation, seizures, borrower, "");
+
+        uint256 lif = 1e18 + DUTCH_SPEED * time;
+
+        assertEq(morphoV2.debtOf(borrower, id), 0, "debt");
+        assertEq(
+            morphoV2.collateralOf(borrower, id, obligation.collaterals[0].token),
+            initialCollateral - 100 * lif / 1e18,
+            "collateral"
+        );
     }
 }

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -181,7 +181,7 @@ contract LiquidationTest is BaseTest {
         delay = bound(delay, 0, 100 weeks);
 
         setupObligation(obligation, 100);
-        vm.warp(obligation.maturity + 15 minutes + delay);
+        vm.warp(obligation.maturity + AUCTION_DURATION + delay);
         deal(address(loanToken), address(this), 100);
         uint256 initialCollateral = morphoV2.collateralOf(borrower, id, obligation.collaterals[0].token);
 
@@ -198,7 +198,7 @@ contract LiquidationTest is BaseTest {
     }
 
     function testLiquidatePostMaturityPartialLIF(uint256 delay) public {
-        delay = bound(delay, 1, 15 minutes);
+        delay = bound(delay, 1, AUCTION_DURATION);
 
         setupObligation(obligation, 100);
         vm.warp(obligation.maturity + delay);

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -2,7 +2,7 @@
 // Copyright (c) 2025 Morpho Association
 pragma solidity ^0.8.0;
 
-import {LIQUIDATION_INCENTIVE_FACTOR} from "../src/libraries/ConstantsLib.sol";
+import {MAX_LIF} from "../src/libraries/ConstantsLib.sol";
 import {Obligation, Collateral, Seizure} from "../src/interfaces/IMorphoV2.sol";
 
 import {Oracle} from "./helpers/Oracle.sol";
@@ -35,7 +35,7 @@ contract LiquidationTest is BaseTest {
     function testLiquidateHealthy() public {
         setupObligation(obligation, 100);
 
-        vm.expectRevert("position is healthy");
+        vm.expectRevert("position is not liquidatable");
         morphoV2.liquidate(obligation, new Seizure[](0), borrower, "");
     }
 
@@ -129,8 +129,8 @@ contract LiquidationTest is BaseTest {
         id = toId(obligation);
 
         setupMaxObligationWithCollaterals(obligation, 100, 100);
-        uint256 price = 1e36 * 1e18 / LIQUIDATION_INCENTIVE_FACTOR * 95 / 100;
-        uint256 price2 = 1e36 * 1e18 / LIQUIDATION_INCENTIVE_FACTOR;
+        uint256 price = 1e36 * 1e18 / MAX_LIF * 95 / 100;
+        uint256 price2 = 1e36 * 1e18 / MAX_LIF;
         oracle.setPrice(price);
         oracle2.setPrice(price2);
         deal(address(loanToken), address(this), 100e18);


### PR DESCRIPTION
alternative for #79 

fixes #19

some notes:
- we use the fact that LIF<=market LIF. This allows us to compute the maxRepayableDebt always in the same way.
- the require "not liquidatable" makes it clear what can make you liquidatable
- thinking in terms of LIF instead of discount allows to basically factorize everything