### PR TITLE
[obligation packing]: pack stored obligation in assembly

### DIFF
--- a/src/libraries/IdLib.sol
+++ b/src/libraries/IdLib.sol
@@ -95,36 +95,24 @@ library IdLib {
     function unpack(bytes memory data) internal pure returns (Obligation memory obligation) {
         require(data.length > 0, "empty data");
         unchecked {
-            address loanToken;
-            uint256 maturity;
-            uint8 len;
-            assembly ("memory-safe") {
-                let ptr := add(data, 32)
-                loanToken := shr(96, mload(add(ptr, 1)))
-                maturity := shr(208, mload(add(ptr, 21)))
-                len := shr(248, mload(add(ptr, 27)))
-            }
+            obligation.loanToken = address(uint160(get(data, 1) >> 96));
+            obligation.maturity = uint48(get(data, 21) >> 208);
+            uint8 len = uint8(data[27]);
 
-            obligation.loanToken = loanToken;
-            obligation.maturity = maturity;
-
-            Collateral[] memory collaterals = new Collateral[](len);
+            obligation.collaterals = new Collateral[](len);
 
             for (uint256 i = 0; i < len; i++) {
                 uint256 offset = 28 + i * 48;
-                address token;
-                uint256 lltv;
-                address oracle;
-                assembly ("memory-safe") {
-                    let ptr := add(add(data, 32), offset)
-                    token := shr(96, mload(ptr))
-                    lltv := shr(192, mload(add(ptr, 20)))
-                    oracle := shr(96, mload(add(ptr, 28)))
-                }
-                collaterals[i] = Collateral({token: token, lltv: lltv, oracle: oracle});
+                obligation.collaterals[i].token = address(uint160(get(data, offset) >> 96));
+                obligation.collaterals[i].lltv = uint64(get(data, offset + 20) >> 192);
+                obligation.collaterals[i].oracle = address(uint160(get(data, offset + 28) >> 96));
             }
+        }
+    }
 
-            obligation.collaterals = collaterals;
+    function get(bytes memory data, uint256 offset) private pure returns (uint256 w) {
+        assembly ("memory-safe") {
+            w := mload(add(add(data, 32), offset))
         }
     }
 }

--- a/src/libraries/IdLib.sol
+++ b/src/libraries/IdLib.sol
@@ -92,6 +92,8 @@ library IdLib {
         }
     }
 
