### PR TITLE
[obligation packing]: pack in morpho contract

### DIFF
--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -538,4 +538,15 @@ contract MorphoV2 is IMorphoV2 {
 
         return (feeLower * (end - timeToMaturity) + feeUpper * (timeToMaturity - start)) / (end - start);
     }
+
+    /// EXTERNAL FUNCTIONS FOR INTERNAL USE ///
+
+    /// @dev Returns a packed representation of the obligation.
+    /// @dev Does not return valid ABI-encoded bytes.
+    function packObligation(Obligation memory obligation) external pure returns (bytes memory) {
+        bytes memory result = IdLib.pack(obligation);
+        assembly ("memory-safe") {
+            return(add(result, 32), mload(result))
+        }
+    }
 }

--- a/src/interfaces/IMorphoV2.sol
+++ b/src/interfaces/IMorphoV2.sol
@@ -56,4 +56,6 @@ struct ObligationState {
     uint16[6] fees;
 }
 
-interface IMorphoV2 {}
+interface IMorphoV2 {
+    function packObligation(Obligation memory obligation) external pure returns (bytes memory);
+}

--- a/src/libraries/IdLib.sol
+++ b/src/libraries/IdLib.sol
@@ -3,28 +3,42 @@
 pragma solidity ^0.8.0;
 
 import {Obligation, Collateral} from "../interfaces/IMorphoV2.sol";
