### PR TITLE
Add default trading fee fallback per loan token

### DIFF
--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -75,22 +75,26 @@ contract MorphoV2 is IMorphoV2 {
         feeSetter = newFeeSetter;
     }
 
-    function setTradingFee(bytes32 id, uint128 tradingFee, uint128 interestCutLimit, bool activated) external {
+    function setTradingFee(bytes32 id, uint256 tradingFee, uint256 interestCutLimit, bool activated) external {
         require(msg.sender == feeSetter, "Only feeSetter");
         require(tradingFee <= WAD, "Trading fee too high");
         require(interestCutLimit <= WAD, "Interest cut limit too high");
-        tradingFeeParams[id] =
-            TradingFeeParams({tradingFee: tradingFee, interestCutLimit: interestCutLimit, activated: activated});
+        // Safe cast because values are below type(uint64).max.
+        tradingFeeParams[id] = TradingFeeParams({
+            tradingFee: uint64(tradingFee), interestCutLimit: uint64(interestCutLimit), activated: activated
+        });
     }
 
-    function setDefaultTradingFee(address loanToken, uint128 tradingFee, uint128 interestCutLimit, bool activated)
+    function setDefaultTradingFee(address loanToken, uint256 tradingFee, uint256 interestCutLimit, bool activated)
         external
     {
         require(msg.sender == feeSetter, "Only feeSetter");
         require(tradingFee <= WAD, "Trading fee too high");
         require(interestCutLimit <= WAD, "Interest cut limit too high");
-        defaultTradingFeeParams[loanToken] =
-            TradingFeeParams({tradingFee: tradingFee, interestCutLimit: interestCutLimit, activated: activated});
+        // Safe cast because values are below type(uint64).max.
+        defaultTradingFeeParams[loanToken] = TradingFeeParams({
+            tradingFee: uint64(tradingFee), interestCutLimit: uint64(interestCutLimit), activated: activated
+        });
     }
 
     function setTradingFeeRecipient(address recipient) external {

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -35,6 +35,7 @@ contract MorphoV2 is IMorphoV2 {
 
     /// @dev Trading fee parameters for a given obligation id.
     mapping(bytes32 id => TradingFeeParams) public tradingFeeParams;
+    mapping(address loanToken => TradingFeeParams) public defaultTradingFeeParams;
     address public tradingFeeRecipient;
 
     /// @dev Contract owner for administrative functions.
@@ -74,11 +75,31 @@ contract MorphoV2 is IMorphoV2 {
         feeSetter = newFeeSetter;
     }
 
-    function setTradingFee(bytes32 id, uint128 tradingFee, uint128 interestCutLimit) external {
+    function setTradingFee(bytes32 id, uint128 tradingFee, uint128 interestCutLimit, bool activated) external {
         require(msg.sender == feeSetter, "Only feeSetter");
         require(tradingFee <= WAD, "Trading fee too high");
         require(interestCutLimit <= WAD, "Interest cut limit too high");
-        tradingFeeParams[id] = TradingFeeParams({tradingFee: tradingFee, interestCutLimit: interestCutLimit});
+        tradingFeeParams[id] = TradingFeeParams({
+            tradingFee: tradingFee,
+            interestCutLimit: interestCutLimit,
+            activated: activated
+        });
+    }
+
+    function setDefaultTradingFee(
+        address loanToken,
+        uint128 tradingFee,
+        uint128 interestCutLimit,
+        bool activated
+    ) external {
+        require(msg.sender == feeSetter, "Only feeSetter");
+        require(tradingFee <= WAD, "Trading fee too high");
+        require(interestCutLimit <= WAD, "Interest cut limit too high");
+        defaultTradingFeeParams[loanToken] = TradingFeeParams({
+            tradingFee: tradingFee,
+            interestCutLimit: interestCutLimit,
+            activated: activated
+        });
     }
 
     function setTradingFeeRecipient(address recipient) external {
@@ -142,6 +163,13 @@ contract MorphoV2 is IMorphoV2 {
         require(offerPrice <= WAD, "price too high");
 
         TradingFeeParams memory _tradingFeeParams = tradingFeeParams[id];
+        if (!_tradingFeeParams.activated) {
+            TradingFeeParams memory _defaultTradingFeeParams =
+                defaultTradingFeeParams[offer.obligation.loanToken];
+            if (_defaultTradingFeeParams.activated) {
+                _tradingFeeParams = _defaultTradingFeeParams;
+            }
+        }
         uint256 buyerPrice = offer.buy
             ? offerPrice
             : UtilsLib.min(

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -79,22 +79,18 @@ contract MorphoV2 is IMorphoV2 {
         require(msg.sender == feeSetter, "Only feeSetter");
         require(tradingFee <= WAD, "Trading fee too high");
         require(interestCutLimit <= WAD, "Interest cut limit too high");
-        tradingFeeParams[id] = TradingFeeParams({
-            tradingFee: tradingFee,
-            interestCutLimit: interestCutLimit,
-            activated: activated
-        });
+        tradingFeeParams[id] =
+            TradingFeeParams({tradingFee: tradingFee, interestCutLimit: interestCutLimit, activated: activated});
     }
 
-    function setDefaultTradingFee(address loanToken, uint128 tradingFee, uint128 interestCutLimit, bool activated) external {
+    function setDefaultTradingFee(address loanToken, uint128 tradingFee, uint128 interestCutLimit, bool activated)
+        external
+    {
         require(msg.sender == feeSetter, "Only feeSetter");
         require(tradingFee <= WAD, "Trading fee too high");
         require(interestCutLimit <= WAD, "Interest cut limit too high");
-        defaultTradingFeeParams[loanToken] = TradingFeeParams({
-            tradingFee: tradingFee,
-            interestCutLimit: interestCutLimit,
-            activated: activated
-        });
+        defaultTradingFeeParams[loanToken] =
+            TradingFeeParams({tradingFee: tradingFee, interestCutLimit: interestCutLimit, activated: activated});
     }
 
     function setTradingFeeRecipient(address recipient) external {
@@ -160,9 +156,7 @@ contract MorphoV2 is IMorphoV2 {
         TradingFeeParams memory _tradingFeeParams = tradingFeeParams[id];
         if (!_tradingFeeParams.activated) {
             TradingFeeParams memory _defaultTradingFeeParams = defaultTradingFeeParams[offer.obligation.loanToken];
-            if (_defaultTradingFeeParams.activated) {
-                _tradingFeeParams = _defaultTradingFeeParams;
-            }
+            if (_defaultTradingFeeParams.activated) _tradingFeeParams = _defaultTradingFeeParams;
         }
         uint256 buyerPrice = offer.buy
             ? offerPrice

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -157,26 +157,36 @@ contract MorphoV2 is IMorphoV2 {
             : offer.startPrice;
         require(offerPrice <= WAD, "price too high");
 
-        TradingFeeParams memory _tradingFeeParams = tradingFeeParams[id];
-        if (!_tradingFeeParams.activated) {
-            TradingFeeParams memory _defaultTradingFeeParams = defaultTradingFeeParams[offer.obligation.loanToken];
-            if (_defaultTradingFeeParams.activated) _tradingFeeParams = _defaultTradingFeeParams;
+        uint256 interestCutLimit;
+        uint256 tradingFee;
+        TradingFeeParams memory params = tradingFeeParams[id];
+        if (params.activated) {
+            interestCutLimit = params.interestCutLimit;
+            tradingFee = params.tradingFee;
+        } else {
+            TradingFeeParams memory defaultParams = defaultTradingFeeParams[offer.obligation.loanToken];
+            if (defaultParams.activated) {
+                interestCutLimit = defaultParams.interestCutLimit;
+                tradingFee = defaultParams.tradingFee;
+            } else {
+                interestCutLimit = 0;
+                tradingFee = 0;
+            }
         }
+
         uint256 buyerPrice;
         uint256 sellerPrice;
         if (offer.buy) {
             buyerPrice = offerPrice;
             sellerPrice = UtilsLib.max(
-                (buyerPrice - _tradingFeeParams.interestCutLimit)
-                .mulDivDown(WAD, WAD - _tradingFeeParams.interestCutLimit),
-                buyerPrice.mulDivDown(WAD, WAD + _tradingFeeParams.tradingFee)
+                (buyerPrice - interestCutLimit).mulDivDown(WAD, WAD - interestCutLimit),
+                buyerPrice.mulDivDown(WAD, WAD + tradingFee)
             );
         } else {
             sellerPrice = offerPrice;
             buyerPrice = UtilsLib.min(
-                sellerPrice.mulDivDown(WAD - _tradingFeeParams.interestCutLimit, WAD)
-                    + _tradingFeeParams.interestCutLimit,
-                sellerPrice.mulDivDown(WAD + _tradingFeeParams.tradingFee, WAD)
+                sellerPrice.mulDivDown(WAD - interestCutLimit, WAD) + interestCutLimit,
+                sellerPrice.mulDivDown(WAD + tradingFee, WAD)
             );
         }
 

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -86,12 +86,7 @@ contract MorphoV2 is IMorphoV2 {
         });
     }
 
-    function setDefaultTradingFee(
-        address loanToken,
-        uint128 tradingFee,
-        uint128 interestCutLimit,
-        bool activated
-    ) external {
+    function setDefaultTradingFee(address loanToken, uint128 tradingFee, uint128 interestCutLimit, bool activated) external {
         require(msg.sender == feeSetter, "Only feeSetter");
         require(tradingFee <= WAD, "Trading fee too high");
         require(interestCutLimit <= WAD, "Interest cut limit too high");
@@ -164,8 +159,7 @@ contract MorphoV2 is IMorphoV2 {
 
         TradingFeeParams memory _tradingFeeParams = tradingFeeParams[id];
         if (!_tradingFeeParams.activated) {
-            TradingFeeParams memory _defaultTradingFeeParams =
-                defaultTradingFeeParams[offer.obligation.loanToken];
+            TradingFeeParams memory _defaultTradingFeeParams = defaultTradingFeeParams[offer.obligation.loanToken];
             if (_defaultTradingFeeParams.activated) {
                 _tradingFeeParams = _defaultTradingFeeParams;
             }

--- a/src/interfaces/IMorphoV2.sol
+++ b/src/interfaces/IMorphoV2.sol
@@ -51,6 +51,7 @@ struct Seizure {
 struct TradingFeeParams {
     uint128 tradingFee;
     uint128 interestCutLimit;
+    bool activated;
 }
 
 interface IMorphoV2 {}

--- a/src/interfaces/IMorphoV2.sol
+++ b/src/interfaces/IMorphoV2.sol
@@ -49,8 +49,8 @@ struct Seizure {
 }
 
 struct TradingFeeParams {
-    uint128 tradingFee;
-    uint128 interestCutLimit;
+    uint64 tradingFee;
+    uint64 interestCutLimit;
     bool activated;
 }
 

--- a/test/SettersTest.sol
+++ b/test/SettersTest.sol
@@ -62,11 +62,7 @@ contract SettersTest is BaseTest {
         morphoV2.setTradingFee(id, tradingFee, 0.1e18, true);
     }
 
-    function testSetDefaultTradingFeeSuccess(
-        address loanToken,
-        uint128 tradingFee,
-        uint128 interestCutLimit
-    ) public {
+    function testSetDefaultTradingFeeSuccess(address loanToken, uint128 tradingFee, uint128 interestCutLimit) public {
         vm.assume(tradingFee <= 1e18);
         vm.assume(interestCutLimit <= 1e18);
         morphoV2.setDefaultTradingFee(loanToken, tradingFee, interestCutLimit, true);

--- a/test/SettersTest.sol
+++ b/test/SettersTest.sol
@@ -36,29 +36,64 @@ contract SettersTest is BaseTest {
     function testSetTradingFeeSuccess(bytes32 id, uint128 tradingFee, uint128 interestCutLimit) public {
         vm.assume(tradingFee <= 1e18);
         vm.assume(interestCutLimit <= 1e18);
-        morphoV2.setTradingFee(id, tradingFee, interestCutLimit);
-        (uint128 _tradingFee, uint128 _interestCutLimit) = morphoV2.tradingFeeParams(id);
+        morphoV2.setTradingFee(id, tradingFee, interestCutLimit, true);
+        (uint128 _tradingFee, uint128 _interestCutLimit, bool activated) = morphoV2.tradingFeeParams(id);
         assertEq(_tradingFee, tradingFee);
         assertEq(_interestCutLimit, interestCutLimit);
+        assertTrue(activated);
     }
 
     function testSetTradingFeeOnlyFeeSetter(address rdm, bytes32 id) public {
         vm.assume(rdm != address(this));
         vm.prank(rdm);
         vm.expectRevert("Only feeSetter");
-        morphoV2.setTradingFee(id, 0.1e18, 0.1e18);
+        morphoV2.setTradingFee(id, 0.1e18, 0.1e18, true);
     }
 
     function testSetInterestCutLimitTooHigh(bytes32 id, uint128 interestCutLimit) public {
         vm.assume(interestCutLimit > 1e18);
         vm.expectRevert("Interest cut limit too high");
-        morphoV2.setTradingFee(id, 0.1e18, interestCutLimit);
+        morphoV2.setTradingFee(id, 0.1e18, interestCutLimit, true);
     }
 
     function testSetTradingFeeTooHigh(bytes32 id, uint128 tradingFee) public {
         vm.assume(tradingFee > 1e18);
         vm.expectRevert("Trading fee too high");
-        morphoV2.setTradingFee(id, tradingFee, 0.1e18);
+        morphoV2.setTradingFee(id, tradingFee, 0.1e18, true);
+    }
+
+    function testSetDefaultTradingFeeSuccess(
+        address loanToken,
+        uint128 tradingFee,
+        uint128 interestCutLimit
+    ) public {
+        vm.assume(tradingFee <= 1e18);
+        vm.assume(interestCutLimit <= 1e18);
+        morphoV2.setDefaultTradingFee(loanToken, tradingFee, interestCutLimit, true);
+        (uint128 _tradingFee, uint128 _interestCutLimit, bool activated) =
+            morphoV2.defaultTradingFeeParams(loanToken);
+        assertEq(_tradingFee, tradingFee);
+        assertEq(_interestCutLimit, interestCutLimit);
+        assertTrue(activated);
+    }
+
+    function testSetDefaultTradingFeeOnlyFeeSetter(address rdm, address loanToken) public {
+        vm.assume(rdm != address(this));
+        vm.prank(rdm);
+        vm.expectRevert("Only feeSetter");
+        morphoV2.setDefaultTradingFee(loanToken, 0.1e18, 0.1e18, true);
+    }
+
+    function testSetDefaultInterestCutLimitTooHigh(address loanToken, uint128 interestCutLimit) public {
+        vm.assume(interestCutLimit > 1e18);
+        vm.expectRevert("Interest cut limit too high");
+        morphoV2.setDefaultTradingFee(loanToken, 0.1e18, interestCutLimit, true);
+    }
+
+    function testSetDefaultTradingFeeTooHigh(address loanToken, uint128 tradingFee) public {
+        vm.assume(tradingFee > 1e18);
+        vm.expectRevert("Trading fee too high");
+        morphoV2.setDefaultTradingFee(loanToken, tradingFee, 0.1e18, true);
     }
 
     function testSetTradingFeeRecipientSuccess(address recipient) public {

--- a/test/SettersTest.sol
+++ b/test/SettersTest.sol
@@ -66,8 +66,7 @@ contract SettersTest is BaseTest {
         vm.assume(tradingFee <= 1e18);
         vm.assume(interestCutLimit <= 1e18);
         morphoV2.setDefaultTradingFee(loanToken, tradingFee, interestCutLimit, true);
-        (uint128 _tradingFee, uint128 _interestCutLimit, bool activated) =
-            morphoV2.defaultTradingFeeParams(loanToken);
+        (uint128 _tradingFee, uint128 _interestCutLimit, bool activated) = morphoV2.defaultTradingFeeParams(loanToken);
         assertEq(_tradingFee, tradingFee);
         assertEq(_interestCutLimit, interestCutLimit);
         assertTrue(activated);

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -1131,15 +1131,9 @@ contract TakeTest is BaseTest {
 contract BorrowCallback is ICallbacks {
     bytes public recordedData;
 
-    function onSell(
-        Obligation memory obligation,
-        address seller,
-        uint256,
-        uint256,
-        uint256,
-        uint256,
-        bytes memory data
-    ) external {
+    function onSell(Obligation memory obligation, address seller, uint256, uint256, uint256, uint256, bytes memory data)
+        external
+    {
         recordedData = data;
         (address collateralToken, uint256 amount) = abi.decode(data, (address, uint256));
         ERC20(collateralToken).approve(msg.sender, amount);

--- a/test/TradingFeeTest.sol
+++ b/test/TradingFeeTest.sol
@@ -59,8 +59,40 @@ contract TradingFeeTest is BaseTest {
 
     // Fee proportional to interest.
 
+    function testDefaultTradingFeeUsedWhenMarketUnset() public {
+        morphoV2.setDefaultTradingFee(address(loanToken), 0.001e18, 0.05e18, true);
+        uint256 buyerAssets = 100 ether;
+
+        borrowerOffer.startPrice = 0.9 ether;
+        borrowerOffer.expiryPrice = 0.9 ether;
+
+        uint256 expectedSellerAssets = buyerAssets.mulDivDown(1e18, 1e18 + 0.001e18);
+        uint256 expectedFee = expectedSellerAssets / 1000;
+
+        take(buyerAssets, 0, 0, 0, lender, borrowerOffer);
+
+        assertApproxEqAbs(loanToken.balanceOf(feeRecipient), expectedFee, 100, "fee recipient balance");
+    }
+
+    function testDefaultTradingFeeUsedWhenMarketDeactivated() public {
+        morphoV2.setDefaultTradingFee(address(loanToken), 0.001e18, 0.05e18, true);
+        morphoV2.setTradingFee(id, 0.5e18, 0.05e18, false);
+
+        uint256 buyerAssets = 100 ether;
+
+        borrowerOffer.startPrice = 0.9 ether;
+        borrowerOffer.expiryPrice = 0.9 ether;
+
+        uint256 expectedSellerAssets = buyerAssets.mulDivDown(1e18, 1e18 + 0.001e18);
+        uint256 expectedFee = expectedSellerAssets / 1000;
+
+        take(buyerAssets, 0, 0, 0, lender, borrowerOffer);
+
+        assertApproxEqAbs(loanToken.balanceOf(feeRecipient), expectedFee, 100, "fee recipient balance");
+    }
+
     function testBuyerAssetsLend() public {
-        morphoV2.setTradingFee(id, 1e18, 0.05e18);
+        morphoV2.setTradingFee(id, 1e18, 0.05e18, true);
         uint256 buyerAssets = 100 ether;
         uint256 price = 0.9 ether;
         uint256 fee = 0.05e18;
@@ -78,7 +110,7 @@ contract TradingFeeTest is BaseTest {
     }
 
     function testBuyerAssetsBorrow() public {
-        morphoV2.setTradingFee(id, 1e18, 0.05e18);
+        morphoV2.setTradingFee(id, 1e18, 0.05e18, true);
         uint256 buyerAssets = 100 ether;
         uint256 price = 0.9 ether;
         uint256 fee = 0.05e18;
@@ -96,7 +128,7 @@ contract TradingFeeTest is BaseTest {
     }
 
     function testSellerAssetsLend() public {
-        morphoV2.setTradingFee(id, 1e18, 0.05e18);
+        morphoV2.setTradingFee(id, 1e18, 0.05e18, true);
         uint256 sellerAssets = 90 ether;
         uint256 price = 0.9 ether;
         uint256 fee = 0.05e18;
@@ -113,7 +145,7 @@ contract TradingFeeTest is BaseTest {
     }
 
     function testSellerAssetsBorrow() public {
-        morphoV2.setTradingFee(id, 1e18, 0.05e18);
+        morphoV2.setTradingFee(id, 1e18, 0.05e18, true);
         uint256 sellerAssets = 90 ether;
         uint256 price = 0.9 ether;
         uint256 fee = 0.05e18;
@@ -131,7 +163,7 @@ contract TradingFeeTest is BaseTest {
     }
 
     function testObligationUnitsLend() public {
-        morphoV2.setTradingFee(id, 1e18, 0.05e18);
+        morphoV2.setTradingFee(id, 1e18, 0.05e18, true);
         uint256 obligationUnits = 100 ether;
         uint256 price = 0.9 ether;
         uint256 fee = 0.05e18;
@@ -148,7 +180,7 @@ contract TradingFeeTest is BaseTest {
     }
 
     function testObligationUnitsBorrow() public {
-        morphoV2.setTradingFee(id, 1e18, 0.05e18);
+        morphoV2.setTradingFee(id, 1e18, 0.05e18, true);
         uint256 obligationUnits = 100 ether;
         uint256 price = 0.9 ether;
         uint256 fee = 0.05e18;
@@ -169,7 +201,7 @@ contract TradingFeeTest is BaseTest {
     // Fee proportional to amount traded.
 
     function testBuyerAssetsLendMax() public {
-        morphoV2.setTradingFee(id, 0.001e18, 0.05e18);
+        morphoV2.setTradingFee(id, 0.001e18, 0.05e18, true);
         uint256 buyerAssets = 100 ether;
         borrowerOffer.startPrice = 0.9 ether;
         borrowerOffer.expiryPrice = 0.9 ether;
@@ -183,7 +215,7 @@ contract TradingFeeTest is BaseTest {
     }
 
     function testBuyerAssetsBorrowMax() public {
-        morphoV2.setTradingFee(id, 0.001e18, 0.05e18);
+        morphoV2.setTradingFee(id, 0.001e18, 0.05e18, true);
         uint256 buyerAssets = 100 ether;
         lenderOffer.startPrice = 0.9 ether;
         lenderOffer.expiryPrice = 0.9 ether;
@@ -197,7 +229,7 @@ contract TradingFeeTest is BaseTest {
     }
 
     function testSellerAssetsLendMax() public {
-        morphoV2.setTradingFee(id, 0.001e18, 0.05e18);
+        morphoV2.setTradingFee(id, 0.001e18, 0.05e18, true);
         uint256 sellerAssets = 100 ether;
         borrowerOffer.startPrice = 0.9 ether;
         borrowerOffer.expiryPrice = 0.9 ether;
@@ -210,7 +242,7 @@ contract TradingFeeTest is BaseTest {
     }
 
     function testSellerAssetsBorrowMax() public {
-        morphoV2.setTradingFee(id, 0.001e18, 0.05e18);
+        morphoV2.setTradingFee(id, 0.001e18, 0.05e18, true);
         uint256 sellerAssets = 90 ether;
         lenderOffer.startPrice = 0.9 ether;
         lenderOffer.expiryPrice = 0.9 ether;
@@ -223,7 +255,7 @@ contract TradingFeeTest is BaseTest {
     }
 
     function testObligationUnitsLendMax() public {
-        morphoV2.setTradingFee(id, 0.001e18, 0.05e18);
+        morphoV2.setTradingFee(id, 0.001e18, 0.05e18, true);
         uint256 obligationUnits = 100 ether;
         borrowerOffer.startPrice = 0.9 ether;
         borrowerOffer.expiryPrice = 0.9 ether;
@@ -237,7 +269,7 @@ contract TradingFeeTest is BaseTest {
     }
 
     function testObligationUnitsBorrowMax() public {
-        morphoV2.setTradingFee(id, 0.001e18, 0.05e18);
+        morphoV2.setTradingFee(id, 0.001e18, 0.05e18, true);
         uint256 obligationUnits = 100 ether;
         lenderOffer.startPrice = 0.9 ether;
         lenderOffer.expiryPrice = 0.9 ether;
@@ -252,7 +284,7 @@ contract TradingFeeTest is BaseTest {
     }
 
     function testObligationSharesLendMax() public {
-        morphoV2.setTradingFee(id, 0.001e18, 0.05e18);
+        morphoV2.setTradingFee(id, 0.001e18, 0.05e18, true);
         uint256 obligationShares = 100 ether;
         borrowerOffer.startPrice = 0.9 ether;
         borrowerOffer.expiryPrice = 0.9 ether;
@@ -266,7 +298,7 @@ contract TradingFeeTest is BaseTest {
     }
 
     function testObligationSharesBorrowMax() public {
-        morphoV2.setTradingFee(id, 0.001e18, 0.05e18);
+        morphoV2.setTradingFee(id, 0.001e18, 0.05e18, true);
         uint256 obligationShares = 100 ether;
         lenderOffer.startPrice = 0.9 ether;
         lenderOffer.expiryPrice = 0.9 ether;


### PR DESCRIPTION
- add default trading fee parameters per loan token with activation flag
- extend trading fee setter and add default setter gated by the feeSetter role
- update matching logic and tests to cover default and deactivated fee scenarios

fixes #175 

https://chatgpt.com/codex/tasks/task_b_690393fbf2dc8321b87a232426da0913