### PR TITLE
Show hashing in assembly

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,6 +3,3 @@ via_ir = true
 
 [profile.default.fmt]
 wrap_comments = true
-
-[lint]
-exclude_lints = ["asm-keccak256"]

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -388,11 +388,11 @@ contract MorphoV2 is IMorphoV2 {
     /// INTERNAL ///
 
     function _id(Obligation memory obligation) internal pure returns (bytes32) {
-        return keccak256(abi.encode(obligation));
+        return UtilsLib.hashObligation(obligation);
     }
 
     function _signer(bytes32 root, Signature memory signature) internal pure returns (address) {
-        bytes32 messageHash = keccak256(bytes.concat("\x19\x45thereum Signed Message:\n32", root));
+        bytes32 messageHash = UtilsLib.hashMessage(root);
         address tentativeSigner = ecrecover(messageHash, signature.v, signature.r, signature.s);
         require(tentativeSigner != address(0), "invalid signature");
         return tentativeSigner;

--- a/src/libraries/UtilsLib.sol
+++ b/src/libraries/UtilsLib.sol
@@ -2,6 +2,8 @@
 // Copyright (c) 2025 Morpho Association
 pragma solidity ^0.8.0;
 
+import {Obligation} from "../interfaces/IMorphoV2.sol";
+
 library UtilsLib {
     /// @dev Returns true if at most one of `x` and `y` is nonzero.
     function atMostOneNonZero(uint256 x, uint256 y) internal pure returns (bool z) {
@@ -34,6 +36,58 @@ library UtilsLib {
     function max(uint256 x, uint256 y) internal pure returns (uint256 z) {
         assembly {
             z := xor(x, mul(xor(x, y), gt(y, x)))
+        }
+    }
+
+    function hashMessage(bytes32 root) internal pure returns (bytes32 hash) {
+        assembly {
+            mstore(0x00, "\x19Ethereum Signed Message:\n32")
+            mstore(0x1c, root)
+            hash := keccak256(0x00, 0x3c)
+        }
+    }
+
+    function hashObligation(Obligation memory obligation) internal pure returns (bytes32 hash) {
+        uint256 length = 32 * 6 + 3 * 32 * obligation.collaterals.length;
+        uint256 ptr;
+        uint256 initPtr;
+        uint256 chainId = obligation.chainId;
+        address loanToken = obligation.loanToken;
+        uint256 maturity = obligation.maturity;
+        uint256 collateralLength = obligation.collaterals.length;
+        assembly {
+            ptr := mload(0x40)
+            mstore(0x40, add(ptr, length))
+            initPtr := ptr
+
+            mstore(ptr, 0x20)
+            ptr := add(ptr, 0x20)
+            mstore(ptr, chainId)
+            ptr := add(ptr, 0x20)
+            mstore(ptr, loanToken)
+            ptr := add(ptr, 0x20)
+            mstore(ptr, 0x80)
+            ptr := add(ptr, 0x20)
+            mstore(ptr, maturity)
+            ptr := add(ptr, 0x20)
+            mstore(ptr, collateralLength)
+            ptr := add(ptr, 0x20)
+        }
+        for (uint256 i = 0; i < obligation.collaterals.length; i++) {
+            address token = obligation.collaterals[i].token;
+            uint256 lltv = obligation.collaterals[i].lltv;
+            address oracle = obligation.collaterals[i].oracle;
+            assembly {
+                mstore(ptr, token)
+                ptr := add(ptr, 0x20)
+                mstore(ptr, lltv)
+                ptr := add(ptr, 0x20)
+                mstore(ptr, oracle)
+                ptr := add(ptr, 0x20)
+            }
+        }
+        assembly {
+            hash := keccak256(initPtr, length)
         }
     }
 }

--- a/test/HashTest.sol
+++ b/test/HashTest.sol
@@ -17,25 +17,6 @@ contract HashTest is BaseTest {
         collaterals[0] = Collateral({token: address(0x8), lltv: 10, oracle: address(0x9)});
         obligation.collaterals = collaterals;
 
-        bytes memory encoded = abi.encode(obligation);
-        for(uint256 i = 32; i <= encoded.length; i+=32) {
-            bytes32 value;
-            assembly {
-                value := mload(add(encoded, i))
-            }
-            console.logBytes32(value);
-        }
-        console.log("--------------------------------");
-
         assertEq(UtilsLib.hashObligation(obligation), keccak256(abi.encode(obligation)));
-        // assertEq(UtilsLib.hashObligation2(obligation), keccak256(abi.encode(obligation)));
-        uint256 length = 32 * 6 + 3 * 32 * obligation.collaterals.length;
-        for(uint256 i; i < length; i+=32) {
-            bytes32 value;
-            assembly {
-                value := mload(add(obligation, i))
-            }
-            console.logBytes32(value);
-        }
     }
 }

--- a/test/HashTest.sol
+++ b/test/HashTest.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
+pragma solidity ^0.8.0;
+
+import {BaseTest} from "./BaseTest.sol";
+import {Obligation, Collateral} from "../src/interfaces/IMorphoV2.sol";
+import {console} from "forge-std/console.sol";
+import {UtilsLib} from "../src/libraries/UtilsLib.sol";
+
+contract HashTest is BaseTest {
+    function testHashObligation() public pure {
+        Obligation memory obligation;
+        obligation.chainId = 9;
+        obligation.loanToken = address(0x7);
+        obligation.maturity = 3;
+        Collateral[] memory collaterals = new Collateral[](1);
+        collaterals[0] = Collateral({token: address(0x8), lltv: 10, oracle: address(0x9)});
+        obligation.collaterals = collaterals;
+
+        bytes memory encoded = abi.encode(obligation);
+        for(uint256 i = 32; i <= encoded.length; i+=32) {
+            bytes32 value;
+            assembly {
+                value := mload(add(encoded, i))
+            }
+            console.logBytes32(value);
+        }
+        console.log("--------------------------------");
+
+        assertEq(UtilsLib.hashObligation(obligation), keccak256(abi.encode(obligation)));
+        // assertEq(UtilsLib.hashObligation2(obligation), keccak256(abi.encode(obligation)));
+        uint256 length = 32 * 6 + 3 * 32 * obligation.collaterals.length;
+        for(uint256 i; i < length; i+=32) {
+            bytes32 value;
+            assembly {
+                value := mload(add(obligation, i))
+            }
+            console.logBytes32(value);
+        }
+    }
+}

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -4,13 +4,12 @@ pragma solidity ^0.8.0;
 
 import {Obligation, Offer, Signature, Collateral, Seizure} from "../src/interfaces/IMorphoV2.sol";
 import {MorphoV2} from "../src/MorphoV2.sol";
-import {ORACLE_PRICE_SCALE, WAD} from "../src/libraries/ConstantsLib.sol";
+import {WAD} from "../src/libraries/ConstantsLib.sol";
 import {MathLib} from "../src/libraries/MathLib.sol";
 import {ICallbacks} from "../src/interfaces/ICallbacks.sol";
 import {stdError} from "../lib/forge-std/src/StdError.sol";
 import {BaseTest} from "./BaseTest.sol";
 import {ERC20} from "./helpers/ERC20.sol";
-import {Oracle} from "./helpers/Oracle.sol";
 
 contract TakeTest is BaseTest {
     using MathLib for uint256;


### PR DESCRIPTION
Motivation was to remove lint errors.

This is very inpractical though, so this can be discarded. Feel free to close this PR.

Another idea would be to hash the memory directly. So hash the collaterals array and hash the other elements (chainId, loanToken, maturity), in memory directly. This avoids copying the memory, but it seems very ugly as well