### PR TITLE
[id to obligation] SSTORE

### DIFF
--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -38,6 +38,7 @@ contract MorphoV2 is IMorphoV2 {
     mapping(bytes32 id => mapping(address user => uint256)) public debtOf;
     mapping(bytes32 id => mapping(address user => mapping(address collateralToken => uint256))) public collateralOf;
     mapping(bytes32 id => ObligationStorage) public obligationStorage;
+    mapping(bytes32 id => Obligation) internal _idToObligation;
 
     /// @dev Groups are useful to have a global offered amount shared accross multiple offers ("OCO").
     /// @dev To work as expected, all offers in a same group should have the same assets, obligationUnits,
@@ -465,12 +466,18 @@ contract MorphoV2 is IMorphoV2 {
             obligationStorage[id].created = true;
             obligationStorage[id].fees = defaultFees[obligation.loanToken];
 
+            _idToObligation[id] = obligation;
+
             emit EventsLib.ObligationCreated(id, obligation);
         }
         return id;
     }
 
     /// VIEW FUNCTIONS ///
+
+    function idToObligation(bytes32 id) external view returns (Obligation memory) {
+        return _idToObligation[id];
+    }
 
     function totalUnits(bytes32 id) external view returns (uint256) {
         return obligationStorage[id].totalUnits;

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -213,6 +213,22 @@ abstract contract BaseTest is Test {
         return arr;
     }
 
+    // Returns an obligation with sorted, non-zero and unique collaterals (done by adding the index to the hash of the
+    // token).
+    function sortedAndUniqueCollateralsInObligation(Obligation memory obligation)
+        internal
+        pure
+        returns (Obligation memory)
+    {
+        Collateral[] memory collaterals = new Collateral[](obligation.collaterals.length);
+        for (uint256 i = 0; i < obligation.collaterals.length; i++) {
+            collaterals[i].token = address(uint160(uint256(keccak256(abi.encode(obligation.collaterals[i].token, i)))));
+        }
+        collaterals = sortCollaterals(collaterals);
+        obligation.collaterals = collaterals;
+        return obligation;
+    }
+
     function setupObligation(Obligation memory obligation, uint256 obligationUnits) internal {
         deal(address(loanToken), lender, obligationUnits);
 

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -156,14 +156,19 @@ contract OtherFunctionsTest is BaseTest {
         assertEq(morphoV2.consumed(user, group), amount, "consumed");
     }
 
-    function testIdToObligation(Obligation memory _obligation) public {
-        // Ensure collaterals are sorted, non-zero and unique (done by adding the index to the hash of the token).
-        Collateral[] memory collaterals = new Collateral[](_obligation.collaterals.length);
-        for (uint256 i = 0; i < _obligation.collaterals.length; i++) {
-            collaterals[i].token = address(uint160(uint256(keccak256(abi.encode(_obligation.collaterals[i].token, i)))));
+    function testTouchObligation(Obligation memory _obligation) public {
+        _obligation = sortedAndUniqueCollateralsInObligation(_obligation);
+
+        bytes32 _id = morphoV2.touchObligation(_obligation);
+        assertEq(morphoV2.obligationCreated(_id), true, "obligation created");
+        uint16[6] memory fees = morphoV2.fees(_id);
+        for (uint256 i = 0; i < 6; i++) {
+            assertEq(fees[i], morphoV2.defaultFees(_obligation.loanToken, i), "fees");
         }
-        collaterals = sortCollaterals(collaterals);
-        _obligation.collaterals = collaterals;
+    }
+
+    function testIdToObligation(Obligation memory _obligation) public {
+        _obligation = sortedAndUniqueCollateralsInObligation(_obligation);
 
         bytes32 _id = morphoV2.touchObligation(_obligation);
         Obligation memory obligationFromId = morphoV2.idToObligation(_id);

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -156,6 +156,27 @@ contract OtherFunctionsTest is BaseTest {
         assertEq(morphoV2.consumed(user, group), amount, "consumed");
     }
 
+    function testIdToObligation(Obligation memory _obligation) public {
+        // Ensure collaterals are sorted, non-zero and unique (done by adding the index to the hash of the token).
+        Collateral[] memory collaterals = new Collateral[](_obligation.collaterals.length);
+        for (uint256 i = 0; i < _obligation.collaterals.length; i++) {
+            collaterals[i].token = address(uint160(uint256(keccak256(abi.encode(_obligation.collaterals[i].token, i)))));
+        }
+        collaterals = sortCollaterals(collaterals);
+        _obligation.collaterals = collaterals;
+
+        bytes32 _id = morphoV2.touchObligation(_obligation);
+        Obligation memory obligationFromId = morphoV2.idToObligation(_id);
+        assertEq(_obligation.loanToken, obligationFromId.loanToken, "loanToken");
+        assertEq(_obligation.maturity, obligationFromId.maturity, "maturity");
+        assertEq(_obligation.collaterals.length, obligationFromId.collaterals.length, "collaterals length");
+        for (uint256 i = 0; i < obligationFromId.collaterals.length; i++) {
+            assertEq(_obligation.collaterals[i].token, obligationFromId.collaterals[i].token, "collateral token");
+            assertEq(_obligation.collaterals[i].lltv, obligationFromId.collaterals[i].lltv, "lltv");
+            assertEq(_obligation.collaterals[i].oracle, obligationFromId.collaterals[i].oracle, "oracle");
+        }
+    }
+
     function testShuffleSession(address user) public {
         vm.prank(user);
         morphoV2.shuffleSession();


### PR DESCRIPTION
Discussion [here](https://morpholabs.slack.com/archives/C08A40KKN9W/p1769605781960269)

Using an obligation with 2 collaterals, the id to obligation is isolated from the touch obligation

<img width="363" height="66" alt="Screenshot 2026-01-30 at 18 36 18" src="https://github.com/user-attachments/assets/d68d4742-e971-4d00-985e-76e169b0213b" />
