### PR TITLE
roi to tick function (spencer problem fix)

### DIFF
--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 
 import {UtilsLib} from "./libraries/UtilsLib.sol";
 import {SafeTransferLib} from "./libraries/SafeTransferLib.sol";
-import {WAD, ORACLE_PRICE_SCALE, MAX_LIF, TIME_TO_MAX_LIF, DELTA, P_0} from "./libraries/ConstantsLib.sol";
+import {WAD, ORACLE_PRICE_SCALE, MAX_LIF, TIME_TO_MAX_LIF} from "./libraries/ConstantsLib.sol";
 import {MathLib} from "./libraries/MathLib.sol";
 import {IOracle} from "./interfaces/IOracle.sol";
 import {
@@ -18,6 +18,7 @@ import {
 } from "./interfaces/IMorphoV2.sol";
 import {ICallbacks, IFlashLoanCallback} from "./interfaces/ICallbacks.sol";
 import {EventsLib} from "./libraries/EventsLib.sol";
+import {TickLib, MIN_TICK, MAX_TICK} from "./libraries/TickLib.sol";
 
 /// OBLIGATIONS
 /// @dev Obligations' collaterals must be sorted by token address.
@@ -134,8 +135,10 @@ contract MorphoV2 is IMorphoV2 {
         require(block.timestamp <= offer.expiry, "offer expired");
         require(offer.obligation.chainId == block.chainid, "chain id mismatch");
         require(offer.start < offer.expiry || offer.expiryTick == offer.startTick, "inconsistent prices");
-        require(offer.startTick < 10_000 || offer.startTick == type(uint256).max, "start tick too high");
-        require(offer.expiryTick < 10_000 || offer.expiryTick == type(uint256).max, "expiry tick too high");
+        require(
+            MAX_TICK >= offer.startTick && offer.startTick >= offer.expiryTick && offer.expiryTick >= MIN_TICK,
+            "incorrect ticks"
+        );
         require(offer.maker != taker, "buyer and seller cannot be the same");
         require(_signer(root, sig) == offer.maker, "invalid signature");
         require(MathLib.isLeaf(root, keccak256(abi.encode(offer)), proof), "invalid proof");
@@ -153,11 +156,18 @@ contract MorphoV2 is IMorphoV2 {
             ? (offer.maker, offer.callback, offer.callbackData, taker, takerCallback, takerCallbackData)
             : (taker, takerCallback, takerCallbackData, offer.maker, offer.callback, offer.callbackData);
 
-        uint256 offerTick = offer.expiry != offer.start
-            ? offer.startTick + (offer.expiryTick - offer.startTick) * (block.timestamp - offer.start)
-                / (offer.expiry - offer.start)
-            : offer.startTick;
-        uint256 offerPrice = tickToPrice(offerTick);
+        uint256 offerPrice;
+        if (offer.startTick != offer.expiryTick && offer.expiry != offer.start) {
+            uint256 startRoi = TickLib.tickToRoi(offer.startTick);
+            uint256 expiryRoi = TickLib.tickToRoi(offer.expiryTick);
+            offerPrice = TickLib.tickToPrice(
+                TickLib.roiToTick(
+                    startRoi - (startRoi - expiryRoi) * (block.timestamp - offer.start) / (offer.expiry - offer.start)
+                )
+            );
+        } else {
+            offerPrice = TickLib.tickToPrice(offer.startTick);
+        }
 
         TradingFeeParams memory _tradingFeeParams = tradingFeeParams[id];
         uint256 buyerPrice;
@@ -445,13 +455,8 @@ contract MorphoV2 is IMorphoV2 {
 
     /// VIEW ///
 
-    function tickToPrice(uint256 tick) public pure returns (uint256) {
-        if (tick == type(uint256).max) {
-            return WAD;
-        } else {
-            return
-                WAD.mulDivDown(WAD, WAD + (WAD.mulDivDown(WAD - P_0, P_0)).mulDivDown(MathLib.wExp(DELTA * tick), WAD));
-        }
+    function tickToPrice(int256 tick) public pure returns (uint256) {
+        return TickLib.tickToPrice(tick);
     }
 
     function toId(Obligation memory obligation) public pure returns (bytes32) {
@@ -478,6 +483,8 @@ contract MorphoV2 is IMorphoV2 {
             return debt <= maxDebt;
         }
     }
+
+    /// INTERNAL ///
 
     function _signer(bytes32 root, Signature memory signature) internal pure returns (address) {
         bytes32 messageHash = keccak256(bytes.concat("\x19\x45thereum Signed Message:\n32", root));

--- a/src/interfaces/IMorphoV2.sol
+++ b/src/interfaces/IMorphoV2.sol
@@ -25,8 +25,8 @@ struct Offer {
     uint256 obligationShares;
     uint256 start;
     uint256 expiry;
-    uint256 startTick;
-    uint256 expiryTick;
+    int256 startTick;
+    int256 expiryTick;
     bytes32 group;
     bytes32 session;
     address callback;

--- a/src/libraries/ConstantsLib.sol
+++ b/src/libraries/ConstantsLib.sol
@@ -7,4 +7,3 @@ uint256 constant ORACLE_PRICE_SCALE = 1e36;
 uint256 constant MAX_LIF = 1.15e18; // Liquidation Incentive Factor
 uint256 constant TIME_TO_MAX_LIF = 15 minutes; // Time to reach MAX_LIF
 uint256 constant DELTA = 0.025e18;
-uint256 constant P_0 = 0.9999999e18;

--- a/src/libraries/TickLib.sol
+++ b/src/libraries/TickLib.sol
@@ -14,7 +14,7 @@ int256 constant X96_INT = 1 << 96;
 int256 constant LN_1_025_DELTA_X96 = 1956350323211722979786136201;
 // ln(2)x96
 int256 constant LN2_X96 = 54916777467707473351141471128;
-// (1/log2(1.025))x64
+// (1/log2(1.025))x96
 int256 constant INV_LOG2_1_025_X96 = 2224016485364590939422807110544;
 
 library TickLib {
@@ -56,60 +56,60 @@ library TickLib {
             mpow = roi << (127 - msb);
         }
 
-        int256 log2roiX96 = (int256(msb) - 96) << 96;
+        int256 log2roiX10 = (int256(msb) - 96) << 10;
 
         assembly ("memory-safe") {
             mpow := shr(127, mul(mpow, mpow))
             let highbit := shr(128, mpow)
-            log2roiX96 := or(log2roiX96, shl(95, highbit))
+            log2roiX10 := or(log2roiX10, shl(9, highbit))
             mpow := shr(highbit, mpow)
 
             mpow := shr(127, mul(mpow, mpow))
             highbit := shr(128, mpow)
-            log2roiX96 := or(log2roiX96, shl(94, highbit))
+            log2roiX10 := or(log2roiX10, shl(8, highbit))
             mpow := shr(highbit, mpow)
 
             mpow := shr(127, mul(mpow, mpow))
             highbit := shr(128, mpow)
-            log2roiX96 := or(log2roiX96, shl(93, highbit))
+            log2roiX10 := or(log2roiX10, shl(7, highbit))
             mpow := shr(highbit, mpow)
 
             mpow := shr(127, mul(mpow, mpow))
             highbit := shr(128, mpow)
-            log2roiX96 := or(log2roiX96, shl(92, highbit))
+            log2roiX10 := or(log2roiX10, shl(6, highbit))
             mpow := shr(highbit, mpow)
 
             mpow := shr(127, mul(mpow, mpow))
             highbit := shr(128, mpow)
-            log2roiX96 := or(log2roiX96, shl(91, highbit))
+            log2roiX10 := or(log2roiX10, shl(5, highbit))
             mpow := shr(highbit, mpow)
 
             mpow := shr(127, mul(mpow, mpow))
             highbit := shr(128, mpow)
-            log2roiX96 := or(log2roiX96, shl(90, highbit))
+            log2roiX10 := or(log2roiX10, shl(4, highbit))
             mpow := shr(highbit, mpow)
 
             mpow := shr(127, mul(mpow, mpow))
             highbit := shr(128, mpow)
-            log2roiX96 := or(log2roiX96, shl(89, highbit))
+            log2roiX10 := or(log2roiX10, shl(3, highbit))
             mpow := shr(highbit, mpow)
 
             mpow := shr(127, mul(mpow, mpow))
             highbit := shr(128, mpow)
-            log2roiX96 := or(log2roiX96, shl(88, highbit))
+            log2roiX10 := or(log2roiX10, shl(2, highbit))
             mpow := shr(highbit, mpow)
 
             mpow := shr(127, mul(mpow, mpow))
             highbit := shr(128, mpow)
-            log2roiX96 := or(log2roiX96, shl(87, highbit))
+            log2roiX10 := or(log2roiX10, shl(1, highbit))
             mpow := shr(highbit, mpow)
 
             mpow := shr(127, mul(mpow, mpow))
             highbit := shr(128, mpow)
-            log2roiX96 := or(log2roiX96, shl(86, highbit))
+            log2roiX10 := or(log2roiX10, highbit)
         }
 
-        return (log2roiX96 * INV_LOG2_1_025_X96 + (1 << 191)) >> 192;
+        return (log2roiX10 * INV_LOG2_1_025_X96 + (1 << 105)) >> 106;
     }
 
     function expX96(uint256 x) private pure returns (uint256) {

--- a/src/libraries/TickLib.sol
+++ b/src/libraries/TickLib.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
+pragma solidity ^0.8.0;
+
+import {WAD} from "./ConstantsLib.sol";
+
+// Min and max useful ticks
+int256 constant MIN_TICK = -1679;
+int256 constant MAX_TICK = 1679;
+// x96 unit
+uint256 constant X96 = 1 << 96;
+int256 constant X96_INT = 1 << 96;
+// ln(1.025)x96
+int256 constant LN_1_025_DELTA_X96 = 1956350323211722979786136201;
+// ln(2)x96
+int256 constant LN2_X96 = 54916777467707473351141471128;
+// (1/log2(1.025))x64
+int256 constant INV_LOG2_1_025_X96 = 2224016485364590939422807110544;
+
+library TickLib {
+    /// @dev Tick range is not checked.
+    function tickToPrice(int256 tick) internal pure returns (uint256) {
+        uint256 roiWad = WAD * tickToRoi(tick) / X96;
+        return WAD * WAD / (WAD + roiWad);
+    }
+
+    /// @dev Tick range is not checked.
+    function tickToRoi(int256 tick) internal pure returns (uint256) {
+        int256 exp = LN_1_025_DELTA_X96 * tick;
+        if (tick >= 0) {
+            return expX96(uint256(exp));
+        } else {
+            return (X96 * X96) / expX96(uint256(-exp));
+        }
+    }
+
+    function roiToTick(uint256 roi) internal pure returns (int256) {
+        if (roi == 0) return MIN_TICK;
+
+        uint256 msb;
+        assembly ("memory-safe") {
+            msb := shl(7, lt(0xffffffffffffffffffffffffffffffff, roi))
+            msb := or(msb, shl(6, lt(0xffffffffffffffff, shr(msb, roi))))
+            msb := or(msb, shl(5, lt(0xffffffff, shr(msb, roi))))
+            msb := or(msb, shl(4, lt(0xffff, shr(msb, roi))))
+            msb := or(msb, shl(3, lt(0xff, shr(msb, roi))))
+            msb := or(msb, shl(2, lt(0xf, shr(msb, roi))))
+            msb := or(msb, shl(1, lt(0x3, shr(msb, roi))))
+            msb := or(msb, lt(0x1, shr(msb, roi)))
+        }
+
+        uint256 mpow;
+        if (msb >= 128) {
+            mpow = roi >> (msb - 127);
+        } else {
+            mpow = roi << (127 - msb);
+        }
+
+        int256 log2roiX96 = (int256(msb) - 96) << 96;
+
+        assembly ("memory-safe") {
+            mpow := shr(127, mul(mpow, mpow))
+            let highbit := shr(128, mpow)
+            log2roiX96 := or(log2roiX96, shl(95, highbit))
+            mpow := shr(highbit, mpow)
+
+            mpow := shr(127, mul(mpow, mpow))
+            highbit := shr(128, mpow)
+            log2roiX96 := or(log2roiX96, shl(94, highbit))
+            mpow := shr(highbit, mpow)
+
+            mpow := shr(127, mul(mpow, mpow))
+            highbit := shr(128, mpow)
+            log2roiX96 := or(log2roiX96, shl(93, highbit))
+            mpow := shr(highbit, mpow)
+
+            mpow := shr(127, mul(mpow, mpow))
+            highbit := shr(128, mpow)
+            log2roiX96 := or(log2roiX96, shl(92, highbit))
+            mpow := shr(highbit, mpow)
+
+            mpow := shr(127, mul(mpow, mpow))
+            highbit := shr(128, mpow)
+            log2roiX96 := or(log2roiX96, shl(91, highbit))
+            mpow := shr(highbit, mpow)
+
+            mpow := shr(127, mul(mpow, mpow))
+            highbit := shr(128, mpow)
+            log2roiX96 := or(log2roiX96, shl(90, highbit))
+            mpow := shr(highbit, mpow)
+
+            mpow := shr(127, mul(mpow, mpow))
+            highbit := shr(128, mpow)
+            log2roiX96 := or(log2roiX96, shl(89, highbit))
+            mpow := shr(highbit, mpow)
+
+            mpow := shr(127, mul(mpow, mpow))
+            highbit := shr(128, mpow)
+            log2roiX96 := or(log2roiX96, shl(88, highbit))
+            mpow := shr(highbit, mpow)
+
+            mpow := shr(127, mul(mpow, mpow))
+            highbit := shr(128, mpow)
+            log2roiX96 := or(log2roiX96, shl(87, highbit))
+            mpow := shr(highbit, mpow)
+
+            mpow := shr(127, mul(mpow, mpow))
+            highbit := shr(128, mpow)
+            log2roiX96 := or(log2roiX96, shl(86, highbit))
+        }
+
+        return (log2roiX96 * INV_LOG2_1_025_X96 + (1 << 191)) >> 192;
+    }
+
+    function expX96(uint256 x) private pure returns (uint256) {
+        unchecked {
+            int256 q = (int256(x) + LN2_X96 / 2) / LN2_X96;
+            int256 r = int256(x) - q * LN2_X96;
+            int256 secondTerm = (r * r) >> 97;
+            int256 thirdTerm = (secondTerm * r / 3) >> 96;
+            int256 expR = X96_INT + r + secondTerm + thirdTerm;
+            return uint256(expR) << uint256(q);
+        }
+    }
+}

--- a/src/libraries/TickLib.sol
+++ b/src/libraries/TickLib.sol
@@ -20,17 +20,21 @@ int256 constant INV_LOG2_1_025_X96 = 2224016485364590939422807110544;
 library TickLib {
     /// @dev Tick range is not checked.
     function tickToPrice(int256 tick) internal pure returns (uint256) {
-        uint256 roiWad = WAD * tickToRoi(tick) / X96;
-        return WAD * WAD / (WAD + roiWad);
+        unchecked {
+            uint256 roiWad = WAD * tickToRoi(tick) / X96;
+            return WAD * WAD / (WAD + roiWad);
+        }
     }
 
     /// @dev Tick range is not checked.
     function tickToRoi(int256 tick) internal pure returns (uint256) {
-        int256 exp = LN_1_025_DELTA_X96 * tick;
-        if (tick >= 0) {
-            return expX96(uint256(exp));
-        } else {
-            return (X96 * X96) / expX96(uint256(-exp));
+        unchecked {
+            int256 exp = LN_1_025_DELTA_X96 * tick;
+            if (tick >= 0) {
+                return expX96(uint256(exp));
+            } else {
+                return (X96 * X96) / expX96(uint256(-exp));
+            }
         }
     }
 

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -9,8 +9,9 @@ import {MathLib} from "../src/libraries/MathLib.sol";
 import {WAD, ORACLE_PRICE_SCALE} from "../src/libraries/ConstantsLib.sol";
 import {Obligation, Offer, Signature, Collateral, Seizure} from "../src/interfaces/IMorphoV2.sol";
 import {MorphoV2} from "../src/MorphoV2.sol";
+import {MIN_TICK} from "../src/libraries/TickLib.sol";
 
-uint256 constant MAX_TEST_AMOUNT = 1e36;
+uint256 constant MAX_TEST_AMOUNT = 1e28;
 
 abstract contract BaseTest is Test {
     using MathLib for uint256;
@@ -110,8 +111,8 @@ abstract contract BaseTest is Test {
         lenderOffer.assets = units;
         lenderOffer.group = keccak256(abi.encode("non zero group"));
         lenderOffer.expiry = block.timestamp + 200;
-        lenderOffer.startTick = type(uint256).max;
-        lenderOffer.expiryTick = type(uint256).max;
+        lenderOffer.startTick = MIN_TICK;
+        lenderOffer.expiryTick = MIN_TICK;
 
         collateralize(obligation, otherBorrower, units);
         take(0, 0, units, 0, otherBorrower, lenderOffer);
@@ -131,8 +132,8 @@ abstract contract BaseTest is Test {
         badBorrowerOffer.assets = 100;
         badBorrowerOffer.start = block.timestamp;
         badBorrowerOffer.expiry = block.timestamp + 200;
-        badBorrowerOffer.startTick = type(uint256).max;
-        badBorrowerOffer.expiryTick = type(uint256).max;
+        badBorrowerOffer.startTick = MIN_TICK;
+        badBorrowerOffer.expiryTick = MIN_TICK;
 
         deal(obligation.collaterals[0].token, address(this), 135);
         morphoV2.supplyCollateral(obligation, obligation.collaterals[0].token, 135, badBorrower);
@@ -219,8 +220,8 @@ abstract contract BaseTest is Test {
         borrowerOffer.assets = obligationUnits;
         borrowerOffer.start = block.timestamp;
         borrowerOffer.expiry = block.timestamp;
-        borrowerOffer.startTick = type(uint256).max;
-        borrowerOffer.expiryTick = type(uint256).max;
+        borrowerOffer.startTick = MIN_TICK;
+        borrowerOffer.expiryTick = MIN_TICK;
 
         morphoV2.take(
             0,

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -167,21 +167,4 @@ contract OtherFunctionsTest is BaseTest {
         morphoV2.shuffleSession();
         assertEq(morphoV2.session(user), keccak256(abi.encode(0, blockhash(block.number - 1))), "session");
     }
-
-    function testTickToPrice() public view {
-        uint256 P_0 = 0.9999999e18;
-        assertEq(morphoV2.tickToPrice(0), P_0, "tick 0");
-
-        uint256 previousReturn = _return(P_0);
-        for (uint256 i = 1; i <= 1000; i++) {
-            assertApproxEqRel(
-                _return(morphoV2.tickToPrice(i)), previousReturn.mulDivDown(WAD + DELTA, WAD), 0.05e18, "tick i"
-            );
-            previousReturn = _return(morphoV2.tickToPrice(i));
-        }
-    }
-
-    function _return(uint256 price) internal pure returns (uint256) {
-        return (WAD - price).mulDivDown(WAD, price);
-    }
 }

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -9,7 +9,11 @@ import {MathLib} from "../src/libraries/MathLib.sol";
 import {ICallbacks} from "../src/interfaces/ICallbacks.sol";
 import {stdError} from "../lib/forge-std/src/StdError.sol";
 import {BaseTest} from "./BaseTest.sol";
+import {MIN_TICK} from "../src/libraries/TickLib.sol";
 import {ERC20} from "./helpers/ERC20.sol";
+
+// Unit amounts become too big beyond that.
+int256 constant MAX_TEST_TICK = 600;
 
 contract TakeTest is BaseTest {
     using MathLib for uint256;
@@ -21,7 +25,7 @@ contract TakeTest is BaseTest {
     Offer internal otherLenderOffer;
     Offer internal otherBorrowerOffer;
 
-    uint256 internal maxAssets = 1e36; // to refine.
+    uint256 internal maxAssets = 1e28; // to refine.
     uint256 internal initialUnits;
     uint256 internal initialShares;
 
@@ -81,15 +85,16 @@ contract TakeTest is BaseTest {
 
     // path 1: Lender enters + borrower enters.
 
-    function testBuyAssetsInput1(uint256 buyerAssets, uint256 tick) public {
+    function testBuyAssetsInput1(uint256 buyerAssets, int256 tick) public {
         buyerAssets = bound(buyerAssets, 0, maxAssets);
-        tick = bound(tick, 0, 1000);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         borrowerOffer.startTick = tick;
         borrowerOffer.expiryTick = tick;
         borrowerOffer.assets = buyerAssets;
         deal(address(loanToken), lender, buyerAssets);
         uint256 expectedUnits = buyerAssets.mulDivDown(WAD, price);
+
         uint256 expectedShares = expectedUnits.mulDivDown(initialShares + 1, initialUnits + 1);
         collateralize(obligation, borrower, expectedUnits);
 
@@ -104,9 +109,9 @@ contract TakeTest is BaseTest {
         assertEq(morphoV2.consumed(borrower, 0), buyerAssets, "borrower consumed");
     }
 
-    function testSellAssetsInput1(uint256 buyerAssets, uint256 tick) public {
+    function testSellAssetsInput1(uint256 buyerAssets, int256 tick) public {
         buyerAssets = bound(buyerAssets, 0, maxAssets);
-        tick = bound(tick, 0, 1000);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         lenderOffer.startTick = tick;
         lenderOffer.expiryTick = tick;
@@ -127,9 +132,9 @@ contract TakeTest is BaseTest {
         assertEq(morphoV2.consumed(lender, 0), buyerAssets, "lender consumed");
     }
 
-    function testBuyObligationUnitsInput1(uint256 obligationUnits, uint256 tick) public {
+    function testBuyObligationUnitsInput1(uint256 obligationUnits, int256 tick) public {
         obligationUnits = bound(obligationUnits, 1, maxAssets);
-        tick = bound(tick, 0, 1000);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         borrowerOffer.startTick = tick;
         borrowerOffer.expiryTick = tick;
@@ -150,9 +155,9 @@ contract TakeTest is BaseTest {
         assertEq(morphoV2.consumed(borrower, 0), expectedAssets, "borrower consumed");
     }
 
-    function testSellObligationUnitsInput1(uint256 obligationUnits, uint256 tick) public {
+    function testSellObligationUnitsInput1(uint256 obligationUnits, int256 tick) public {
         obligationUnits = bound(obligationUnits, 1, maxAssets);
-        tick = bound(tick, 0, 1000);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         lenderOffer.startTick = tick;
         lenderOffer.expiryTick = tick;
@@ -173,9 +178,9 @@ contract TakeTest is BaseTest {
         assertEq(morphoV2.consumed(lender, 0), expectedAssets, "lender consumed");
     }
 
-    function testBuyObligationSharesInput1(uint256 obligationShares, uint256 tick) public {
+    function testBuyObligationSharesInput1(uint256 obligationShares, int256 tick) public {
         obligationShares = bound(obligationShares, 1, maxAssets);
-        tick = bound(tick, 0, 1000);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         borrowerOffer.startTick = tick;
         borrowerOffer.expiryTick = tick;
@@ -196,9 +201,9 @@ contract TakeTest is BaseTest {
         assertEq(morphoV2.consumed(borrower, 0), expectedAssets, "borrower consumed");
     }
 
-    function testSellObligationSharesInput1(uint256 obligationShares, uint256 tick) public {
+    function testSellObligationSharesInput1(uint256 obligationShares, int256 tick) public {
         obligationShares = bound(obligationShares, 1, maxAssets);
-        tick = bound(tick, 0, 1000);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         lenderOffer.startTick = tick;
         lenderOffer.expiryTick = tick;
@@ -221,9 +226,9 @@ contract TakeTest is BaseTest {
 
     // path 2: Lender enters + lender exits.
 
-    function testBuyAssetsInput2(uint256 buyerAssets, uint256 tick, uint256 otherLenderUnits) public {
+    function testBuyAssetsInput2(uint256 buyerAssets, int256 tick, uint256 otherLenderUnits) public {
         buyerAssets = bound(buyerAssets, 0, maxAssets);
-        tick = bound(tick, 0, 600);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         uint256 expectedUnits = buyerAssets.mulDivDown(WAD, price);
         uint256 expectedShares = expectedUnits.mulDivDown(initialShares + 1, initialUnits + 1);
@@ -249,9 +254,9 @@ contract TakeTest is BaseTest {
         assertEq(morphoV2.consumed(otherLenderOffer.maker, 0), buyerAssets, "maker consumed");
     }
 
-    function testSellAssetsInput2(uint256 buyerAssets, uint256 tick, uint256 otherLenderUnits) public {
+    function testSellAssetsInput2(uint256 buyerAssets, int256 tick, uint256 otherLenderUnits) public {
         buyerAssets = bound(buyerAssets, 0, maxAssets);
-        tick = bound(tick, 0, 600);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         uint256 expectedUnits = buyerAssets.mulDivDown(WAD, price);
         uint256 expectedShares = expectedUnits.mulDivDown(initialShares + 1, initialUnits + 1);
@@ -276,9 +281,9 @@ contract TakeTest is BaseTest {
         assertEq(morphoV2.consumed(lenderOffer.maker, 0), buyerAssets, "maker consumed");
     }
 
-    function testBuyObligationUnitsInput2(uint256 obligationUnits, uint256 tick, uint256 otherLenderUnits) public {
+    function testBuyObligationUnitsInput2(uint256 obligationUnits, int256 tick, uint256 otherLenderUnits) public {
         obligationUnits = bound(obligationUnits, 0, maxAssets);
-        tick = bound(tick, 0, 600);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         uint256 buyerAssets = obligationUnits.mulDivDown(price, WAD);
         uint256 expectedShares = obligationUnits.mulDivDown(initialShares + 1, initialUnits + 1);
@@ -304,9 +309,9 @@ contract TakeTest is BaseTest {
         assertEq(morphoV2.consumed(otherLenderOffer.maker, 0), buyerAssets, "maker consumed");
     }
 
-    function testSellObligationUnitsInput2(uint256 obligationUnits, uint256 tick, uint256 otherLenderUnits) public {
+    function testSellObligationUnitsInput2(uint256 obligationUnits, int256 tick, uint256 otherLenderUnits) public {
         obligationUnits = bound(obligationUnits, 0, maxAssets);
-        tick = bound(tick, 0, 600);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         uint256 buyerAssets = obligationUnits.mulDivDown(price, WAD);
         uint256 expectedShares = obligationUnits.mulDivDown(initialShares + 1, initialUnits + 1);
@@ -332,9 +337,9 @@ contract TakeTest is BaseTest {
         assertEq(morphoV2.consumed(lenderOffer.maker, 0), buyerAssets, "maker consumed");
     }
 
-    function testBuyObligationSharesInput2(uint256 obligationShares, uint256 tick, uint256 otherLenderUnits) public {
+    function testBuyObligationSharesInput2(uint256 obligationShares, int256 tick, uint256 otherLenderUnits) public {
         obligationShares = bound(obligationShares, 0, maxAssets);
-        tick = bound(tick, 0, 600);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         uint256 expectedUnits = obligationShares.mulDivDown(initialUnits + 1, initialShares + 1);
         uint256 buyerAssets = expectedUnits.mulDivDown(price, WAD);
@@ -361,9 +366,9 @@ contract TakeTest is BaseTest {
         assertApproxEqAbs(morphoV2.consumed(otherLenderOffer.maker, 0), buyerAssets, 1, "maker consumed");
     }
 
-    function testSellObligationSharesInput2(uint256 obligationShares, uint256 tick, uint256 otherLenderUnits) public {
+    function testSellObligationSharesInput2(uint256 obligationShares, int256 tick, uint256 otherLenderUnits) public {
         obligationShares = bound(obligationShares, 0, maxAssets);
-        tick = bound(tick, 0, 600);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         uint256 expectedUnits = obligationShares.mulDivDown(initialUnits + 1, initialShares + 1);
         uint256 buyerAssets = expectedUnits.mulDivDown(price, WAD);
@@ -403,9 +408,9 @@ contract TakeTest is BaseTest {
 
     // path 3: Borrower exits + borrower enters.
 
-    function testBuyAssetsInput3(uint256 buyerAssets, uint256 tick, uint256 otherBorrowerDebt) public {
+    function testBuyAssetsInput3(uint256 buyerAssets, int256 tick, uint256 otherBorrowerDebt) public {
         buyerAssets = bound(buyerAssets, 0, maxAssets);
-        tick = bound(tick, 0, 600);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         uint256 expectedUnits = buyerAssets.mulDivDown(WAD, price);
         otherBorrowerDebt = bound(otherBorrowerDebt, expectedUnits, max(expectedUnits, maxAssets));
@@ -427,9 +432,9 @@ contract TakeTest is BaseTest {
         assertEq(morphoV2.consumed(borrowerOffer.maker, 0), buyerAssets, "maker consumed");
     }
 
-    function testSellAssetsInput3(uint256 buyerAssets, uint256 tick, uint256 otherBorrowerDebt) public {
+    function testSellAssetsInput3(uint256 buyerAssets, int256 tick, uint256 otherBorrowerDebt) public {
         buyerAssets = bound(buyerAssets, 0, maxAssets);
-        tick = bound(tick, 0, 600);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         uint256 expectedUnits = buyerAssets.mulDivDown(WAD, price);
         otherBorrowerDebt = bound(otherBorrowerDebt, expectedUnits, max(expectedUnits, maxAssets));
@@ -451,9 +456,9 @@ contract TakeTest is BaseTest {
         assertEq(morphoV2.consumed(otherBorrowerOffer.maker, 0), buyerAssets, "maker consumed");
     }
 
-    function testBuyObligationUnitsInput3(uint256 obligationUnits, uint256 tick, uint256 otherBorrowerDebt) public {
+    function testBuyObligationUnitsInput3(uint256 obligationUnits, int256 tick, uint256 otherBorrowerDebt) public {
         obligationUnits = bound(obligationUnits, 0, maxAssets);
-        tick = bound(tick, 0, 600);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         uint256 buyerAssets = obligationUnits.mulDivDown(price, WAD);
         otherBorrowerDebt = bound(otherBorrowerDebt, obligationUnits, maxAssets);
@@ -475,9 +480,9 @@ contract TakeTest is BaseTest {
         assertEq(morphoV2.consumed(borrowerOffer.maker, 0), buyerAssets, "maker consumed");
     }
 
-    function testSellObligationUnitsInput3(uint256 obligationUnits, uint256 tick, uint256 otherBorrowerDebt) public {
+    function testSellObligationUnitsInput3(uint256 obligationUnits, int256 tick, uint256 otherBorrowerDebt) public {
         obligationUnits = bound(obligationUnits, 0, maxAssets);
-        tick = bound(tick, 0, 600);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         uint256 buyerAssets = obligationUnits.mulDivDown(price, WAD);
         otherBorrowerDebt = bound(otherBorrowerDebt, obligationUnits, maxAssets);
@@ -499,9 +504,9 @@ contract TakeTest is BaseTest {
         assertEq(morphoV2.consumed(otherBorrowerOffer.maker, 0), buyerAssets, "maker consumed");
     }
 
-    function testBuyObligationSharesInput3(uint256 obligationShares, uint256 tick, uint256 otherBorrowerDebt) public {
+    function testBuyObligationSharesInput3(uint256 obligationShares, int256 tick, uint256 otherBorrowerDebt) public {
         obligationShares = bound(obligationShares, 0, maxAssets);
-        tick = bound(tick, 0, 600);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         uint256 expectedUnits = obligationShares.mulDivDown(initialUnits + 1, initialShares + 1);
         uint256 buyerAssets = expectedUnits.mulDivDown(price, WAD);
@@ -528,9 +533,9 @@ contract TakeTest is BaseTest {
         assertApproxEqAbs(morphoV2.consumed(borrowerOffer.maker, 0), buyerAssets, 1, "maker consumed");
     }
 
-    function testSellObligationSharesInput3(uint256 obligationShares, uint256 tick, uint256 otherBorrowerDebt) public {
+    function testSellObligationSharesInput3(uint256 obligationShares, int256 tick, uint256 otherBorrowerDebt) public {
         obligationShares = bound(obligationShares, 0, maxAssets);
-        tick = bound(tick, 0, 600);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         uint256 expectedUnits = obligationShares.mulDivDown(initialUnits + 1, initialShares + 1);
         uint256 buyerAssets = expectedUnits.mulDivDown(price, WAD);
@@ -571,9 +576,9 @@ contract TakeTest is BaseTest {
 
     // path 4: Borrower exits + lender exits.
 
-    function testBuyAssetsInput4(uint256 buyerAssets, uint256 tick, uint256 existingUnits) public {
+    function testBuyAssetsInput4(uint256 buyerAssets, int256 tick, uint256 existingUnits) public {
         buyerAssets = bound(buyerAssets, 0, maxAssets);
-        tick = bound(tick, 0, 600);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         uint256 expectedUnits = buyerAssets.mulDivDown(WAD, price);
         uint256 expectedShares = expectedUnits.mulDivDown(initialShares + 1, initialUnits + 1);
@@ -599,9 +604,9 @@ contract TakeTest is BaseTest {
         assertEq(morphoV2.consumed(otherLenderOffer.maker, 0), buyerAssets, "maker consumed");
     }
 
-    function testSellAssetsInput4(uint256 buyerAssets, uint256 tick, uint256 existingUnits) public {
+    function testSellAssetsInput4(uint256 buyerAssets, int256 tick, uint256 existingUnits) public {
         buyerAssets = bound(buyerAssets, 0, maxAssets);
-        tick = bound(tick, 0, 600);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         uint256 expectedUnits = buyerAssets.mulDivDown(WAD, price);
         uint256 expectedShares = expectedUnits.mulDivDown(initialShares + 1, initialUnits + 1);
@@ -627,9 +632,9 @@ contract TakeTest is BaseTest {
         assertEq(morphoV2.consumed(otherBorrowerOffer.maker, 0), buyerAssets, "maker consumed");
     }
 
-    function testBuyObligationUnitsInput4(uint256 obligationUnits, uint256 tick, uint256 existingUnits) public {
+    function testBuyObligationUnitsInput4(uint256 obligationUnits, int256 tick, uint256 existingUnits) public {
         obligationUnits = bound(obligationUnits, 0, maxAssets);
-        tick = bound(tick, 0, 1000);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         uint256 buyerAssets = obligationUnits.mulDivDown(price, WAD);
         uint256 expectedShares = obligationUnits.mulDivDown(initialShares + 1, initialUnits + 1);
@@ -655,9 +660,9 @@ contract TakeTest is BaseTest {
         assertEq(morphoV2.consumed(otherLenderOffer.maker, 0), buyerAssets, "maker consumed");
     }
 
-    function testSellObligationUnitsInput4(uint256 obligationUnits, uint256 tick, uint256 existingUnits) public {
+    function testSellObligationUnitsInput4(uint256 obligationUnits, int256 tick, uint256 existingUnits) public {
         obligationUnits = bound(obligationUnits, 0, maxAssets);
-        tick = bound(tick, 0, 1000);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         uint256 buyerAssets = obligationUnits.mulDivDown(price, WAD);
         uint256 expectedShares = obligationUnits.mulDivDown(initialShares + 1, initialUnits + 1);
@@ -683,9 +688,9 @@ contract TakeTest is BaseTest {
         assertEq(morphoV2.consumed(otherBorrowerOffer.maker, 0), buyerAssets, "maker consumed");
     }
 
-    function testBuyObligationSharesInput4(uint256 obligationShares, uint256 tick, uint256 existingUnits) public {
+    function testBuyObligationSharesInput4(uint256 obligationShares, int256 tick, uint256 existingUnits) public {
         obligationShares = bound(obligationShares, 0, maxAssets);
-        tick = bound(tick, 0, 1000);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         uint256 expectedUnits = obligationShares.mulDivDown(initialUnits + 1, initialShares + 1);
         uint256 buyerAssets = expectedUnits.mulDivDown(price, WAD);
@@ -712,9 +717,9 @@ contract TakeTest is BaseTest {
         assertApproxEqAbs(morphoV2.consumed(otherLenderOffer.maker, 0), buyerAssets, 1, "maker consumed");
     }
 
-    function testSellObligationSharesInput4(uint256 obligationShares, uint256 tick, uint256 existingUnits) public {
+    function testSellObligationSharesInput4(uint256 obligationShares, int256 tick, uint256 existingUnits) public {
         obligationShares = bound(obligationShares, 0, maxAssets);
-        tick = bound(tick, 0, 1000);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         uint256 expectedUnits = obligationShares.mulDivDown(initialUnits + 1, initialShares + 1);
         uint256 buyerAssets = expectedUnits.mulDivDown(price, WAD);
@@ -755,8 +760,8 @@ contract TakeTest is BaseTest {
         secondRevertingTake = bound(secondRevertingTake, offerAmount - assets + 1, maxAssets);
         secondPassingTake = bound(secondPassingTake, 0, offerAmount - assets);
         borrowerOffer.assets = offerAmount;
-        borrowerOffer.startTick = 400;
-        borrowerOffer.expiryTick = 400;
+        borrowerOffer.startTick = -879;
+        borrowerOffer.expiryTick = -879;
         deal(address(loanToken), lender, offerAmount);
         collateralize(obligation, borrower, offerAmount.mulDivDown(WAD, morphoV2.tickToPrice(borrowerOffer.startTick)));
 
@@ -779,8 +784,8 @@ contract TakeTest is BaseTest {
         secondRevertingTake = bound(secondRevertingTake, offerAmount - assets + 1, maxAssets);
         secondPassingTake = bound(secondPassingTake, 0, offerAmount - assets);
         lenderOffer.assets = offerAmount;
-        lenderOffer.startTick = 400;
-        lenderOffer.expiryTick = 400;
+        lenderOffer.startTick = -879;
+        lenderOffer.expiryTick = -879;
         deal(address(loanToken), lender, offerAmount);
         collateralize(obligation, borrower, offerAmount.mulDivDown(WAD, morphoV2.tickToPrice(lenderOffer.startTick)));
 
@@ -796,8 +801,8 @@ contract TakeTest is BaseTest {
         firstFill = bound(firstFill, 0, maxAssets);
         secondFill = bound(secondFill, 0, maxAssets);
         borrowerOffer.assets = firstFill + secondFill;
-        borrowerOffer.startTick = 400;
-        borrowerOffer.expiryTick = 400;
+        borrowerOffer.startTick = -879;
+        borrowerOffer.expiryTick = -879;
         Offer memory borrowerOffer2 = borrowerOffer;
         borrowerOffer2.obligation.maturity = obligation.maturity + 100;
         deal(address(loanToken), lender, firstFill + secondFill);
@@ -1027,11 +1032,11 @@ contract TakeTest is BaseTest {
     // other tests.
 
     // address(this) makes an arbitrage for 2 crossed offers.
-    function testMatch(uint256 units, uint256 tick1, uint256 tick2) public {
+    function testMatch(uint256 units, int256 tick1, int256 tick2) public {
         units = bound(units, 1, maxAssets);
-        tick1 = bound(tick1, 0, 1000);
-        tick2 = bound(tick2, 0, 1000);
-        vm.assume(tick1 > tick2);
+        tick1 = bound(tick1, MIN_TICK, MAX_TEST_TICK);
+        tick2 = bound(tick2, MIN_TICK, MAX_TEST_TICK);
+        vm.assume(tick1 < tick2);
         uint256 price1 = morphoV2.tickToPrice(tick1);
         uint256 price2 = morphoV2.tickToPrice(tick2);
         borrowerOffer.assets = units;
@@ -1060,11 +1065,10 @@ contract TakeTest is BaseTest {
     }
 
     // address(this) makes an arbitrage for 2 crossed offers.
-    function testMatchInverse(uint256 units, uint256 tick1, uint256 tick2) public {
+    function testMatchInverse(uint256 units, int256 tick1, int256 tick2) public {
         units = bound(units, 1, maxAssets);
-        tick1 = bound(tick1, 0, 1000);
-        tick2 = bound(tick2, 0, 1000);
-        vm.assume(tick1 > tick2);
+        tick1 = bound(tick1, MIN_TICK + 1, MAX_TEST_TICK);
+        tick2 = bound(tick2, MIN_TICK, tick1);
         uint256 price1 = morphoV2.tickToPrice(tick1);
         uint256 price2 = morphoV2.tickToPrice(tick2);
         borrowerOffer.assets = units;
@@ -1099,8 +1103,8 @@ contract TakeTest is BaseTest {
         vm.warp(timestamp);
         borrowerOffer.expiry = timestamp;
         borrowerOffer.assets = 100;
-        borrowerOffer.startTick = type(uint256).max;
-        borrowerOffer.expiryTick = type(uint256).max;
+        borrowerOffer.startTick = MIN_TICK;
+        borrowerOffer.expiryTick = MIN_TICK;
         deal(address(loanToken), lender, 100);
         collateralize(obligation, borrower, 100);
 
@@ -1112,18 +1116,18 @@ contract TakeTest is BaseTest {
         vm.warp(timestamp);
         lenderOffer.expiry = timestamp;
         lenderOffer.assets = 100;
-        lenderOffer.startTick = type(uint256).max;
-        lenderOffer.expiryTick = type(uint256).max;
+        lenderOffer.startTick = MIN_TICK;
+        lenderOffer.expiryTick = MIN_TICK;
         deal(address(loanToken), lender, 100);
         collateralize(obligation, borrower, 100);
 
         take(100, 0, 0, 0, borrower, lenderOffer);
     }
 
-    function testBuyUnhealthy(uint256 units, uint256 tick, uint256 collateralized) public {
+    function testBuyUnhealthy(uint256 units, int256 tick, uint256 collateralized) public {
         units = bound(units, 1, maxAssets);
         collateralized = bound(collateralized, 0, units / 2);
-        tick = bound(tick, 0, 1000);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         borrowerOffer.assets = units;
         borrowerOffer.startTick = tick;
@@ -1135,10 +1139,10 @@ contract TakeTest is BaseTest {
         take(0, 0, units, 0, lender, borrowerOffer);
     }
 
-    function testSellUnhealthy(uint256 units, uint256 tick, uint256 collateralized) public {
+    function testSellUnhealthy(uint256 units, int256 tick, uint256 collateralized) public {
         units = bound(units, 1, maxAssets);
         collateralized = bound(collateralized, 0, units / 2);
-        tick = bound(tick, 0, 1000);
+        tick = bound(tick, MIN_TICK, MAX_TEST_TICK);
         uint256 price = morphoV2.tickToPrice(tick);
         lenderOffer.assets = units;
         lenderOffer.startTick = tick;
@@ -1150,7 +1154,7 @@ contract TakeTest is BaseTest {
         take(0, 0, units, 0, borrower, lenderOffer);
     }
 
-    function testTakeInconsistentPrices(uint256 startTick, uint256 expiryTick) public {
+    function testTakeInconsistentPrices(int256 startTick, int256 expiryTick) public {
         vm.assume(startTick != expiryTick);
         lenderOffer.start = block.timestamp;
         lenderOffer.expiry = lenderOffer.start;
@@ -1266,8 +1270,8 @@ contract TakeTest is BaseTest {
         borrowerOffer.callback = address(new BorrowCallback());
         borrowerOffer.callbackData = abi.encode(obligation.collaterals[0].token, collateral);
         borrowerOffer.assets = assets;
-        borrowerOffer.startTick = type(uint256).max;
-        borrowerOffer.expiryTick = type(uint256).max;
+        borrowerOffer.startTick = MIN_TICK;
+        borrowerOffer.expiryTick = MIN_TICK;
         deal(address(loanToken), lender, assets);
         deal(obligation.collaterals[0].token, borrowerOffer.callback, collateral);
         assertEq(morphoV2.collateralOf(borrower, id, obligation.collaterals[0].token), 0);
@@ -1282,8 +1286,8 @@ contract TakeTest is BaseTest {
         assets = bound(assets, 0, maxAssets);
         uint256 collateral = assets.mulDivUp(WAD, obligation.collaterals[0].lltv);
         lenderOffer.assets = assets;
-        lenderOffer.startTick = type(uint256).max;
-        lenderOffer.expiryTick = type(uint256).max;
+        lenderOffer.startTick = MIN_TICK;
+        lenderOffer.expiryTick = MIN_TICK;
         address callback = address(new BorrowCallback());
         deal(address(loanToken), lender, assets);
         deal(obligation.collaterals[0].token, callback, collateral);
@@ -1311,8 +1315,8 @@ contract TakeTest is BaseTest {
         lenderOffer.callbackData = abi.encode(loanToken, assets);
         lenderOffer.maker = address(otherLender);
         lenderOffer.assets = assets;
-        lenderOffer.startTick = type(uint256).max;
-        lenderOffer.expiryTick = type(uint256).max;
+        lenderOffer.startTick = MIN_TICK;
+        lenderOffer.expiryTick = MIN_TICK;
         deal(address(loanToken), lenderOffer.callback, assets);
         collateralize(obligation, borrower, assets);
 
@@ -1328,9 +1332,10 @@ contract TakeTest is BaseTest {
         loanToken.approve(address(morphoV2), assets);
         address callback = address(new LendCallback());
         borrowerOffer.assets = assets;
-        borrowerOffer.startTick = type(uint256).max;
-        borrowerOffer.expiryTick = type(uint256).max;
+        borrowerOffer.startTick = MIN_TICK;
+        borrowerOffer.expiryTick = MIN_TICK;
         deal(address(loanToken), callback, assets);
+
         collateralize(obligation, borrower, assets);
 
         morphoV2.take(

--- a/test/TickLibTest.sol
+++ b/test/TickLibTest.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {Test} from "../lib/forge-std/src/Test.sol";
+import {TickLib, MIN_TICK, MAX_TICK} from "../src/libraries/TickLib.sol";
+import {WAD} from "../src/libraries/ConstantsLib.sol";
+
+contract TickLibTest is Test {
+    function testExhaustiveTickToRoi() public pure {
+        for (int256 t = MIN_TICK; t <= MAX_TICK; t++) {
+            assertEq(TickLib.roiToTick(TickLib.tickToRoi(t)), t);
+            assertLt(TickLib.tickToRoi(t), TickLib.tickToRoi(t + 1));
+        }
+    }
+
+    function testSomeTicks() public pure {
+        assertEq(TickLib.tickToPrice(MIN_TICK), 1e18);
+        assertEq(TickLib.tickToPrice(0), WAD / 2);
+        assertEq(TickLib.tickToPrice(MAX_TICK), 0);
+    }
+
+    function testRoiToTickSecondBestAtWorst(uint256 r) public pure {
+        r = bound(r, TickLib.tickToRoi(MIN_TICK), TickLib.tickToRoi(MAX_TICK));
+        int256 tr = TickLib.roiToTick(r);
+        uint256 rtr = TickLib.tickToRoi(tr);
+        uint256 rtrPrev = tr > MIN_TICK ? TickLib.tickToRoi(tr - 1) : rtr;
+        uint256 rtrNext = tr < MAX_TICK ? TickLib.tickToRoi(tr + 1) : rtr;
+        assertTrue((rtrPrev <= r && r <= rtr) || (rtr <= r && r <= rtrNext), "bound not tight");
+    }
+
+    function testRoiToTickInterpolationTight() public pure {
+        for (int256 t = MIN_TICK; t < MAX_TICK; t++) {
+            uint256 rt = TickLib.tickToRoi(t);
+            uint256 rtp1 = TickLib.tickToRoi(t + 1);
+            uint256 roiLow = rt + (rtp1 - rt) * 47 / 100;
+            uint256 roiHigh = rt + (rtp1 - rt) * 55 / 100;
+
+            assertEq(TickLib.roiToTick(roiLow), t, "47% interpolation should map to t");
+            assertEq(TickLib.roiToTick(roiHigh), t + 1, "55% interpolation should map to t+1");
+        }
+    }
+}

--- a/test/TradingFeeTest.sol
+++ b/test/TradingFeeTest.sol
@@ -7,6 +7,7 @@ import {MathLib} from "../src/libraries/MathLib.sol";
 import {Obligation, Offer, Collateral} from "../src/interfaces/IMorphoV2.sol";
 
 import {BaseTest, MAX_TEST_AMOUNT} from "./BaseTest.sol";
+import {MIN_TICK, MAX_TICK} from "../src/libraries/TickLib.sol";
 
 contract TradingFeeTest is BaseTest {
     using MathLib for uint256;
@@ -59,11 +60,11 @@ contract TradingFeeTest is BaseTest {
     // iff (P_B - interestCutLimit) / (1 - interestCutLimit) <= P_B / (1 + tradingFee)
     // iff P_B <= interestCutLimit * (1 + tradingFee) / (tradingFee + interestCutLimit)
 
-    function testBuyBuyerAssetsProportional(uint256 buyerAssets, uint256 sellerTick, uint256 tradingFee) public {
+    function testBuyBuyerAssetsProportional(uint256 buyerAssets, int256 sellerTick, uint256 tradingFee) public {
         buyerAssets = bound(buyerAssets, 0, MAX_TEST_AMOUNT);
         tradingFee = bound(tradingFee, 0, 0.5 ether);
         uint256 interestCutLimit = WAD - 1;
-        sellerTick = bound(sellerTick, 0, 1000);
+        sellerTick = bound(sellerTick, MIN_TICK, MAX_TICK);
         vm.assume(morphoV2.tickToPrice(sellerTick) >= 0.5e18);
         vm.assume(morphoV2.tickToPrice(sellerTick) < interestCutLimit.mulDivDown(WAD, tradingFee + interestCutLimit));
         uint256 sellerPrice = morphoV2.tickToPrice(sellerTick);
@@ -81,11 +82,11 @@ contract TradingFeeTest is BaseTest {
         assertApproxEqAbs(loanToken.balanceOf(feeRecipient), expectedFee, 100, "fee recipient balance");
     }
 
-    function testSellBuyerAssetsProportional(uint256 tradingFee, uint256 buyerTick, uint256 buyerAssets) public {
+    function testSellBuyerAssetsProportional(uint256 tradingFee, int256 buyerTick, uint256 buyerAssets) public {
         buyerAssets = bound(buyerAssets, 0, MAX_TEST_AMOUNT);
         tradingFee = bound(tradingFee, 0, 0.5 ether);
         uint256 interestCutLimit = WAD - 1;
-        buyerTick = bound(buyerTick, 0, 1000);
+        buyerTick = bound(buyerTick, MIN_TICK, MAX_TICK);
         vm.assume(morphoV2.tickToPrice(buyerTick) >= 0.5e18);
         vm.assume(
             morphoV2.tickToPrice(buyerTick)
@@ -109,11 +110,11 @@ contract TradingFeeTest is BaseTest {
         );
     }
 
-    function testBuySellerAssetsProportional(uint256 tradingFee, uint256 sellerTick, uint256 sellerAssets) public {
+    function testBuySellerAssetsProportional(uint256 tradingFee, int256 sellerTick, uint256 sellerAssets) public {
         sellerAssets = bound(sellerAssets, 0, MAX_TEST_AMOUNT);
         tradingFee = bound(tradingFee, 0, 0.5 ether);
         uint256 interestCutLimit = WAD - 1;
-        sellerTick = bound(sellerTick, 0, 1000);
+        sellerTick = bound(sellerTick, MIN_TICK, MAX_TICK);
         vm.assume(morphoV2.tickToPrice(sellerTick) >= 0.5e18);
         vm.assume(morphoV2.tickToPrice(sellerTick) < interestCutLimit.mulDivDown(WAD, tradingFee + interestCutLimit));
         morphoV2.setTradingFee(id, tradingFee, interestCutLimit);
@@ -131,11 +132,11 @@ contract TradingFeeTest is BaseTest {
         assertApproxEqAbs(loanToken.balanceOf(feeRecipient), expectedFee, 100, "fee recipient balance");
     }
 
-    function testSellSellerAssetsProportional(uint256 tradingFee, uint256 buyerTick, uint256 sellerAssets) public {
+    function testSellSellerAssetsProportional(uint256 tradingFee, int256 buyerTick, uint256 sellerAssets) public {
         sellerAssets = bound(sellerAssets, 0, MAX_TEST_AMOUNT);
         tradingFee = bound(tradingFee, 0, 0.5 ether);
         uint256 interestCutLimit = WAD - 1;
-        buyerTick = bound(buyerTick, 0, 1000);
+        buyerTick = bound(buyerTick, MIN_TICK, MAX_TICK);
         vm.assume(morphoV2.tickToPrice(buyerTick) >= 0.5e18);
         vm.assume(
             morphoV2.tickToPrice(buyerTick)
@@ -158,13 +159,11 @@ contract TradingFeeTest is BaseTest {
         assertApproxEqAbs(loanToken.balanceOf(feeRecipient), expectedFee, 100, "fee recipient balance");
     }
 
-    function testBuyObligationUnitsProportional(uint256 tradingFee, uint256 sellerTick, uint256 obligationUnits)
-        public
-    {
+    function testBuyObligationUnitsProportional(uint256 tradingFee, int256 sellerTick, uint256 obligationUnits) public {
         obligationUnits = bound(obligationUnits, 0, MAX_TEST_AMOUNT);
         tradingFee = bound(tradingFee, 0, 0.5 ether);
         uint256 interestCutLimit = WAD - 1;
-        sellerTick = bound(sellerTick, 0, 1000);
+        sellerTick = bound(sellerTick, MIN_TICK, MAX_TICK);
         vm.assume(morphoV2.tickToPrice(sellerTick) >= 0.5e18);
         vm.assume(morphoV2.tickToPrice(sellerTick) < interestCutLimit.mulDivDown(WAD, tradingFee + interestCutLimit));
         uint256 sellerPrice = morphoV2.tickToPrice(sellerTick);
@@ -183,13 +182,11 @@ contract TradingFeeTest is BaseTest {
         assertApproxEqAbs(loanToken.balanceOf(feeRecipient), expectedFee, 100, "fee recipient balance");
     }
 
-    function testSellObligationUnitsProportional(uint256 tradingFee, uint256 buyerTick, uint256 obligationUnits)
-        public
-    {
+    function testSellObligationUnitsProportional(uint256 tradingFee, int256 buyerTick, uint256 obligationUnits) public {
         obligationUnits = bound(obligationUnits, 0, MAX_TEST_AMOUNT);
         tradingFee = bound(tradingFee, 0, 0.5 ether);
         uint256 interestCutLimit = WAD - 1;
-        buyerTick = bound(buyerTick, 0, 1000);
+        buyerTick = bound(buyerTick, MIN_TICK, MAX_TICK);
         vm.assume(morphoV2.tickToPrice(buyerTick) >= 0.5e18);
         vm.assume(
             morphoV2.tickToPrice(buyerTick)
@@ -213,13 +210,13 @@ contract TradingFeeTest is BaseTest {
         assertApproxEqAbs(loanToken.balanceOf(feeRecipient), expectedFee, 100, "fee recipient balance");
     }
 
-    function testBuyObligationSharesProportional(uint256 tradingFee, uint256 sellerTick, uint256 obligationShares)
+    function testBuyObligationSharesProportional(uint256 tradingFee, int256 sellerTick, uint256 obligationShares)
         public
     {
         obligationShares = bound(obligationShares, 0, MAX_TEST_AMOUNT);
         tradingFee = bound(tradingFee, 0, 0.5 ether);
         uint256 interestCutLimit = WAD - 1;
-        sellerTick = bound(sellerTick, 0, 1000);
+        sellerTick = bound(sellerTick, MIN_TICK, MAX_TICK);
         vm.assume(morphoV2.tickToPrice(sellerTick) >= 0.5e18);
         vm.assume(morphoV2.tickToPrice(sellerTick) < interestCutLimit.mulDivDown(WAD, tradingFee + interestCutLimit));
         uint256 sellerPrice = morphoV2.tickToPrice(sellerTick);
@@ -238,13 +235,13 @@ contract TradingFeeTest is BaseTest {
         assertApproxEqAbs(loanToken.balanceOf(feeRecipient), expectedFee, 100, "fee recipient balance");
     }
 
-    function testSellObligationSharesProportional(uint256 tradingFee, uint256 buyerTick, uint256 obligationShares)
+    function testSellObligationSharesProportional(uint256 tradingFee, int256 buyerTick, uint256 obligationShares)
         public
     {
         obligationShares = bound(obligationShares, 0, MAX_TEST_AMOUNT);
         tradingFee = bound(tradingFee, 0, 0.5 ether);
         uint256 interestCutLimit = WAD - 1;
-        buyerTick = bound(buyerTick, 0, 1000);
+        buyerTick = bound(buyerTick, MIN_TICK, MAX_TICK);
         vm.assume(morphoV2.tickToPrice(buyerTick) >= 0.5e18);
         vm.assume(
             morphoV2.tickToPrice(buyerTick)
@@ -280,12 +277,12 @@ contract TradingFeeTest is BaseTest {
     // iff P_B >= interestCutLimit * (1+tradingFee) / (tradingFee + interestCutLimit)
     // which is the same as P_B >= interestCutLimit if tradingFee is very high.
 
-    function testBuyBuyerAssetsInterestCutLimit(uint256 interestCutLimit, uint256 sellerTick, uint256 buyerAssets)
+    function testBuyBuyerAssetsInterestCutLimit(uint256 interestCutLimit, int256 sellerTick, uint256 buyerAssets)
         public
     {
         buyerAssets = bound(buyerAssets, 0, MAX_TEST_AMOUNT);
         interestCutLimit = bound(interestCutLimit, 0, 0.5 ether);
-        sellerTick = bound(sellerTick, 0, 1000);
+        sellerTick = bound(sellerTick, MIN_TICK, MAX_TICK);
         uint256 sellerPrice = morphoV2.tickToPrice(sellerTick);
         vm.assume(sellerPrice >= 0.5e18);
         morphoV2.setTradingFee(id, 1000 ether, interestCutLimit);
@@ -304,12 +301,12 @@ contract TradingFeeTest is BaseTest {
         );
     }
 
-    function testSellBuyerAssetsInterestCutLimit(uint256 interestCutLimit, uint256 buyerTick, uint256 buyerAssets)
+    function testSellBuyerAssetsInterestCutLimit(uint256 interestCutLimit, int256 buyerTick, uint256 buyerAssets)
         public
     {
         buyerAssets = bound(buyerAssets, 0, MAX_TEST_AMOUNT);
         interestCutLimit = bound(interestCutLimit, 0, 0.1 ether);
-        buyerTick = bound(buyerTick, 0, 1000);
+        buyerTick = bound(buyerTick, MIN_TICK, MAX_TICK);
         uint256 buyerPrice = morphoV2.tickToPrice(buyerTick);
         vm.assume(buyerPrice >= 0.5e18);
         morphoV2.setTradingFee(id, 100_000 ether, interestCutLimit);
@@ -326,12 +323,12 @@ contract TradingFeeTest is BaseTest {
         assertApproxEqAbs(loanToken.balanceOf(feeRecipient), expectedFee, 100, "fee recipient balance");
     }
 
-    function testBuySellerAssetsInterestCutLimit(uint256 interestCutLimit, uint256 sellerTick, uint256 sellerAssets)
+    function testBuySellerAssetsInterestCutLimit(uint256 interestCutLimit, int256 sellerTick, uint256 sellerAssets)
         public
     {
         sellerAssets = bound(sellerAssets, 0, MAX_TEST_AMOUNT);
         interestCutLimit = bound(interestCutLimit, 0, 0.1 ether);
-        sellerTick = bound(sellerTick, 0, 1000);
+        sellerTick = bound(sellerTick, MIN_TICK, MAX_TICK);
         uint256 sellerPrice = morphoV2.tickToPrice(sellerTick);
         vm.assume(sellerPrice >= 0.5e18);
         morphoV2.setTradingFee(id, 100_000 ether, interestCutLimit);
@@ -349,12 +346,12 @@ contract TradingFeeTest is BaseTest {
         );
     }
 
-    function testSellSellerAssetsInterestCutLimit(uint256 interestCutLimit, uint256 buyerTick, uint256 sellerAssets)
+    function testSellSellerAssetsInterestCutLimit(uint256 interestCutLimit, int256 buyerTick, uint256 sellerAssets)
         public
     {
         sellerAssets = bound(sellerAssets, 0, MAX_TEST_AMOUNT);
         interestCutLimit = bound(interestCutLimit, 0, 0.1 ether);
-        buyerTick = bound(buyerTick, 0, 1000);
+        buyerTick = bound(buyerTick, MIN_TICK, MAX_TICK);
         uint256 buyerPrice = morphoV2.tickToPrice(buyerTick);
         vm.assume(buyerPrice >= 0.5e18);
         vm.assume(buyerPrice >= interestCutLimit);
@@ -375,12 +372,12 @@ contract TradingFeeTest is BaseTest {
 
     function testBuyObligationUnitsInterestCutLimit(
         uint256 interestCutLimit,
-        uint256 sellerTick,
+        int256 sellerTick,
         uint256 obligationUnits
     ) public {
         obligationUnits = bound(obligationUnits, 0, MAX_TEST_AMOUNT);
         interestCutLimit = bound(interestCutLimit, 0, 0.1 ether);
-        sellerTick = bound(sellerTick, 0, 1000);
+        sellerTick = bound(sellerTick, MIN_TICK, MAX_TICK);
         uint256 sellerPrice = morphoV2.tickToPrice(sellerTick);
         vm.assume(sellerPrice >= 0.5e18);
         morphoV2.setTradingFee(id, 1000 ether, interestCutLimit);
@@ -401,12 +398,12 @@ contract TradingFeeTest is BaseTest {
 
     function testSellObligationUnitsInterestCutLimit(
         uint256 interestCutLimit,
-        uint256 buyerTick,
+        int256 buyerTick,
         uint256 obligationUnits
     ) public {
         obligationUnits = bound(obligationUnits, 0, MAX_TEST_AMOUNT);
         interestCutLimit = bound(interestCutLimit, 0, 0.3 ether);
-        buyerTick = bound(buyerTick, 0, 1000);
+        buyerTick = bound(buyerTick, MIN_TICK, MAX_TICK);
         uint256 buyerPrice = morphoV2.tickToPrice(buyerTick);
         vm.assume(buyerPrice >= 0.5e18);
         vm.assume(buyerPrice >= interestCutLimit);
@@ -427,12 +424,12 @@ contract TradingFeeTest is BaseTest {
 
     function testBuyObligationSharesInterestCutLimit(
         uint256 interestCutLimit,
-        uint256 sellerTick,
+        int256 sellerTick,
         uint256 obligationShares
     ) public {
         obligationShares = bound(obligationShares, 0, MAX_TEST_AMOUNT);
         interestCutLimit = bound(interestCutLimit, 0, 0.1 ether);
-        sellerTick = bound(sellerTick, 0, 1000);
+        sellerTick = bound(sellerTick, MIN_TICK, MAX_TICK);
         uint256 sellerPrice = morphoV2.tickToPrice(sellerTick);
         vm.assume(sellerPrice >= 0.5e18);
         morphoV2.setTradingFee(id, 1000 ether, interestCutLimit);
@@ -455,12 +452,12 @@ contract TradingFeeTest is BaseTest {
 
     function testSellObligationSharesInterestCutLimit(
         uint256 interestCutLimit,
-        uint256 buyerTick,
+        int256 buyerTick,
         uint256 obligationShares
     ) public {
         obligationShares = bound(obligationShares, 0, MAX_TEST_AMOUNT);
         interestCutLimit = bound(interestCutLimit, 0, 0.3 ether);
-        buyerTick = bound(buyerTick, 0, 1000);
+        buyerTick = bound(buyerTick, MIN_TICK, MAX_TICK);
         uint256 buyerPrice = morphoV2.tickToPrice(buyerTick);
         vm.assume(buyerPrice >= 0.5e18);
         vm.assume(buyerPrice >= interestCutLimit);


### PR DESCRIPTION
see [this Notion page](https://www.notion.so/morpho-labs/Properties-of-roiToTick-2e1d69939e6d80c3bc3fc3e70e5d4717?source=copy_link) for a proof that it works

Using the function costs ~1.2k extra gas (function itself is <1k gas). Using `clz` saves an addition 150 gas.