+import {IMorphoV2} from "../interfaces/IMorphoV2.sol";
 
 library IdLib {
-    /// @dev Creation code that returns the code after the prefix as runtime bytecode, except for the first 52 bytes.
+    /// @dev Calls its deployer with its 74:end bytes.
+    /// @dev Uses the returned bytes as runtime code.
     /// @dev Explanation of the prefix:
-    /// hex       opcode          stack              comments
-    /// ------------------------------------------------------------------------------
-    /// 60 3f     PUSH1 0x3f      [63]               63 = len(prefix+chainId+morphoV2)
-    /// 38        CODESIZE        [codesize, 63]
-    /// 03        SUB             [len]              with len = codesize - 63
-    /// 80        DUP1            [len, len]
-    /// 60 3f     PUSH1 0x3f      [63, len, len]     code offset = 63
-    /// 5f        PUSH0           [0, 63, len, len]  mem offset = 0
-    /// 39        CODECOPY        [len]              mem[0:len] <- code[63:63+len]
-    /// 5f        PUSH0           [0, len]           return offset = 0
-    /// f3        RETURN          []                 mem[0:len] is returned
+    /// hex     opcode           stack                               comments
+    /// -----------------------------------------------------------------------------------------------
+    /// 60 4a   PUSH1 0x4a      [74]                                74 = len(prefix+chainId+morphoV2)
+    /// 38      codeSize        [codeSize, 74]
+    /// 80      DUP1            [codeSize, codeSize, 74]
+    /// 91      SWAP2           [74, codeSize, codeSize]
+    /// 5f      PUSH0           [0, 74, codeSize, codeSize]
+    /// 39      CODECOPY        [codeSize]                          mem[0:codeSize] <- code[74:], zero-padded
+    /// 5f      PUSH0           [0, codeSize]
+    /// 5f      PUSH0           [0, 0, codeSize]
+    /// 91      SWAP2           [codeSize, 0, 0]
+    /// 5f      PUSH0           [0, codeSize, 0, 0]
+    /// 33      CALLER          [caller, 0, codeSize, 0, 0]
+    /// 5a      GAS             [gas, caller, 0, codeSize, 0, 0]
+    /// fa      STATICCALL      [ok]
+    /// 3d      RETURNDATASIZE  [returnDataSize, ok]
+    /// 02      MUL             [retSize]                           0 if failed staticcall
+    /// 80      DUP1            [retSize, retSize]
+    /// 5f      PUSH0           [0, retSize, retSize]
+    /// 5f      PUSH0           [0, 0, retSize, retSize]
+    /// 3e      RETURNDATACOPY  [retSize]                           mem[0:retSize] <- returndata[0:retSize]
+    /// 5f      PUSH0           [0, retSize]
+    /// f3      RETURN          []                                  return mem[0:retSize]
     function creationCode(Obligation memory obligation, uint256 chainId, address morphoV2)
         internal
         pure
         returns (bytes memory)
     {
-        bytes memory prefix = hex"603f380380603f5f395ff3";
-        return abi.encodePacked(prefix, chainId, morphoV2, pack(obligation));
+        bytes memory prefix = hex"604a3880915f395f5f915f335afa3d02805f5f3e5ff3";
+        return abi.encodePacked(prefix, chainId, morphoV2, IMorphoV2.packObligation.selector, abi.encode(obligation));
     }
 
     function toId(Obligation memory obligation, uint256 chainId, address morphoV2) internal pure returns (bytes32) {
@@ -55,40 +69,15 @@ library IdLib {
     function pack(Obligation memory obligation) internal pure returns (bytes memory result) {
         require(obligation.maturity <= type(uint48).max, "maturity too large");
         require(obligation.collaterals.length <= type(uint8).max, "collateral count too large");
-        Collateral[] memory collaterals = obligation.collaterals;
-        uint256 len = collaterals.length;
 
-        uint256 ptr;
-        assembly ("memory-safe") {
-            result := mload(0x40)
-            let size := add(28, mul(len, 48))
-            mstore(result, size)
+        result = abi.encodePacked(
+            bytes1(0x00), obligation.loanToken, uint48(obligation.maturity), uint8(obligation.collaterals.length)
+        );
 
-            ptr := add(result, 32)
-            // [stop, 1 byte][loanToken, 20 bytes][maturity, 6 bytes][collateral count, 1 byte]
-            let header := or(or(shl(88, mload(obligation)), shl(40, mload(add(obligation, 0x40)))), shl(32, len))
-            mstore(ptr, header)
-            ptr := add(ptr, 28)
-        }
-
-        for (uint256 i = 0; i < len; i++) {
-            Collateral memory c = collaterals[i];
-            require(c.lltv <= type(uint64).max, "lltv too large");
-
-            assembly ("memory-safe") {
-                // [token, 20 bytes][lltv, 8 bytes]
-                mstore(ptr, or(shl(96, mload(c)), shl(32, mload(add(c, 0x20)))))
-                ptr := add(ptr, 28)
-
-                // [oracle, 20 bytes]
-                mstore(ptr, shl(96, mload(add(c, 0x40))))
-                ptr := add(ptr, 20)
-            }
-        }
-
-        assembly ("memory-safe") {
-            // Round up to the next 32-byte word for the free memory pointer.
-            mstore(0x40, and(add(ptr, 31), not(31)))
+        for (uint256 i = 0; i < obligation.collaterals.length; i++) {
+            Collateral memory collateral = obligation.collaterals[i];
+            require(collateral.lltv <= type(uint64).max, "lltv too large");
+            result = abi.encodePacked(result, collateral.token, uint64(collateral.lltv), collateral.oracle);
         }
     }
 

--- a/src/libraries/IdLib.sol
+++ b/src/libraries/IdLib.sol
@@ -81,6 +81,8 @@ library IdLib {
         }
     }
 
+    /// @dev Unpacks a packed representation of the obligation.
+    /// @dev Should only be used on data known to be a packed obligation.
     function unpack(bytes memory data) internal pure returns (Obligation memory obligation) {
         require(data.length > 0, "empty data");
         unchecked {

--- a/src/libraries/IdLib.sol
+++ b/src/libraries/IdLib.sol
@@ -86,36 +86,25 @@ library IdLib {
     function unpack(bytes memory data) internal pure returns (Obligation memory obligation) {
         require(data.length > 0, "empty data");
         unchecked {
-            address loanToken;
-            uint256 maturity;
-            uint8 len;
-            assembly ("memory-safe") {
-                let ptr := add(data, 32)
-                loanToken := shr(96, mload(add(ptr, 1)))
-                maturity := shr(208, mload(add(ptr, 21)))
-                len := shr(248, mload(add(ptr, 27)))
-            }
+            obligation.loanToken = address(uint160(get(data, 1, 160)));
+            obligation.maturity = uint48(get(data, 21, 48));
+            uint8 len = uint8(data[27]);
 
-            obligation.loanToken = loanToken;
-            obligation.maturity = maturity;
-
-            Collateral[] memory collaterals = new Collateral[](len);
+            obligation.collaterals = new Collateral[](len);
 
             for (uint256 i = 0; i < len; i++) {
                 uint256 offset = 28 + i * 48;
-                address token;
-                uint256 lltv;
-                address oracle;
-                assembly ("memory-safe") {
-                    let ptr := add(add(data, 32), offset)
-                    token := shr(96, mload(ptr))
-                    lltv := shr(192, mload(add(ptr, 20)))
-                    oracle := shr(96, mload(add(ptr, 28)))
-                }
-                collaterals[i] = Collateral({token: token, lltv: lltv, oracle: oracle});
+                obligation.collaterals[i].token = address(uint160(get(data, offset, 160)));
+                obligation.collaterals[i].lltv = uint64(get(data, offset + 20, 64));
+                obligation.collaterals[i].oracle = address(uint160(get(data, offset + 28, 160)));
             }
+        }
+    }
 
-            obligation.collaterals = collaterals;
+    function get(bytes memory data, uint256 offset, uint256 size) private pure returns (uint256 w) {
+        uint256 shift = 256 - size;
+        assembly ("memory-safe") {
+            w := shr(shift, mload(add(add(data, 32), offset)))
         }
     }
 }

--- a/src/libraries/IdLib.sol
+++ b/src/libraries/IdLib.sol
@@ -2,7 +2,7 @@
 // Copyright (c) 2025 Morpho Association
 pragma solidity ^0.8.0;
 
-import {Obligation} from "../interfaces/IMorphoV2.sol";
+import {Obligation, Collateral} from "../interfaces/IMorphoV2.sol";
 
 library IdLib {
     /// @dev Creation code that returns the code after the prefix as runtime bytecode, except for the first 52 bytes.
@@ -24,7 +24,7 @@ library IdLib {
         returns (bytes memory)
     {
         bytes memory prefix = hex"603f380380603f5f395ff3";
-        return abi.encodePacked(prefix, chainId, morphoV2, abi.encode(obligation));
+        return abi.encodePacked(prefix, chainId, morphoV2, pack(obligation));
     }
 
     function toId(Obligation memory obligation, uint256 chainId, address morphoV2) internal pure returns (bytes32) {
@@ -34,11 +34,11 @@ library IdLib {
     function idToObligation(bytes32 id, address morphoV2) internal view returns (Obligation memory) {
         address create2Address =
             address(uint160(uint256(keccak256(abi.encodePacked(uint8(0xff), morphoV2, bytes32(0), id)))));
-        return abi.decode(create2Address.code, (Obligation));
+        return unpack(create2Address.code);
     }
 
-    /// @dev Deploys a contract with runtime code = abi.encode(obligation)
-    /// @dev The contract code begins with 0x00 (STOP), because the first word is the offset of the obligation.
+    /// @dev Deploys a contract with runtime code = pack(obligation)
+    /// @dev The contract code begins with 0x00 (STOP) for safety.
     function storeInCode(Obligation memory obligation) internal {
         bytes memory _creationCode = creationCode(obligation, block.chainid, address(this));
         address create2Address;
@@ -46,5 +46,85 @@ library IdLib {
             create2Address := create2(0, add(_creationCode, 0x20), mload(_creationCode), 0)
         }
         require(create2Address != address(0), "Failed to create SStore2 contract");
+    }
+
+    /// @dev Returns a packed representation of the obligation.
+    /// @dev The maturity must fit on 6 bytes.
+    /// @dev The collateral count must fit on 1 byte.
+    /// @dev All lltvs must fit on 8 bytes.
+    function pack(Obligation memory obligation) internal pure returns (bytes memory result) {
+        require(obligation.maturity <= type(uint48).max, "maturity too large");
+        require(obligation.collaterals.length <= type(uint8).max, "collateral count too large");
+        Collateral[] memory collaterals = obligation.collaterals;
+        uint256 len = collaterals.length;
+
+        uint256 ptr;
+        assembly ("memory-safe") {
+            result := mload(0x40)
+            let size := add(28, mul(len, 48))
+            mstore(result, size)
+
+            ptr := add(result, 32)
+            // [stop, 1 byte][loanToken, 20 bytes][maturity, 6 bytes][collateral count, 1 byte]
+            let header := or(or(shl(88, mload(obligation)), shl(40, mload(add(obligation, 0x40)))), shl(32, len))
+            mstore(ptr, header)
+            ptr := add(ptr, 28)
+        }
+
+        for (uint256 i = 0; i < len; i++) {
+            Collateral memory c = collaterals[i];
+            require(c.lltv <= type(uint64).max, "lltv too large");
+
+            assembly ("memory-safe") {
+                // [token, 20 bytes][lltv, 8 bytes]
+                mstore(ptr, or(shl(96, mload(c)), shl(32, mload(add(c, 0x20)))))
+                ptr := add(ptr, 28)
+
+                // [oracle, 20 bytes]
+                mstore(ptr, shl(96, mload(add(c, 0x40))))
+                ptr := add(ptr, 20)
+            }
+        }
+
+        assembly ("memory-safe") {
+            // Round up to the next 32-byte word for the free memory pointer.
+            mstore(0x40, and(add(ptr, 31), not(31)))
+        }
+    }
+
+    function unpack(bytes memory data) internal pure returns (Obligation memory obligation) {
+        require(data.length > 0, "empty data");
+        unchecked {
+            address loanToken;
+            uint256 maturity;
+            uint8 len;
+            assembly ("memory-safe") {
+                let ptr := add(data, 32)
+                loanToken := shr(96, mload(add(ptr, 1)))
+                maturity := shr(208, mload(add(ptr, 21)))
+                len := shr(248, mload(add(ptr, 27)))
+            }
+
+            obligation.loanToken = loanToken;
+            obligation.maturity = maturity;
+
+            Collateral[] memory collaterals = new Collateral[](len);
+
+            for (uint256 i = 0; i < len; i++) {
+                uint256 offset = 28 + i * 48;
+                address token;
+                uint256 lltv;
+                address oracle;
+                assembly ("memory-safe") {
+                    let ptr := add(add(data, 32), offset)
+                    token := shr(96, mload(ptr))
+                    lltv := shr(192, mload(add(ptr, 20)))
+                    oracle := shr(96, mload(add(ptr, 28)))
+                }
+                collaterals[i] = Collateral({token: token, lltv: lltv, oracle: oracle});
+            }
+
+            obligation.collaterals = collaterals;
+        }
     }
 }

--- a/src/libraries/IdLib.sol
+++ b/src/libraries/IdLib.sol
@@ -59,7 +59,7 @@ library IdLib {
         assembly ("memory-safe") {
             create2Address := create2(0, add(_creationCode, 0x20), mload(_creationCode), 0)
         }
-        require(create2Address != address(0), "Failed to create SStore2 contract");
+        require(create2Address.code.length > 0, "Failed to create SStore2 contract");
     }
 
     /// @dev Returns a packed representation of the obligation.

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -277,4 +277,12 @@ abstract contract BaseTest is Test {
         }
         obligation.collaterals = collaterals;
     }
+
+    function packObligation(Obligation memory obligation) external pure returns (bytes memory) {
+        // Must return raw bytes via assembly (not ABI-encoded) to match MorphoV2's behavior
+        bytes memory result = IdLib.pack(obligation);
+        assembly ("memory-safe") {
+            return(add(result, 32), mload(result))
+        }
+    }
 }

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -265,4 +265,16 @@ abstract contract BaseTest is Test {
     function absDiff(uint256 a, uint256 b) internal pure returns (uint256) {
         return a > b ? a - b : b - a;
     }
+
+    function boundObligation(Obligation memory obligation) internal pure {
+        obligation.maturity = bound(obligation.maturity, 0, type(uint48).max);
+        uint256 len = bound(obligation.collaterals.length, 0, type(uint8).max);
+        Collateral[] memory collaterals = new Collateral[](len);
+        for (uint256 i = 0; i < len; i++) {
+            collaterals[i] = obligation.collaterals[i];
+            collaterals[i].lltv = bound(obligation.collaterals[i].lltv, 0, type(uint64).max);
+            collaterals[i].oracle = obligation.collaterals[i].oracle;
+        }
+        obligation.collaterals = collaterals;
+    }
 }

--- a/test/IdLibTest.sol
+++ b/test/IdLibTest.sol
@@ -108,6 +108,14 @@ contract IdLibTest is BaseTest {
         IdLib.pack(obligation);
     }
 
+    function testStoreInCodeRevertsOnInvalidObligation() public {
+        Obligation memory obligation;
+        obligation.maturity = uint256(type(uint48).max) + 1;
+
+        vm.expectRevert("Failed to create SStore2 contract");
+        morphoV2.touchObligation(obligation);
+    }
+
     /// forge-config: default.allow_internal_expect_revert = true
     function testPackRejectsLargeMaturity() public {
         Obligation memory obligation;

--- a/test/IdLibTest.sol
+++ b/test/IdLibTest.sol
@@ -1,18 +1,20 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {Test} from "../lib/forge-std/src/Test.sol";
+import {BaseTest} from "./BaseTest.sol";
 import {IdLib} from "../src/libraries/IdLib.sol";
-import {Obligation} from "../src/interfaces/IMorphoV2.sol";
+import {Obligation, Collateral} from "../src/interfaces/IMorphoV2.sol";
 
 // idToObligation is tested in OtherFunctionsTest.sol, to test actual implementation (avoid introducing mocks).
-contract IdLibTest is Test {
+contract IdLibTest is BaseTest {
     function testToIdIsInjectiveInObligation(
         Obligation memory obligation1,
         Obligation memory obligation2,
         uint256 chainid,
         address morphoV2
     ) public pure {
+        boundObligation(obligation1);
+        boundObligation(obligation2);
         bool sameLoanToken = obligation1.loanToken == obligation2.loanToken;
         bool sameMaturity = obligation1.maturity == obligation2.maturity;
         bool sameCollaterals = obligation1.collaterals.length == obligation2.collaterals.length;
@@ -36,6 +38,7 @@ contract IdLibTest is Test {
         uint256 chainid2,
         address morphoV2
     ) public pure {
+        boundObligation(obligation);
         vm.assume(chainid1 != chainid2);
         bytes32 id1 = IdLib.toId(obligation, chainid1, morphoV2);
         bytes32 id2 = IdLib.toId(obligation, chainid2, morphoV2);
@@ -48,9 +51,78 @@ contract IdLibTest is Test {
         address morphoV2One,
         address morphoV2Two
     ) public pure {
+        boundObligation(obligation);
         vm.assume(morphoV2One != morphoV2Two);
         bytes32 id1 = IdLib.toId(obligation, chainid, morphoV2One);
         bytes32 id2 = IdLib.toId(obligation, chainid, morphoV2Two);
         assertNotEq(id1, id2);
+    }
+
+    function testRoundtrip(Obligation memory obligation) public {
+        boundObligation(obligation);
+
+        IdLib.storeInCode(obligation);
+
+        bytes32 id = IdLib.toId(obligation, block.chainid, address(this));
+        Obligation memory decoded = IdLib.idToObligation(id, address(this));
+
+        assertEq(decoded.loanToken, obligation.loanToken);
+        assertEq(decoded.maturity, obligation.maturity);
+        assertEq(decoded.collaterals.length, obligation.collaterals.length);
+        for (uint256 i = 0; i < obligation.collaterals.length; i++) {
+            assertEq(decoded.collaterals[i].token, obligation.collaterals[i].token);
+            assertEq(decoded.collaterals[i].lltv, obligation.collaterals[i].lltv);
+            assertEq(decoded.collaterals[i].oracle, obligation.collaterals[i].oracle);
+        }
+    }
+
+    function testPackUnpackRoundtrip(Obligation memory obligation) public pure {
+        boundObligation(obligation);
+
+        bytes memory packed = IdLib.pack(obligation);
+        Obligation memory decoded = IdLib.unpack(packed);
+
+        assertEq(decoded.loanToken, obligation.loanToken);
+        assertEq(decoded.maturity, obligation.maturity);
+        assertEq(decoded.collaterals.length, obligation.collaterals.length);
+        for (uint256 i = 0; i < obligation.collaterals.length; i++) {
+            assertEq(decoded.collaterals[i].token, obligation.collaterals[i].token);
+            assertEq(decoded.collaterals[i].lltv, obligation.collaterals[i].lltv);
+            assertEq(decoded.collaterals[i].oracle, obligation.collaterals[i].oracle);
+        }
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testUnpackEmptyReverts() public {
+        vm.expectRevert();
+        IdLib.unpack("");
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testPackRejectsLargeLltv() public {
+        Obligation memory obligation;
+        obligation.collaterals = new Collateral[](1);
+        obligation.collaterals[0].lltv = uint256(type(uint64).max) + 1;
+
+        vm.expectRevert("lltv too large");
+        IdLib.pack(obligation);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testPackRejectsLargeMaturity() public {
+        Obligation memory obligation;
+        obligation.maturity = uint256(type(uint64).max) + 1;
+
+        vm.expectRevert("maturity too large");
+        IdLib.pack(obligation);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testPackRejectsTooManyCollaterals() public {
+        Obligation memory obligation;
+        obligation.collaterals = new Collateral[](uint256(type(uint8).max) + 1);
+
+        vm.expectRevert("collateral count too large");
+        IdLib.pack(obligation);
     }
 }

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -162,6 +162,7 @@ contract OtherFunctionsTest is BaseTest {
     }
 
     function testTouchObligation(Obligation memory _obligation) public {
+        boundObligation(_obligation);
         _obligation = sortedAndUniqueCollateralsInObligation(_obligation);
 
         bytes32 _id = morphoV2.touchObligation(_obligation);
@@ -173,6 +174,7 @@ contract OtherFunctionsTest is BaseTest {
     }
 
     function testIdToObligation(Obligation memory _obligation) public {
+        boundObligation(_obligation);
         _obligation = sortedAndUniqueCollateralsInObligation(_obligation);
 
         bytes32 _id = morphoV2.touchObligation(_obligation);
@@ -188,6 +190,7 @@ contract OtherFunctionsTest is BaseTest {
     }
 
     function testSstore2CodeStartsWithStop(Obligation memory _obligation) public {
+        boundObligation(_obligation);
         _obligation = sortedAndUniqueCollateralsInObligation(_obligation);
 
         bytes32 _id = morphoV2.touchObligation(_obligation);


### PR DESCRIPTION
- still the 35k gas saving vs. not packing on first touching an obligation
- almost no overhead in toId (+18 gas)
- obligation id is just defined in terms of abi.encode, very simple

Works by having the deployed contract call back morpho to get the packed version