### PR TITLE
Obligation level min collat quoted in loan without liquidation

### DIFF
--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -320,6 +320,21 @@ contract MorphoV2 is IMorphoV2 {
 
         collateralOf[id][onBehalf][collateral] += assets;
 
+        uint256 collateralIndex = 0;
+        for (
+            ;
+            collateralIndex < obligation.collaterals.length
+                && obligation.collaterals[collateralIndex].token != collateral;
+            collateralIndex++
+        ) {}
+        uint256 collateralPrice = IOracle(obligation.collaterals[collateralIndex].oracle).price();
+        uint256 collateralValue = collateralOf[id][onBehalf][collateral].mulDivDown(collateralPrice, ORACLE_PRICE_SCALE);
+
+        require(
+            collateralOf[id][onBehalf][collateral] == 0 || collateralValue >= obligation.minCollateral,
+            "Below min collateral"
+        );
+
         emit EventsLib.SupplyCollateral(msg.sender, id, collateral, assets, onBehalf);
 
         SafeTransferLib.safeTransferFrom(collateral, msg.sender, address(this), assets);
@@ -333,6 +348,20 @@ contract MorphoV2 is IMorphoV2 {
         collateralOf[id][onBehalf][collateral] -= assets;
 
         require(isHealthy(obligation, id, onBehalf), "Unhealthy borrower");
+
+        uint256 collateralIndex = 0;
+        for (
+            ;
+            collateralIndex < obligation.collaterals.length
+                && obligation.collaterals[collateralIndex].token != collateral;
+            collateralIndex++
+        ) {}
+        uint256 collateralPrice = IOracle(obligation.collaterals[collateralIndex].oracle).price();
+        uint256 collateralValue = collateralOf[id][onBehalf][collateral].mulDivDown(collateralPrice, ORACLE_PRICE_SCALE);
+        require(
+            collateralOf[id][onBehalf][collateral] == 0 || collateralValue >= obligation.minCollateral,
+            "Below min collateral"
+        );
 
         emit EventsLib.WithdrawCollateral(msg.sender, id, collateral, assets, onBehalf);
 

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -317,40 +317,40 @@ contract MorphoV2 is IMorphoV2 {
         external
     {
         bytes32 id = touchObligation(obligation);
-        address collateral = obligation.collaterals[collateralIndex].token;
+        address collateralToken = obligation.collaterals[collateralIndex].token;
 
-        collateralOf[id][onBehalf][collateral] += assets;
+        collateralOf[id][onBehalf][collateralToken] += assets;
 
         uint256 collateralPrice = IOracle(obligation.collaterals[collateralIndex].oracle).price();
-        uint256 _collateralOf = collateralOf[id][onBehalf][collateral];
+        uint256 _collateralOf = collateralOf[id][onBehalf][collateralToken];
         uint256 collateralValue = _collateralOf.mulDivDown(collateralPrice, ORACLE_PRICE_SCALE);
 
         require(_collateralOf == 0 || collateralValue >= obligation.minCollateral, "Below min collateral");
 
-        emit EventsLib.SupplyCollateral(msg.sender, id, collateral, assets, onBehalf);
+        emit EventsLib.SupplyCollateral(msg.sender, id, collateralToken, assets, onBehalf);
 
-        SafeTransferLib.safeTransferFrom(collateral, msg.sender, address(this), assets);
+        SafeTransferLib.safeTransferFrom(collateralToken, msg.sender, address(this), assets);
     }
 
     function withdrawCollateral(Obligation memory obligation, uint256 collateralIndex, uint256 assets, address onBehalf)
         external
     {
         bytes32 id = touchObligation(obligation);
-        address collateral = obligation.collaterals[collateralIndex].token;
+        address collateralToken = obligation.collaterals[collateralIndex].token;
 
-        collateralOf[id][onBehalf][collateral] -= assets;
+        collateralOf[id][onBehalf][collateralToken] -= assets;
 
         require(isHealthy(obligation, id, onBehalf), "Unhealthy borrower");
 
         uint256 collateralPrice = IOracle(obligation.collaterals[collateralIndex].oracle).price();
-        uint256 _collateralOf = collateralOf[id][onBehalf][collateral];
+        uint256 _collateralOf = collateralOf[id][onBehalf][collateralToken];
         uint256 collateralValue = _collateralOf.mulDivDown(collateralPrice, ORACLE_PRICE_SCALE);
 
         require(_collateralOf == 0 || collateralValue >= obligation.minCollateral, "Below min collateral");
 
-        emit EventsLib.WithdrawCollateral(msg.sender, id, collateral, assets, onBehalf);
+        emit EventsLib.WithdrawCollateral(msg.sender, id, collateralToken, assets, onBehalf);
 
-        SafeTransferLib.safeTransfer(collateral, msg.sender, assets);
+        SafeTransferLib.safeTransfer(collateralToken, msg.sender, assets);
     }
 
     /// @dev At least one of `repaidUnits` or `seizedAssets` should be equal to zero.

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -322,12 +322,10 @@ contract MorphoV2 is IMorphoV2 {
         collateralOf[id][onBehalf][collateral] += assets;
 
         uint256 collateralPrice = IOracle(obligation.collaterals[collateralIndex].oracle).price();
-        uint256 collateralValue = collateralOf[id][onBehalf][collateral].mulDivDown(collateralPrice, ORACLE_PRICE_SCALE);
+        uint256 _collateralOf = collateralOf[id][onBehalf][collateral];
+        uint256 collateralValue = _collateralOf.mulDivDown(collateralPrice, ORACLE_PRICE_SCALE);
 
-        require(
-            collateralOf[id][onBehalf][collateral] == 0 || collateralValue >= obligation.minCollateral,
-            "Below min collateral"
-        );
+        require(_collateralOf == 0 || collateralValue >= obligation.minCollateral, "Below min collateral");
 
         emit EventsLib.SupplyCollateral(msg.sender, id, collateral, assets, onBehalf);
 
@@ -345,11 +343,10 @@ contract MorphoV2 is IMorphoV2 {
         require(isHealthy(obligation, id, onBehalf), "Unhealthy borrower");
 
         uint256 collateralPrice = IOracle(obligation.collaterals[collateralIndex].oracle).price();
-        uint256 collateralValue = collateralOf[id][onBehalf][collateral].mulDivDown(collateralPrice, ORACLE_PRICE_SCALE);
-        require(
-            collateralOf[id][onBehalf][collateral] == 0 || collateralValue >= obligation.minCollateral,
-            "Below min collateral"
-        );
+        uint256 _collateralOf = collateralOf[id][onBehalf][collateral];
+        uint256 collateralValue = _collateralOf.mulDivDown(collateralPrice, ORACLE_PRICE_SCALE);
+
+        require(_collateralOf == 0 || collateralValue >= obligation.minCollateral, "Below min collateral");
 
         emit EventsLib.WithdrawCollateral(msg.sender, id, collateral, assets, onBehalf);
 

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -503,6 +503,7 @@ contract MorphoV2 is IMorphoV2 {
     }
 
     /// @dev This function should be called with the id corresponding to the obligation.
+    /// @dev This function does not call the oracle if debt is 0.
     function isHealthy(Obligation memory obligation, bytes32 id, address borrower) public view returns (bool) {
         uint256 debt = debtOf[id][borrower];
         uint256 maxDebt;

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -313,6 +313,7 @@ contract MorphoV2 is IMorphoV2 {
         SafeTransferLib.safeTransferFrom(obligation.loanToken, msg.sender, address(this), obligationUnits);
     }
 
+    /// @dev This function does not call the oracle if the collateral balance is 0 after the update.
     function supplyCollateral(Obligation memory obligation, uint256 collateralIndex, uint256 assets, address onBehalf)
         external
     {
@@ -321,17 +322,20 @@ contract MorphoV2 is IMorphoV2 {
 
         collateralOf[id][onBehalf][collateralToken] += assets;
 
-        uint256 collateralPrice = IOracle(obligation.collaterals[collateralIndex].oracle).price();
+        address oracle = obligation.collaterals[collateralIndex].oracle;
         uint256 _collateralOf = collateralOf[id][onBehalf][collateralToken];
-        uint256 collateralValue = _collateralOf.mulDivDown(collateralPrice, ORACLE_PRICE_SCALE);
-
-        require(_collateralOf == 0 || collateralValue >= obligation.minCollateral, "Below min collateral");
+        require(
+            _collateralOf == 0
+                || _collateralOf.mulDivDown(IOracle(oracle).price(), ORACLE_PRICE_SCALE) >= obligation.minCollateral,
+            "Below min collateral"
+        );
 
         emit EventsLib.SupplyCollateral(msg.sender, id, collateralToken, assets, onBehalf);
 
         SafeTransferLib.safeTransferFrom(collateralToken, msg.sender, address(this), assets);
     }
 
+    /// @dev This function does not call the oracle if the collateral balance is 0 after the update.
     function withdrawCollateral(Obligation memory obligation, uint256 collateralIndex, uint256 assets, address onBehalf)
         external
     {
@@ -342,11 +346,13 @@ contract MorphoV2 is IMorphoV2 {
 
         require(isHealthy(obligation, id, onBehalf), "Unhealthy borrower");
 
-        uint256 collateralPrice = IOracle(obligation.collaterals[collateralIndex].oracle).price();
+        address oracle = obligation.collaterals[collateralIndex].oracle;
         uint256 _collateralOf = collateralOf[id][onBehalf][collateralToken];
-        uint256 collateralValue = _collateralOf.mulDivDown(collateralPrice, ORACLE_PRICE_SCALE);
-
-        require(_collateralOf == 0 || collateralValue >= obligation.minCollateral, "Below min collateral");
+        require(
+            _collateralOf == 0
+                || _collateralOf.mulDivDown(IOracle(oracle).price(), ORACLE_PRICE_SCALE) >= obligation.minCollateral,
+            "Below min collateral"
+        );
 
         emit EventsLib.WithdrawCollateral(msg.sender, id, collateralToken, assets, onBehalf);
 

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -415,7 +415,7 @@ contract MorphoV2 is IMorphoV2 {
                     - _collateralOf.mulDivDown(liquidatedCollateralPrice, ORACLE_PRICE_SCALE).mulDivDown(lltv, WAD)
                     + (_collateralOf - seizedAssets).mulDivDown(liquidatedCollateralPrice, ORACLE_PRICE_SCALE)
                         .mulDivDown(lltv, WAD);
-                require(originalDebt - repaidUnits >= newMaxDebt, "recovery close factor violated");
+                require(originalDebt - badDebt - repaidUnits >= newMaxDebt, "recovery close factor violated");
             }
 
             collateralOf[id][borrower][liquidatedCollateralToken] -= seizedAssets;

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -313,20 +313,14 @@ contract MorphoV2 is IMorphoV2 {
         SafeTransferLib.safeTransferFrom(obligation.loanToken, msg.sender, address(this), obligationUnits);
     }
 
-    function supplyCollateral(Obligation memory obligation, address collateral, uint256 assets, address onBehalf)
+    function supplyCollateral(Obligation memory obligation, uint256 collateralIndex, uint256 assets, address onBehalf)
         external
     {
         bytes32 id = touchObligation(obligation);
+        address collateral = obligation.collaterals[collateralIndex].token;
 
         collateralOf[id][onBehalf][collateral] += assets;
 
-        uint256 collateralIndex = 0;
-        for (
-            ;
-            collateralIndex < obligation.collaterals.length
-                && obligation.collaterals[collateralIndex].token != collateral;
-            collateralIndex++
-        ) {}
         uint256 collateralPrice = IOracle(obligation.collaterals[collateralIndex].oracle).price();
         uint256 collateralValue = collateralOf[id][onBehalf][collateral].mulDivDown(collateralPrice, ORACLE_PRICE_SCALE);
 
@@ -340,22 +334,16 @@ contract MorphoV2 is IMorphoV2 {
         SafeTransferLib.safeTransferFrom(collateral, msg.sender, address(this), assets);
     }
 
-    function withdrawCollateral(Obligation memory obligation, address collateral, uint256 assets, address onBehalf)
+    function withdrawCollateral(Obligation memory obligation, uint256 collateralIndex, uint256 assets, address onBehalf)
         external
     {
         bytes32 id = touchObligation(obligation);
+        address collateral = obligation.collaterals[collateralIndex].token;
 
         collateralOf[id][onBehalf][collateral] -= assets;
 
         require(isHealthy(obligation, id, onBehalf), "Unhealthy borrower");
 
-        uint256 collateralIndex = 0;
-        for (
-            ;
-            collateralIndex < obligation.collaterals.length
-                && obligation.collaterals[collateralIndex].token != collateral;
-            collateralIndex++
-        ) {}
         uint256 collateralPrice = IOracle(obligation.collaterals[collateralIndex].oracle).price();
         uint256 collateralValue = collateralOf[id][onBehalf][collateral].mulDivDown(collateralPrice, ORACLE_PRICE_SCALE);
         require(

--- a/src/interfaces/IMorphoV2.sol
+++ b/src/interfaces/IMorphoV2.sol
@@ -7,7 +7,8 @@ struct Obligation {
     // Must be sorted by address.
     Collateral[] collaterals;
     uint256 maturity;
-    uint256 minCollateral; // quoted in loan token
+    // Minimum collateral value (quoted in loan token) to be left on supply & withdraw collateral.
+    uint256 minCollateral;
 }
 
 struct Collateral {

--- a/src/interfaces/IMorphoV2.sol
+++ b/src/interfaces/IMorphoV2.sol
@@ -7,6 +7,7 @@ struct Obligation {
     // Must be sorted by address.
     Collateral[] collaterals;
     uint256 maturity;
+    uint256 minCollateral; // quoted in loan token
 }
 
 struct Collateral {

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -75,7 +75,7 @@ abstract contract BaseTest is Test {
         uint256 collateral = debt.mulDivUp(WAD, obligation.collaterals[0].lltv);
         deal(address(obligation.collaterals[0].token), address(this), collateral);
         collateralToken1.approve(address(morphoV2), collateral);
-        morphoV2.supplyCollateral(obligation, address(obligation.collaterals[0].token), collateral, _borrower);
+        morphoV2.supplyCollateral(obligation, 0, collateral, _borrower);
     }
 
     // hardcodes the right root, signature, proof, and callback (no callback)
@@ -135,7 +135,7 @@ abstract contract BaseTest is Test {
         badBorrowerOffer.tick = TICK_RANGE;
 
         deal(obligation.collaterals[0].token, address(this), 135);
-        morphoV2.supplyCollateral(obligation, obligation.collaterals[0].token, 135, badBorrower);
+        morphoV2.supplyCollateral(obligation, 0, 135, badBorrower);
 
         deal(address(loanToken), unluckyLender, 100);
 

--- a/test/IdLibTest.sol
+++ b/test/IdLibTest.sol
@@ -16,6 +16,7 @@ contract IdLibTest is Test {
         bool sameLoanToken = obligation1.loanToken == obligation2.loanToken;
         bool sameMaturity = obligation1.maturity == obligation2.maturity;
         bool sameCollaterals = obligation1.collaterals.length == obligation2.collaterals.length;
+        bool sameMinCollateral = obligation1.minCollateral == obligation2.minCollateral;
         if (sameCollaterals) {
             for (uint256 i = 0; i < obligation1.collaterals.length; i++) {
                 if (obligation1.collaterals[i].token != obligation2.collaterals[i].token) sameCollaterals = false;
@@ -23,7 +24,8 @@ contract IdLibTest is Test {
                 if (obligation1.collaterals[i].oracle != obligation2.collaterals[i].oracle) sameCollaterals = false;
             }
         }
-        vm.assume(!(sameLoanToken && sameMaturity && sameCollaterals));
+
+        vm.assume(!(sameLoanToken && sameMaturity && sameCollaterals && sameMinCollateral));
 
         bytes32 id1 = IdLib.toId(obligation1, chainid, morphoV2);
         bytes32 id2 = IdLib.toId(obligation2, chainid, morphoV2);

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -6,6 +6,7 @@ import {MAX_LIF, WAD, ORACLE_PRICE_SCALE, TIME_TO_MAX_LIF} from "../src/librarie
 import {Obligation, Collateral} from "../src/interfaces/IMorphoV2.sol";
 import {UtilsLib} from "../src/libraries/UtilsLib.sol";
 import {Oracle} from "./helpers/Oracle.sol";
+import {ERC20} from "./helpers/ERC20.sol";
 import {BaseTest, MAX_TEST_AMOUNT} from "./BaseTest.sol";
 import {stdError} from "../lib/forge-std/src/StdError.sol";
 
@@ -313,6 +314,52 @@ contract LiquidationTest is BaseTest {
 
         vm.expectRevert("recovery close factor violated");
         morphoV2.liquidate(obligation, 0, units, 0, borrower, "");
+    }
+
+    // gas tests
+
+    /// forge-config: default.isolate = true
+    function testGasLiquidateMultipleCollaterals() public {
+        uint256 units = 1000e18;
+        uint256 collateralAmount = units.mulDivUp(WAD, obligation.collaterals[0].lltv);
+
+        // Supply both collaterals.
+        for (uint256 i = 0; i < 2; i++) {
+            address token = obligation.collaterals[i].token;
+            deal(token, address(this), collateralAmount);
+            ERC20(token).approve(address(morphoV2), collateralAmount);
+            morphoV2.supplyCollateral(obligation, token, collateralAmount, borrower);
+        }
+
+        setupObligation(obligation, units);
+
+        // Make position liquidatable.
+        oracle1.setPrice(0.5e36);
+        oracle2.setPrice(0.5e36);
+        vm.warp(obligation.maturity + TIME_TO_MAX_LIF);
+        deal(address(loanToken), address(this), units);
+        uint256 repay = units / 2;
+
+        uint256 snapshot = vm.snapshotState();
+
+        // Multicall with 1 liquidation.
+        bytes[] memory calls1 = new bytes[](1);
+        calls1[0] = abi.encodeCall(morphoV2.liquidate, (obligation, 0, repay, 0, borrower, ""));
+        uint256 gasBefore1 = gasleft();
+        morphoV2.multicall(calls1);
+        uint256 gas1 = gasBefore1 - gasleft();
+        vm.revertToState(snapshot);
+
+        // Multicall with 2 liquidations.
+        bytes[] memory calls2 = new bytes[](2);
+        calls2[0] = abi.encodeCall(morphoV2.liquidate, (obligation, 0, repay, 0, borrower, ""));
+        calls2[1] = abi.encodeCall(morphoV2.liquidate, (obligation, 1, repay, 0, borrower, ""));
+        uint256 gasBefore2 = gasleft();
+        morphoV2.multicall(calls2);
+        uint256 gas2 = gasBefore2 - gasleft();
+
+        emit log_named_uint("Gas 1st seizure (cold)", gas1);
+        emit log_named_uint("Gas 2nd seizure (warm)", gas2 - gas1);
     }
 
     // helpers.

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -28,6 +28,7 @@ contract LiquidationTest is BaseTest {
         obligation.collaterals
             .push(Collateral({token: address(collateralToken2), lltv: 0.75e18, oracle: address(oracle2)}));
         obligation.collaterals = sortCollaterals(obligation.collaterals);
+        obligation.minCollateral = 0;
 
         id = toId(obligation);
     }

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -328,7 +328,7 @@ contract LiquidationTest is BaseTest {
             address token = obligation.collaterals[i].token;
             deal(token, address(this), collateralAmount);
             ERC20(token).approve(address(morphoV2), collateralAmount);
-            morphoV2.supplyCollateral(obligation, token, collateralAmount, borrower);
+            morphoV2.supplyCollateral(obligation, i, collateralAmount, borrower);
         }
 
         setupObligation(obligation, units);

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -3,11 +3,13 @@
 pragma solidity ^0.8.0;
 
 import {IdLib} from "../src/libraries/IdLib.sol";
-import {Obligation, Collateral} from "../src/interfaces/IMorphoV2.sol";
+import {Obligation, Collateral, Offer} from "../src/interfaces/IMorphoV2.sol";
 
 import {ERC20} from "./helpers/ERC20.sol";
+import {Oracle} from "./helpers/Oracle.sol";
 import {BaseTest, MAX_TEST_AMOUNT} from "./BaseTest.sol";
-
+import {WAD, ORACLE_PRICE_SCALE} from "../src/libraries/ConstantsLib.sol";
+import {TICK_RANGE} from "../src/libraries/TickLib.sol";
 import {UtilsLib} from "../src/libraries/UtilsLib.sol";
 
 contract OtherFunctionsTest is BaseTest {
@@ -26,36 +28,9 @@ contract OtherFunctionsTest is BaseTest {
         obligation.collaterals
             .push(Collateral({token: address(collateralToken2), lltv: 0.75e18, oracle: address(oracle2)}));
         obligation.collaterals = sortCollaterals(obligation.collaterals);
+        obligation.minCollateral = 0;
 
         id = toId(obligation);
-    }
-
-    function testSupplyCollateral(address user, uint256 amount) public {
-        vm.assume(user != address(morphoV2));
-        address collateralToken = address(new ERC20("collat", "c"));
-        deal(collateralToken, address(this), amount);
-        ERC20(collateralToken).approve(address(morphoV2), amount);
-
-        // Note: you can supply collaterals that are not in the obligation.
-        morphoV2.supplyCollateral(obligation, collateralToken, amount, user);
-
-        assertEq(morphoV2.collateralOf(id, user, collateralToken), amount, "collateral of");
-        assertEq(ERC20(collateralToken).balanceOf(address(morphoV2)), amount, "balance of morphoV2");
-    }
-
-    function testWithdrawCollateralNoBorrow(address user, uint256 supply, uint256 withdraw) public {
-        vm.assume(user != address(morphoV2));
-        withdraw = bound(withdraw, 0, supply);
-        address collateralToken = address(new ERC20("collat", "c"));
-        deal(collateralToken, address(this), supply);
-        ERC20(collateralToken).approve(address(morphoV2), supply);
-        morphoV2.supplyCollateral(obligation, collateralToken, supply, user);
-
-        morphoV2.withdrawCollateral(obligation, collateralToken, withdraw, user);
-
-        assertEq(morphoV2.collateralOf(id, user, collateralToken), supply - withdraw, "collateral of");
-        assertEq(ERC20(collateralToken).balanceOf(address(morphoV2)), supply - withdraw, "balance of morphoV2");
-        assertEq(ERC20(collateralToken).balanceOf(address(this)), withdraw, "balance of this");
     }
 
     function testWithdrawCollateralWithBorrowHealthy(uint256 additionalCollateral, uint256 withdraw, uint256 units)
@@ -202,5 +177,52 @@ contract OtherFunctionsTest is BaseTest {
         vm.prank(user);
         morphoV2.shuffleSession();
         assertEq(morphoV2.session(user), keccak256(abi.encode(0, blockhash(block.number - 1))), "session");
+    }
+
+    function testMinCollateralInSupplyCollateral(uint256 collateral, uint256 price, uint256 minCollateral) public {
+        collateral = bound(collateral, 1, MAX_TEST_AMOUNT);
+        price = bound(price, 1, ORACLE_PRICE_SCALE);
+        Oracle(obligation.collaterals[0].oracle).setPrice(price);
+
+        uint256 collateralValue = collateral.mulDivDown(price, ORACLE_PRICE_SCALE);
+        minCollateral = bound(minCollateral, collateralValue + 1, type(uint256).max);
+        obligation.minCollateral = minCollateral;
+
+        address collateralToken = obligation.collaterals[0].token;
+        deal(collateralToken, address(this), collateral);
+        ERC20(collateralToken).approve(address(morphoV2), collateral);
+        vm.expectRevert("Below min collateral");
+        morphoV2.supplyCollateral(obligation, collateralToken, collateral, borrower);
+    }
+
+    function testMinCollateralInWithdrawCollateral(
+        uint256 collateral,
+        uint256 price,
+        uint256 withdrawnCollateral,
+        uint256 minCollateral
+    ) public {
+        collateral = bound(collateral, 2, MAX_TEST_AMOUNT);
+        price = bound(price, 1, ORACLE_PRICE_SCALE);
+        Oracle(obligation.collaterals[0].oracle).setPrice(price);
+
+        uint256 initialValue = collateral.mulDivDown(price, ORACLE_PRICE_SCALE);
+        vm.assume(initialValue > 0);
+
+        // withdrawnCollateral must leave some remaining (can't withdraw all)
+        withdrawnCollateral = bound(withdrawnCollateral, 1, collateral - 1);
+        uint256 remainingValue = (collateral - withdrawnCollateral).mulDivDown(price, ORACLE_PRICE_SCALE);
+
+        // minCollateral must be in (remainingValue, initialValue] for supply to succeed and withdraw to fail
+        vm.assume(remainingValue < initialValue);
+        minCollateral = bound(minCollateral, remainingValue + 1, initialValue);
+        obligation.minCollateral = minCollateral;
+
+        address collateralToken = obligation.collaterals[0].token;
+        deal(collateralToken, address(this), collateral);
+        ERC20(collateralToken).approve(address(morphoV2), collateral);
+        morphoV2.supplyCollateral(obligation, collateralToken, collateral, borrower);
+
+        vm.expectRevert("Below min collateral");
+        morphoV2.withdrawCollateral(obligation, collateralToken, withdrawnCollateral, borrower);
     }
 }

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -41,11 +41,11 @@ contract OtherFunctionsTest is BaseTest {
         collateralize(obligation, borrower, units);
         setupObligation(obligation, units);
         deal(collateralToken, address(this), additionalCollateral);
-        morphoV2.supplyCollateral(obligation, collateralToken, additionalCollateral, borrower);
+        morphoV2.supplyCollateral(obligation, 0, additionalCollateral, borrower);
         withdraw = bound(withdraw, 0, additionalCollateral);
         uint256 initialCollateral = morphoV2.collateralOf(id, borrower, collateralToken);
 
-        morphoV2.withdrawCollateral(obligation, collateralToken, withdraw, borrower);
+        morphoV2.withdrawCollateral(obligation, 0, withdraw, borrower);
 
         assertEq(morphoV2.collateralOf(id, borrower, collateralToken), initialCollateral - withdraw, "collateral of");
         assertEq(
@@ -63,12 +63,12 @@ contract OtherFunctionsTest is BaseTest {
         collateralize(obligation, borrower, units);
         setupObligation(obligation, units);
         deal(collateralToken, address(this), additionalCollateral);
-        morphoV2.supplyCollateral(obligation, collateralToken, additionalCollateral, borrower);
+        morphoV2.supplyCollateral(obligation, 0, additionalCollateral, borrower);
         uint256 initialCollateral = morphoV2.collateralOf(id, borrower, collateralToken);
         withdraw = bound(withdraw, additionalCollateral + 1, initialCollateral);
 
         vm.expectRevert("Unhealthy borrower");
-        morphoV2.withdrawCollateral(obligation, collateralToken, withdraw, borrower);
+        morphoV2.withdrawCollateral(obligation, 0, withdraw, borrower);
     }
 
     function testRepay(uint256 units, uint256 repaid) public {
@@ -191,7 +191,7 @@ contract OtherFunctionsTest is BaseTest {
         deal(collateralToken, address(this), collateral);
         ERC20(collateralToken).approve(address(morphoV2), collateral);
         vm.expectRevert("Below min collateral");
-        morphoV2.supplyCollateral(obligation, collateralToken, collateral, borrower);
+        morphoV2.supplyCollateral(obligation, 0, collateral, borrower);
     }
 
     function testMinCollateralInWithdrawCollateral(
@@ -219,9 +219,9 @@ contract OtherFunctionsTest is BaseTest {
         address collateralToken = obligation.collaterals[0].token;
         deal(collateralToken, address(this), collateral);
         ERC20(collateralToken).approve(address(morphoV2), collateral);
-        morphoV2.supplyCollateral(obligation, collateralToken, collateral, borrower);
+        morphoV2.supplyCollateral(obligation, 0, collateral, borrower);
 
         vm.expectRevert("Below min collateral");
-        morphoV2.withdrawCollateral(obligation, collateralToken, withdrawnCollateral, borrower);
+        morphoV2.withdrawCollateral(obligation, 0, withdrawnCollateral, borrower);
     }
 }

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -3,13 +3,12 @@
 pragma solidity ^0.8.0;
 
 import {IdLib} from "../src/libraries/IdLib.sol";
-import {Obligation, Collateral, Offer} from "../src/interfaces/IMorphoV2.sol";
+import {Obligation, Collateral} from "../src/interfaces/IMorphoV2.sol";
 
 import {ERC20} from "./helpers/ERC20.sol";
 import {Oracle} from "./helpers/Oracle.sol";
 import {BaseTest, MAX_TEST_AMOUNT} from "./BaseTest.sol";
-import {WAD, ORACLE_PRICE_SCALE} from "../src/libraries/ConstantsLib.sol";
-import {TICK_RANGE} from "../src/libraries/TickLib.sol";
+import {ORACLE_PRICE_SCALE} from "../src/libraries/ConstantsLib.sol";
 import {UtilsLib} from "../src/libraries/UtilsLib.sol";
 
 contract OtherFunctionsTest is BaseTest {

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -7,6 +7,7 @@ import {Obligation, Collateral} from "../src/interfaces/IMorphoV2.sol";
 
 import {ERC20} from "./helpers/ERC20.sol";
 import {Oracle} from "./helpers/Oracle.sol";
+import {RevertingOracle} from "./helpers/RevertingOracle.sol";
 import {BaseTest, MAX_TEST_AMOUNT} from "./BaseTest.sol";
 import {ORACLE_PRICE_SCALE} from "../src/libraries/ConstantsLib.sol";
 import {UtilsLib} from "../src/libraries/UtilsLib.sol";
@@ -223,5 +224,56 @@ contract OtherFunctionsTest is BaseTest {
 
         vm.expectRevert("Below min collateral");
         morphoV2.withdrawCollateral(obligation, 0, withdrawnCollateral, borrower);
+    }
+
+    function testSupplyCollateralZeroDoesNotCallOracle() public {
+        RevertingOracle revertingOracle = new RevertingOracle();
+        Collateral[] memory collaterals = new Collateral[](1);
+        collaterals[0] = Collateral({token: address(collateralToken1), lltv: 0.75e18, oracle: address(revertingOracle)});
+
+        Obligation memory obligationWithRevertingOracle;
+        obligationWithRevertingOracle.loanToken = address(loanToken);
+        obligationWithRevertingOracle.maturity = block.timestamp + 100;
+        obligationWithRevertingOracle.collaterals = collaterals;
+
+        // Make the oracle revert.
+        revertingOracle.stopOracle();
+
+        // Should succeed if oracle is not called.
+        morphoV2.supplyCollateral(obligationWithRevertingOracle, 0, 0, borrower);
+
+        vm.expectRevert("Oracle should not be called");
+        morphoV2.supplyCollateral(obligationWithRevertingOracle, 0, 1, borrower);
+    }
+
+    function testWithdrawCollateralToZeroDoesNotCallOracle(uint256 collateral) public {
+        collateral = bound(collateral, 1, MAX_TEST_AMOUNT);
+
+        RevertingOracle revertingOracle = new RevertingOracle();
+        Collateral[] memory collaterals = new Collateral[](1);
+        collaterals[0] = Collateral({token: address(collateralToken1), lltv: 0.75e18, oracle: address(revertingOracle)});
+
+        Obligation memory obligationWithRevertingOracle;
+        obligationWithRevertingOracle.loanToken = address(loanToken);
+        obligationWithRevertingOracle.maturity = block.timestamp + 100;
+        obligationWithRevertingOracle.collaterals = collaterals;
+
+        deal(address(collateralToken1), address(this), collateral);
+        morphoV2.supplyCollateral(obligationWithRevertingOracle, 0, collateral, borrower);
+
+        bytes32 _id = toId(obligationWithRevertingOracle);
+        assertEq(
+            morphoV2.collateralOf(_id, borrower, address(collateralToken1)), collateral, "collateral should be set"
+        );
+
+        revertingOracle.stopOracle();
+
+        morphoV2.withdrawCollateral(obligationWithRevertingOracle, 0, collateral, borrower);
+
+        assertEq(
+            morphoV2.collateralOf(_id, borrower, address(collateralToken1)),
+            0,
+            "collateral should be 0 after withdrawal"
+        );
     }
 }

--- a/test/SettersTest.sol
+++ b/test/SettersTest.sol
@@ -60,8 +60,9 @@ contract SettersTest is BaseTest {
         morphoV2.setDefaultTradingFee(loanToken, 5, oneEightyDaysFee);
 
         // touch obligation with this loan token
-        Obligation memory obligation =
-            Obligation({loanToken: loanToken, maturity: block.timestamp + 1 days, collaterals: new Collateral[](0)});
+        Obligation memory obligation = Obligation({
+            loanToken: loanToken, maturity: block.timestamp + 1 days, collaterals: new Collateral[](0), minCollateral: 0
+        });
         bytes32 id = toId(obligation);
         morphoV2.touchObligation(obligation);
 
@@ -135,8 +136,9 @@ contract SettersTest is BaseTest {
         morphoV2.setDefaultTradingFee(loanToken, 5, oneEightyDaysFee);
 
         // touch obligation with this loan token
-        Obligation memory obligation =
-            Obligation({loanToken: loanToken, maturity: block.timestamp + 1 days, collaterals: new Collateral[](0)});
+        Obligation memory obligation = Obligation({
+            loanToken: loanToken, maturity: block.timestamp + 1 days, collaterals: new Collateral[](0), minCollateral: 0
+        });
         bytes32 id = toId(obligation);
         morphoV2.touchObligation(obligation);
 
@@ -174,8 +176,9 @@ contract SettersTest is BaseTest {
         morphoV2.setDefaultTradingFee(loanToken, 5, 0.01e18);
 
         // touch obligation with this loan token
-        Obligation memory obligation =
-            Obligation({loanToken: loanToken, maturity: block.timestamp + 1 days, collaterals: new Collateral[](0)});
+        Obligation memory obligation = Obligation({
+            loanToken: loanToken, maturity: block.timestamp + 1 days, collaterals: new Collateral[](0), minCollateral: 0
+        });
         bytes32 id = toId(obligation);
         morphoV2.touchObligation(obligation);
 
@@ -214,8 +217,9 @@ contract SettersTest is BaseTest {
         morphoV2.setDefaultTradingFee(loanToken, 5, 0.01e18); // 180d: 1%
 
         // touch obligation with this loan token
-        Obligation memory obligation =
-            Obligation({loanToken: loanToken, maturity: block.timestamp + 1 days, collaterals: new Collateral[](0)});
+        Obligation memory obligation = Obligation({
+            loanToken: loanToken, maturity: block.timestamp + 1 days, collaterals: new Collateral[](0), minCollateral: 0
+        });
         bytes32 id = toId(obligation);
         morphoV2.touchObligation(obligation);
 

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -36,6 +36,7 @@ contract TakeTest is BaseTest {
         obligation.collaterals
             .push(Collateral({token: address(collateralToken2), lltv: 0.75e18, oracle: address(oracle2)}));
         obligation.collaterals = sortCollaterals(obligation.collaterals);
+        obligation.minCollateral = 0;
 
         id = toId(obligation);
 

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -1224,7 +1224,7 @@ contract TakeTest is BaseTest {
         assets = bound(assets, 0, maxAssets);
         uint256 collateral = assets.mulDivUp(WAD, obligation.collaterals[0].lltv);
         borrowerOffer.callback = address(new BorrowCallback());
-        borrowerOffer.callbackData = abi.encode(obligation.collaterals[0].token, collateral);
+        borrowerOffer.callbackData = abi.encode(0, collateral);
         borrowerOffer.assets = assets;
         borrowerOffer.tick = TICK_RANGE;
         deal(address(loanToken), lender, assets);
@@ -1257,10 +1257,10 @@ contract TakeTest is BaseTest {
             root([lenderOffer]),
             proof([lenderOffer]),
             callback,
-            abi.encode(obligation.collaterals[0].token, collateral)
+            abi.encode(0, collateral)
         );
         assertEq(morphoV2.collateralOf(id, borrower, obligation.collaterals[0].token), collateral);
-        assertEq(BorrowCallback(callback).recordedData(), abi.encode(obligation.collaterals[0].token, collateral));
+        assertEq(BorrowCallback(callback).recordedData(), abi.encode(0, collateral));
     }
 
     function testSellBuyerCallback(uint256 assets) public {
@@ -1313,9 +1313,10 @@ contract BorrowCallback is ICallbacks {
         external
     {
         recordedData = data;
-        (address collateralToken, uint256 amount) = abi.decode(data, (address, uint256));
+        (uint256 collateralIndex, uint256 amount) = abi.decode(data, (uint256, uint256));
+        address collateralToken = obligation.collaterals[collateralIndex].token;
         ERC20(collateralToken).approve(msg.sender, amount);
-        MorphoV2(msg.sender).supplyCollateral(obligation, collateralToken, amount, seller);
+        MorphoV2(msg.sender).supplyCollateral(obligation, collateralIndex, amount, seller);
     }
 
     function onBuy(

--- a/test/helpers/RevertingOracle.sol
+++ b/test/helpers/RevertingOracle.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
+pragma solidity ^0.8.0;
+
+contract RevertingOracle {
+    uint256 internal _price = 1e36;
+    bool internal stopped;
+
+    function price() external view returns (uint256) {
+        require(!stopped, "Oracle should not be called");
+        return _price;
+    }
+
+    function stopOracle() external {
+        stopped = true;
+    }
+}


### PR DESCRIPTION
New min collat implementation. 

A few notes
- `supplyCollateral` and `withdrawCollateral` can no longer be done with a collateral that is not in the `Obligation`
- we could say that in this implementation, the min collateral enforcement is 'weak' because it's only checked during `supplyCollateral` and `withdrawCollateral` but it could fall below min collateral later through an oracle price update and no liquidation mechanism is currently mitigating this (#343)



see rationale: https://morpholabs.slack.com/archives/C02N7CZ088N/p1770296213352059 