+    /// @dev Unpacks a packed representation of the obligation.
+    /// @dev Should only be used on data known to be a packed obligation.
     function unpack(bytes memory data) internal pure returns (Obligation memory obligation) {
         require(data.length > 0, "empty data");
         unchecked {

--- a/src/libraries/IdLib.sol
+++ b/src/libraries/IdLib.sol
@@ -2,7 +2,7 @@
 // Copyright (c) 2025 Morpho Association
 pragma solidity ^0.8.0;
 
-import {Obligation} from "../interfaces/IMorphoV2.sol";
+import {Obligation, Collateral} from "../interfaces/IMorphoV2.sol";
 
 library IdLib {
     /// @dev Creation code that returns the code after the prefix as runtime bytecode, except for the first 52 bytes.
@@ -24,7 +24,7 @@ library IdLib {
         returns (bytes memory)
     {
         bytes memory prefix = hex"603f380380603f5f395ff3";
-        return abi.encodePacked(prefix, chainId, morphoV2, abi.encode(obligation));
+        return abi.encodePacked(prefix, chainId, morphoV2, pack(obligation));
     }
 
     function toId(Obligation memory obligation, uint256 chainId, address morphoV2) internal pure returns (bytes32) {
@@ -34,11 +34,11 @@ library IdLib {
     function idToObligation(bytes32 id, address morphoV2) internal view returns (Obligation memory) {
         address create2Address =
             address(uint160(uint256(keccak256(abi.encodePacked(uint8(0xff), morphoV2, bytes32(0), id)))));
-        return abi.decode(create2Address.code, (Obligation));
+        return unpack(create2Address.code);
     }
 
-    /// @dev Deploys a contract with runtime code = abi.encode(obligation)
-    /// @dev The contract code begins with 0x00 (STOP), because the first word is the offset of the obligation.
+    /// @dev Deploys a contract with runtime code = pack(obligation)
+    /// @dev The contract code begins with 0x00 (STOP) for safety.
     function storeInCode(Obligation memory obligation) internal {
         bytes memory _creationCode = creationCode(obligation, block.chainid, address(this));
         address create2Address;
@@ -46,5 +46,85 @@ library IdLib {
             create2Address := create2(0, add(_creationCode, 0x20), mload(_creationCode), 0)
         }
         require(create2Address != address(0), "Failed to create SStore2 contract");
+    }
+
+    /// @dev Returns a packed representation of the obligation.
+    /// @dev The maturity must fit on 6 bytes.
+    /// @dev The collateral count must fit on 1 byte.
+    /// @dev All lltvs must fit on 8 bytes.
+    function pack(Obligation memory obligation) internal pure returns (bytes memory result) {
+        require(obligation.maturity <= type(uint48).max, "maturity too large");
+        require(obligation.collaterals.length <= type(uint8).max, "collateral count too large");
+        Collateral[] memory collaterals = obligation.collaterals;
+        uint256 len = collaterals.length;
+
+        uint256 ptr;
+        assembly ("memory-safe") {
+            result := mload(0x40)
+            let size := add(28, mul(len, 48))
+            mstore(result, size)
+
+            ptr := add(result, 32)
+            // [stop, 1 byte][loanToken, 20 bytes][maturity, 6 bytes][collateral count, 1 byte]
+            let header := or(or(shl(88, mload(obligation)), shl(40, mload(add(obligation, 0x40)))), shl(32, len))
+            mstore(ptr, header)
+            ptr := add(ptr, 28)
+        }
+
+        for (uint256 i = 0; i < len; i++) {
+            Collateral memory c = collaterals[i];
+            require(c.lltv <= type(uint64).max, "lltv too large");
+
+            assembly ("memory-safe") {
+                // [token, 20 bytes][lltv, 8 bytes]
+                mstore(ptr, or(shl(96, mload(c)), shl(32, mload(add(c, 0x20)))))
+                ptr := add(ptr, 28)
+
+                // [oracle, 20 bytes]
+                mstore(ptr, shl(96, mload(add(c, 0x40))))
+                ptr := add(ptr, 20)
+            }
+        }
+
+        assembly ("memory-safe") {
+            // Round up to the next 32-byte word for the free memory pointer.
+            mstore(0x40, and(add(ptr, 31), not(31)))
+        }
+    }
+
+    function unpack(bytes memory data) internal pure returns (Obligation memory obligation) {
+        require(data.length > 0, "empty data");
+        unchecked {
+            address loanToken;
+            uint256 maturity;
+            uint8 len;
+            assembly ("memory-safe") {
+                let ptr := add(data, 32)
+                loanToken := shr(96, mload(add(ptr, 1)))
+                maturity := shr(208, mload(add(ptr, 21)))
+                len := shr(248, mload(add(ptr, 27)))
+            }
+
+            obligation.loanToken = loanToken;
+            obligation.maturity = maturity;
+
+            Collateral[] memory collaterals = new Collateral[](len);
+
+            for (uint256 i = 0; i < len; i++) {
+                uint256 offset = 28 + i * 48;
+                address token;
+                uint256 lltv;
+                address oracle;
+                assembly ("memory-safe") {
+                    let ptr := add(add(data, 32), offset)
+                    token := shr(96, mload(ptr))
+                    lltv := shr(192, mload(add(ptr, 20)))
+                    oracle := shr(96, mload(add(ptr, 28)))
+                }
+                collaterals[i] = Collateral({token: token, lltv: lltv, oracle: oracle});
+            }
+
+            obligation.collaterals = collaterals;
+        }
     }
 }

--- a/src/libraries/IdLib.sol
+++ b/src/libraries/IdLib.sol
@@ -53,42 +53,43 @@ library IdLib {
     /// @dev The collateral count must fit on 1 byte.
     /// @dev All lltvs must fit on 8 bytes.
     function pack(Obligation memory obligation) internal pure returns (bytes memory result) {
-        require(obligation.maturity <= type(uint48).max, "maturity too large");
-        require(obligation.collaterals.length <= type(uint8).max, "collateral count too large");
-        Collateral[] memory collaterals = obligation.collaterals;
-        uint256 len = collaterals.length;
+        unchecked {
+            require(obligation.maturity <= type(uint48).max, "maturity too large");
+            require(obligation.collaterals.length <= type(uint8).max, "collateral count too large");
 
-        uint256 ptr;
-        assembly ("memory-safe") {
-            result := mload(0x40)
-            let size := add(28, mul(len, 48))
-            mstore(result, size)
-
-            ptr := add(result, 32)
-            // [stop, 1 byte][loanToken, 20 bytes][maturity, 6 bytes][collateral count, 1 byte]
-            let header := or(or(shl(88, mload(obligation)), shl(40, mload(add(obligation, 0x40)))), shl(32, len))
-            mstore(ptr, header)
-            ptr := add(ptr, 28)
-        }
-
-        for (uint256 i = 0; i < len; i++) {
-            Collateral memory c = collaterals[i];
-            require(c.lltv <= type(uint64).max, "lltv too large");
+            Collateral[] memory collaterals = obligation.collaterals;
+            uint256 len = collaterals.length;
 
             assembly ("memory-safe") {
-                // [token, 20 bytes][lltv, 8 bytes]
-                mstore(ptr, or(shl(96, mload(c)), shl(32, mload(add(c, 0x20)))))
-                ptr := add(ptr, 28)
+                result := mload(0x40)
+                mstore(result, add(28, mul(len, 48)))
+                mstore(0x40, add(result, mul(add(len, 1), 64)))
+            }
 
-                // [oracle, 20 bytes]
-                mstore(ptr, shl(96, mload(add(c, 0x40))))
-                ptr := add(ptr, 20)
+            set(result, 0, 0, 8); // stop
+            set(result, 1, uint256(uint160(obligation.loanToken)), 160);
+            set(result, 21, obligation.maturity, 48);
+            set(result, 27, len, 8);
+
+            for (uint256 i = 0; i < len; i++) {
+                uint256 pointer;
+                assembly ("memory-safe") {
+                    pointer := mload(add(add(collaterals, 32), mul(32, i)))
+                }
+                uint256 lltv = get(pointer, 32, 256);
+                require(lltv <= type(uint64).max, "lltv too large");
+                uint256 offset = 28 + i * 48;
+
+                set(result, offset, get(pointer, 0, 256), 160);
+                set(result, offset + 20, lltv, 64);
+                set(result, offset + 28, get(pointer, 64, 256), 160);
             }
         }
+    }
 
+    function set(bytes memory data, uint256 offset, uint256 value, uint256 bits) private pure {
         assembly ("memory-safe") {
-            // Round up to the next 32-byte word for the free memory pointer.
-            mstore(0x40, and(add(ptr, 31), not(31)))
+            mstore(add(add(data, 32), offset), shl(sub(256, bits), value))
         }
     }
 
@@ -97,24 +98,30 @@ library IdLib {
     function unpack(bytes memory data) internal pure returns (Obligation memory obligation) {
         require(data.length > 0, "empty data");
         unchecked {
-            obligation.loanToken = address(uint160(get(data, 1) >> 96));
-            obligation.maturity = uint48(get(data, 21) >> 208);
-            uint8 len = uint8(data[27]);
+            obligation.loanToken = address(uint160(getArray(data, 1, 160)));
+            obligation.maturity = uint48(getArray(data, 21, 48));
+            uint8 len = uint8(getArray(data, 27, 8));
 
             obligation.collaterals = new Collateral[](len);
 
             for (uint256 i = 0; i < len; i++) {
                 uint256 offset = 28 + i * 48;
-                obligation.collaterals[i].token = address(uint160(get(data, offset) >> 96));
-                obligation.collaterals[i].lltv = uint64(get(data, offset + 20) >> 192);
-                obligation.collaterals[i].oracle = address(uint160(get(data, offset + 28) >> 96));
+                obligation.collaterals[i].token = address(uint160(getArray(data, offset, 160)));
+                obligation.collaterals[i].lltv = uint64(getArray(data, offset + 20, 64));
+                obligation.collaterals[i].oracle = address(uint160(getArray(data, offset + 28, 160)));
             }
         }
     }
 
-    function get(bytes memory data, uint256 offset) private pure returns (uint256 w) {
+    function get(uint256 pointer, uint256 offset, uint256 size) private pure returns (uint256 w) {
         assembly ("memory-safe") {
-            w := mload(add(add(data, 32), offset))
+            w := shr(sub(256, size), mload(add(pointer, offset)))
+        }
+    }
+
+    function getArray(bytes memory data, uint256 offset, uint256 size) private pure returns (uint256 w) {
+        assembly ("memory-safe") {
+            w := shr(sub(256, size), mload(add(add(data, 32), offset)))
         }
     }
 }

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -265,4 +265,16 @@ abstract contract BaseTest is Test {
     function absDiff(uint256 a, uint256 b) internal pure returns (uint256) {
         return a > b ? a - b : b - a;
     }
+
+    function boundObligation(Obligation memory obligation) internal pure {
+        obligation.maturity = bound(obligation.maturity, 0, type(uint48).max);
+        uint256 len = bound(obligation.collaterals.length, 0, type(uint8).max);
+        Collateral[] memory collaterals = new Collateral[](len);
+        for (uint256 i = 0; i < len; i++) {
+            collaterals[i] = obligation.collaterals[i];
+            collaterals[i].lltv = bound(obligation.collaterals[i].lltv, 0, type(uint64).max);
+            collaterals[i].oracle = obligation.collaterals[i].oracle;
+        }
+        obligation.collaterals = collaterals;
+    }
 }

--- a/test/IdLibTest.sol
+++ b/test/IdLibTest.sol
@@ -1,18 +1,20 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {Test} from "../lib/forge-std/src/Test.sol";
+import {BaseTest} from "./BaseTest.sol";
 import {IdLib} from "../src/libraries/IdLib.sol";
-import {Obligation} from "../src/interfaces/IMorphoV2.sol";
+import {Obligation, Collateral} from "../src/interfaces/IMorphoV2.sol";
 
 // idToObligation is tested in OtherFunctionsTest.sol, to test actual implementation (avoid introducing mocks).
-contract IdLibTest is Test {
+contract IdLibTest is BaseTest {
     function testToIdIsInjectiveInObligation(
         Obligation memory obligation1,
         Obligation memory obligation2,
         uint256 chainid,
         address morphoV2
     ) public pure {
+        boundObligation(obligation1);
+        boundObligation(obligation2);
         bool sameLoanToken = obligation1.loanToken == obligation2.loanToken;
         bool sameMaturity = obligation1.maturity == obligation2.maturity;
         bool sameCollaterals = obligation1.collaterals.length == obligation2.collaterals.length;
@@ -36,6 +38,7 @@ contract IdLibTest is Test {
         uint256 chainid2,
         address morphoV2
     ) public pure {
+        boundObligation(obligation);
         vm.assume(chainid1 != chainid2);
         bytes32 id1 = IdLib.toId(obligation, chainid1, morphoV2);
         bytes32 id2 = IdLib.toId(obligation, chainid2, morphoV2);
@@ -48,9 +51,78 @@ contract IdLibTest is Test {
         address morphoV2One,
         address morphoV2Two
     ) public pure {
+        boundObligation(obligation);
         vm.assume(morphoV2One != morphoV2Two);
         bytes32 id1 = IdLib.toId(obligation, chainid, morphoV2One);
         bytes32 id2 = IdLib.toId(obligation, chainid, morphoV2Two);
         assertNotEq(id1, id2);
+    }
+
+    function testRoundtrip(Obligation memory obligation) public {
+        boundObligation(obligation);
+
+        IdLib.storeInCode(obligation);
+
+        bytes32 id = IdLib.toId(obligation, block.chainid, address(this));
+        Obligation memory decoded = IdLib.idToObligation(id, address(this));
+
+        assertEq(decoded.loanToken, obligation.loanToken);
+        assertEq(decoded.maturity, obligation.maturity);
+        assertEq(decoded.collaterals.length, obligation.collaterals.length);
+        for (uint256 i = 0; i < obligation.collaterals.length; i++) {
+            assertEq(decoded.collaterals[i].token, obligation.collaterals[i].token);
+            assertEq(decoded.collaterals[i].lltv, obligation.collaterals[i].lltv);
+            assertEq(decoded.collaterals[i].oracle, obligation.collaterals[i].oracle);
+        }
+    }
+
+    function testPackUnpackRoundtrip(Obligation memory obligation) public pure {
+        boundObligation(obligation);
+
+        bytes memory packed = IdLib.pack(obligation);
+        Obligation memory decoded = IdLib.unpack(packed);
+
+        assertEq(decoded.loanToken, obligation.loanToken);
+        assertEq(decoded.maturity, obligation.maturity);
+        assertEq(decoded.collaterals.length, obligation.collaterals.length);
+        for (uint256 i = 0; i < obligation.collaterals.length; i++) {
+            assertEq(decoded.collaterals[i].token, obligation.collaterals[i].token);
+            assertEq(decoded.collaterals[i].lltv, obligation.collaterals[i].lltv);
+            assertEq(decoded.collaterals[i].oracle, obligation.collaterals[i].oracle);
+        }
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testUnpackEmptyReverts() public {
+        vm.expectRevert();
+        IdLib.unpack("");
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testPackRejectsLargeLltv() public {
+        Obligation memory obligation;
+        obligation.collaterals = new Collateral[](1);
+        obligation.collaterals[0].lltv = uint256(type(uint64).max) + 1;
+
+        vm.expectRevert("lltv too large");
+        IdLib.pack(obligation);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testPackRejectsLargeMaturity() public {
+        Obligation memory obligation;
+        obligation.maturity = uint256(type(uint64).max) + 1;
+
+        vm.expectRevert("maturity too large");
+        IdLib.pack(obligation);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testPackRejectsTooManyCollaterals() public {
+        Obligation memory obligation;
+        obligation.collaterals = new Collateral[](uint256(type(uint8).max) + 1);
+
+        vm.expectRevert("collateral count too large");
+        IdLib.pack(obligation);
     }
 }

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -162,6 +162,7 @@ contract OtherFunctionsTest is BaseTest {
     }
 
     function testTouchObligation(Obligation memory _obligation) public {
+        boundObligation(_obligation);
         _obligation = sortedAndUniqueCollateralsInObligation(_obligation);
 
         bytes32 _id = morphoV2.touchObligation(_obligation);
@@ -173,6 +174,7 @@ contract OtherFunctionsTest is BaseTest {
     }
 
     function testIdToObligation(Obligation memory _obligation) public {
+        boundObligation(_obligation);
         _obligation = sortedAndUniqueCollateralsInObligation(_obligation);
 
         bytes32 _id = morphoV2.touchObligation(_obligation);
@@ -188,6 +190,7 @@ contract OtherFunctionsTest is BaseTest {
     }
 
     function testSstore2CodeStartsWithStop(Obligation memory _obligation) public {
+        boundObligation(_obligation);
         _obligation = sortedAndUniqueCollateralsInObligation(_obligation);
 
         bytes32 _id = morphoV2.touchObligation(_obligation);


### PR DESCRIPTION
* saves 35k gas when storing an obligation in code
* toId is cheaper up to 6 collaterals

