### PR TITLE
Taker assets

### DIFF
--- a/certora/specs/MorphoV2.spec
+++ b/certora/specs/MorphoV2.spec
@@ -3,7 +3,7 @@
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;
 
-    function withdrawable(bytes32 id) external returns uint256 envfree;
+    function withdrawable(bytes32 id) external returns (uint256) envfree;
     function totalUnits(bytes32 id) external returns (uint256) envfree;
     function totalShares(bytes32 id) external returns (uint256) envfree;
     function consumed(address user, bytes32 group) external returns (uint256) envfree;
@@ -11,6 +11,7 @@ methods {
     function debtOf(bytes32 id, address owner) external returns (uint256) envfree;
 
     function _.price() external => NONDET;
+    function _.toId(MorphoV2.Obligation memory obligation, uint256 chainId, address morphoV2) internal => NONDET;
 }
 
 /// HELPERS ///
@@ -31,21 +32,23 @@ hook Sstore debtOf[KEY bytes32 id][KEY address owner] uint256 newDebt (uint256 o
     sumDebtOf[id] = sumDebtOf[id] - oldDebt + newDebt;
 }
 
-rule takeInputOutputConsistency(env e, uint256 buyerAssets, uint256 sellerAssets, uint256 obligationUnits, uint256 obligationShares, address taker, MorphoV2.Offer offer, MorphoV2.Signature signature, bytes32 root, bytes32[] proof, address takerCallbackAddress, bytes takerCallbackData) {
+rule takeInputOutputConsistency(env e, uint256 takerAssets, uint256 obligationUnits, uint256 obligationShares, address taker, MorphoV2.Offer offer, MorphoV2.Signature signature, bytes32 root, bytes32[] proof, address takerCallbackAddress, bytes takerCallbackData) {
     uint256 buyerAssetsOutput;
     uint256 sellerAssetsOutput;
     uint256 obligationUnitsOutput;
     uint256 obligationSharesOutput;
+    uint256 expectedBuyerAssets = offer.buy ? 0 : takerAssets;
+    uint256 expectedSellerAssets = offer.buy ? takerAssets : 0;
 
-    buyerAssetsOutput, sellerAssetsOutput, obligationUnitsOutput, obligationSharesOutput = take(e, buyerAssets, sellerAssets, obligationUnits, obligationShares, taker, offer, signature, root, proof, takerCallbackAddress, takerCallbackData);
+    buyerAssetsOutput, sellerAssetsOutput, obligationUnitsOutput, obligationSharesOutput = take(e, takerAssets, obligationUnits, obligationShares, taker, offer, signature, root, proof, takerCallbackAddress, takerCallbackData);
 
-    assert buyerAssets == 0 || buyerAssetsOutput == buyerAssets;
-    assert sellerAssets == 0 || sellerAssetsOutput == sellerAssets;
+    assert expectedBuyerAssets == 0 || buyerAssetsOutput == expectedBuyerAssets;
+    assert expectedSellerAssets == 0 || sellerAssetsOutput == expectedSellerAssets;
     assert obligationUnits == 0 || obligationUnitsOutput == obligationUnits;
     assert obligationShares == 0 || obligationSharesOutput == obligationShares;
 }
 
-rule offerInputsConsumed(env e, uint256 buyerAssets, uint256 sellerAssets, uint256 obligationUnits, uint256 obligationShares, address taker, MorphoV2.Offer offer, MorphoV2.Signature signature, bytes32 root, bytes32[] proof, address takerCallbackAddress, bytes takerCallbackData) {
+rule offerInputsConsumed(env e, uint256 takerAssets, uint256 obligationUnits, uint256 obligationShares, address taker, MorphoV2.Offer offer, MorphoV2.Signature signature, bytes32 root, bytes32[] proof, address takerCallbackAddress, bytes takerCallbackData) {
     uint256 consumedBefore = consumed(offer.maker, offer.group);
 
     uint256 buyerAssetsOutput;
@@ -53,14 +56,14 @@ rule offerInputsConsumed(env e, uint256 buyerAssets, uint256 sellerAssets, uint2
     uint256 obligationUnitsOutput;
     uint256 obligationSharesOutput;
 
-    buyerAssetsOutput, sellerAssetsOutput, obligationUnitsOutput, obligationSharesOutput = take(e, buyerAssets, sellerAssets, obligationUnits, obligationShares, taker, offer, signature, root, proof, takerCallbackAddress, takerCallbackData);
+    buyerAssetsOutput, sellerAssetsOutput, obligationUnitsOutput, obligationSharesOutput = take(e, takerAssets, obligationUnits, obligationShares, taker, offer, signature, root, proof, takerCallbackAddress, takerCallbackData);
 
     assert offer.assets == 0 || consumed(offer.maker, offer.group) == consumedBefore + (offer.buy ? buyerAssetsOutput : sellerAssetsOutput);
     assert offer.obligationUnits == 0 || consumed(offer.maker, offer.group) == consumedBefore + obligationUnitsOutput;
     assert offer.obligationShares == 0 || consumed(offer.maker, offer.group) == consumedBefore + obligationSharesOutput;
 }
 
-rule offerInputsLimit(env e, uint256 buyerAssets, uint256 sellerAssets, uint256 obligationUnits, uint256 obligationShares, address taker, MorphoV2.Offer offer, MorphoV2.Signature signature, bytes32 root, bytes32[] proof, address takerCallbackAddress, bytes takerCallbackData) {
+rule offerInputsLimit(env e, uint256 takerAssets, uint256 obligationUnits, uint256 obligationShares, address taker, MorphoV2.Offer offer, MorphoV2.Signature signature, bytes32 root, bytes32[] proof, address takerCallbackAddress, bytes takerCallbackData) {
     uint256 consumedBefore = consumed(offer.maker, offer.group);
 
     uint256 buyerAssetsOutput;
@@ -68,7 +71,7 @@ rule offerInputsLimit(env e, uint256 buyerAssets, uint256 sellerAssets, uint256 
     uint256 obligationUnitsOutput;
     uint256 obligationSharesOutput;
 
-    buyerAssetsOutput, sellerAssetsOutput, obligationUnitsOutput, obligationSharesOutput = take(e, buyerAssets, sellerAssets, obligationUnits, obligationShares, taker, offer, signature, root, proof, takerCallbackAddress, takerCallbackData);
+    buyerAssetsOutput, sellerAssetsOutput, obligationUnitsOutput, obligationSharesOutput = take(e, takerAssets, obligationUnits, obligationShares, taker, offer, signature, root, proof, takerCallbackAddress, takerCallbackData);
 
     assert offer.assets == 0 || (offer.buy ? buyerAssetsOutput : sellerAssetsOutput) <= offer.assets - consumedBefore;
     assert offer.obligationUnits == 0 || obligationUnitsOutput <= offer.obligationUnits - consumedBefore;

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -132,8 +132,7 @@ contract MorphoV2 is IMorphoV2 {
     /// @dev Neither the taker nor the maker can pass from having shares to having debt in one take.
     /// @dev The taker might not get the price they expected if the trading fee was just changed.
     function take(
-        uint256 buyerAssets,
-        uint256 sellerAssets,
+        uint256 takerAssets,
         uint256 obligationUnits,
         uint256 obligationShares,
         address taker,
@@ -144,10 +143,7 @@ contract MorphoV2 is IMorphoV2 {
         address takerCallback,
         bytes memory takerCallbackData
     ) public returns (uint256, uint256, uint256, uint256) {
-        require(
-            UtilsLib.atMostOneNonZero(buyerAssets, sellerAssets, obligationUnits, obligationShares),
-            "inconsistent input"
-        );
+        require(UtilsLib.atMostOneNonZero(takerAssets, obligationUnits, obligationShares), "inconsistent input");
         require(
             UtilsLib.atMostOneNonZero(offer.assets, offer.obligationUnits, offer.obligationShares),
             "inconsistent offer input"
@@ -177,6 +173,8 @@ contract MorphoV2 is IMorphoV2 {
         uint256 _tradingFee = tradingFee(id, timeToMaturity);
         uint256 sellerPrice = offer.buy ? offerPrice - _tradingFee : offerPrice;
         uint256 buyerPrice = sellerPrice + _tradingFee;
+        uint256 buyerAssets = offer.buy ? 0 : takerAssets;
+        uint256 sellerAssets = offer.buy ? takerAssets : 0;
 
         if (buyerAssets > 0) {
             obligationUnits = buyerAssets.mulDivDown(WAD, buyerPrice);

--- a/src/libraries/UtilsLib.sol
+++ b/src/libraries/UtilsLib.sol
@@ -17,13 +17,6 @@ library UtilsLib {
         }
     }
 
-    /// @dev Returns true if at most one of `a`, `b`, `c`, `d` is nonzero.
-    function atMostOneNonZero(uint256 a, uint256 b, uint256 c, uint256 d) internal pure returns (bool z) {
-        assembly {
-            z := gt(add(add(add(iszero(a), iszero(b)), iszero(c)), iszero(d)), 2)
-        }
-    }
-
     /// @dev Returns min(a, b).
     function min(uint256 x, uint256 y) internal pure returns (uint256 z) {
         assembly {

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -80,16 +80,14 @@ abstract contract BaseTest is Test {
 
     // hardcodes the right root, signature, proof, and callback (no callback)
     function take(
-        uint256 buyerAssets,
-        uint256 sellerAssets,
+        uint256 takerAssets,
         uint256 obligationUnits,
         uint256 obligationShares,
         address taker,
         Offer memory offer
     ) internal returns (uint256, uint256, uint256, uint256) {
         return morphoV2.take(
-            buyerAssets,
-            sellerAssets,
+            takerAssets,
             obligationUnits,
             obligationShares,
             taker,
@@ -115,7 +113,7 @@ abstract contract BaseTest is Test {
         lenderOffer.tick = TICK_RANGE;
 
         collateralize(obligation, otherBorrower, units);
-        take(0, 0, units, 0, otherBorrower, lenderOffer);
+        take(0, units, 0, otherBorrower, lenderOffer);
     }
 
     function createBadDebt(Obligation memory obligation) internal {
@@ -139,7 +137,7 @@ abstract contract BaseTest is Test {
 
         deal(address(loanToken), unluckyLender, 100);
 
-        take(100, 0, 0, 0, unluckyLender, badBorrowerOffer);
+        take(100, 0, 0, unluckyLender, badBorrowerOffer);
 
         Oracle(obligation.collaterals[0].oracle).setPrice(ORACLE_PRICE_SCALE / 4);
         morphoV2.liquidate(obligation, new Seizure[](0), badBorrower, "");
@@ -244,7 +242,6 @@ abstract contract BaseTest is Test {
         borrowerOffer.tick = TICK_RANGE;
 
         morphoV2.take(
-            0,
             0,
             obligationUnits,
             0,

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -89,7 +89,7 @@ contract TakeTest is BaseTest {
         uint256 expectedShares = expectedUnits.mulDivDown(initialShares + 1, initialUnits + 1);
         collateralize(obligation, borrower, expectedUnits);
 
-        take(buyerAssets, 0, 0, 0, lender, borrowerOffer);
+        take(buyerAssets, 0, 0, lender, borrowerOffer);
 
         assertEq(morphoV2.sharesOf(id, lender), expectedShares, "lender shares");
         assertEq(morphoV2.debtOf(id, borrower), expectedUnits, "borrower debt");
@@ -112,7 +112,7 @@ contract TakeTest is BaseTest {
         uint256 expectedShares = expectedUnits.mulDivDown(initialShares + 1, initialUnits + 1);
         collateralize(obligation, borrower, expectedUnits);
 
-        take(buyerAssets, 0, 0, 0, borrower, lenderOffer);
+        take(buyerAssets, 0, 0, borrower, lenderOffer);
 
         assertEq(morphoV2.sharesOf(id, lender), expectedShares, "lender shares");
         assertEq(morphoV2.debtOf(id, borrower), expectedUnits, "borrower debt");
@@ -135,7 +135,7 @@ contract TakeTest is BaseTest {
         collateralize(obligation, borrower, obligationUnits);
         borrowerOffer.assets = expectedAssets + 1;
 
-        take(0, 0, obligationUnits, 0, lender, borrowerOffer);
+        take(0, obligationUnits, 0, lender, borrowerOffer);
 
         assertEq(morphoV2.sharesOf(id, lender), expectedShares, "lender shares");
         assertEq(morphoV2.debtOf(id, borrower), obligationUnits, "borrower debt");
@@ -158,7 +158,7 @@ contract TakeTest is BaseTest {
         collateralize(obligation, borrower, obligationUnits);
         lenderOffer.assets = expectedAssets + 1;
 
-        take(0, 0, obligationUnits, 0, borrower, lenderOffer);
+        take(0, obligationUnits, 0, borrower, lenderOffer);
 
         assertEq(morphoV2.sharesOf(id, lender), expectedShares, "lender shares");
         assertEq(morphoV2.debtOf(id, borrower), obligationUnits, "borrower debt");
@@ -181,7 +181,7 @@ contract TakeTest is BaseTest {
         collateralize(obligation, borrower, obligationShares);
         borrowerOffer.assets = expectedAssets + 1;
 
-        take(0, 0, 0, obligationShares, lender, borrowerOffer);
+        take(0, 0, obligationShares, lender, borrowerOffer);
 
         assertEq(morphoV2.sharesOf(id, lender), obligationShares, "lender shares");
         assertEq(morphoV2.debtOf(id, borrower), expectedUnits, "borrower debt");
@@ -204,7 +204,7 @@ contract TakeTest is BaseTest {
         collateralize(obligation, borrower, obligationShares);
         lenderOffer.assets = expectedAssets + 1;
 
-        take(0, 0, 0, obligationShares, borrower, lenderOffer);
+        take(0, 0, obligationShares, borrower, lenderOffer);
 
         assertEq(morphoV2.sharesOf(id, lender), obligationShares, "lender shares");
         assertEq(morphoV2.debtOf(id, borrower), expectedUnits, "borrower debt");
@@ -232,7 +232,7 @@ contract TakeTest is BaseTest {
         otherLenderOffer.assets = buyerAssets;
         otherLenderOffer.tick = tick;
 
-        take(buyerAssets, 0, 0, 0, lender, otherLenderOffer);
+        take(buyerAssets, 0, 0, lender, otherLenderOffer);
 
         assertApproxEqAbs(morphoV2.sharesOf(id, lender), expectedShares, 1, "lender shares");
         assertApproxEqAbs(
@@ -259,7 +259,7 @@ contract TakeTest is BaseTest {
         lenderOffer.assets = buyerAssets;
         lenderOffer.tick = tick;
 
-        take(buyerAssets, 0, 0, 0, otherLender, lenderOffer);
+        take(buyerAssets, 0, 0, otherLender, lenderOffer);
 
         assertApproxEqAbs(morphoV2.sharesOf(id, lender), expectedShares, 1, "lender shares");
         assertApproxEqAbs(
@@ -287,7 +287,7 @@ contract TakeTest is BaseTest {
         otherLenderOffer.assets = buyerAssets + 1;
         otherLenderOffer.tick = tick;
 
-        take(0, 0, obligationUnits, 0, lender, otherLenderOffer);
+        take(0, obligationUnits, 0, lender, otherLenderOffer);
 
         assertApproxEqAbs(morphoV2.sharesOf(id, lender), expectedShares, 1, "lender shares"); // TODO: approx
         assertApproxEqAbs(
@@ -315,7 +315,7 @@ contract TakeTest is BaseTest {
         lenderOffer.assets = buyerAssets + 1;
         lenderOffer.tick = tick;
 
-        take(0, 0, obligationUnits, 0, otherLender, lenderOffer);
+        take(0, obligationUnits, 0, otherLender, lenderOffer);
 
         assertApproxEqAbs(morphoV2.sharesOf(id, lender), expectedShares, 1, "lender shares"); // TODO: approx
         assertApproxEqAbs(
@@ -344,7 +344,7 @@ contract TakeTest is BaseTest {
         otherLenderOffer.assets = type(uint256).max;
         otherLenderOffer.tick = tick;
 
-        take(0, 0, 0, obligationShares, lender, otherLenderOffer);
+        take(0, 0, obligationShares, lender, otherLenderOffer);
 
         assertApproxEqAbs(morphoV2.sharesOf(id, lender), obligationShares, 1, "lender shares"); // TODO: approx
         assertApproxEqAbs(
@@ -372,7 +372,7 @@ contract TakeTest is BaseTest {
         lenderOffer.assets = type(uint256).max;
         lenderOffer.tick = tick;
 
-        take(0, 0, 0, obligationShares, otherLender, lenderOffer);
+        take(0, 0, obligationShares, otherLender, lenderOffer);
 
         assertApproxEqAbs(morphoV2.sharesOf(id, lender), obligationShares, 1, "lender shares"); // TODO: approx
         assertApproxEqAbs(
@@ -391,10 +391,10 @@ contract TakeTest is BaseTest {
         setupOtherUsers(obligation, otherLenderUnits);
 
         vm.expectRevert(stdError.arithmeticError);
-        take(0, 0, obligationUnits, 0, lender, otherLenderOffer);
+        take(0, obligationUnits, 0, lender, otherLenderOffer);
 
         vm.expectRevert(stdError.arithmeticError);
-        take(0, 0, obligationUnits, 0, otherLender, lenderOffer);
+        take(0, obligationUnits, 0, otherLender, lenderOffer);
     }
 
     // path 3: Borrower exits + borrower enters.
@@ -412,7 +412,7 @@ contract TakeTest is BaseTest {
         borrowerOffer.assets = buyerAssets;
         borrowerOffer.tick = tick;
 
-        take(buyerAssets, 0, 0, 0, otherBorrower, borrowerOffer);
+        take(buyerAssets, 0, 0, otherBorrower, borrowerOffer);
 
         assertEq(morphoV2.debtOf(id, borrower), expectedUnits, "borrower shares");
         assertEq(morphoV2.debtOf(id, otherBorrower), otherBorrowerDebt - expectedUnits, "otherBorrower debt");
@@ -436,7 +436,7 @@ contract TakeTest is BaseTest {
         otherBorrowerOffer.assets = buyerAssets;
         otherBorrowerOffer.tick = tick;
 
-        take(buyerAssets, 0, 0, 0, borrower, otherBorrowerOffer);
+        take(buyerAssets, 0, 0, borrower, otherBorrowerOffer);
 
         assertEq(morphoV2.debtOf(id, borrower), expectedUnits, "borrower debt");
         assertEq(morphoV2.debtOf(id, otherBorrower), otherBorrowerDebt - expectedUnits, "otherBorrower debt");
@@ -460,7 +460,7 @@ contract TakeTest is BaseTest {
         borrowerOffer.assets = buyerAssets + 1;
         borrowerOffer.tick = tick;
 
-        take(0, 0, obligationUnits, 0, otherBorrower, borrowerOffer);
+        take(0, obligationUnits, 0, otherBorrower, borrowerOffer);
 
         assertEq(morphoV2.debtOf(id, borrower), obligationUnits, "otherBorrower debt");
         assertEq(morphoV2.debtOf(id, otherBorrower), otherBorrowerDebt - obligationUnits, "otherBorrower debt");
@@ -483,7 +483,7 @@ contract TakeTest is BaseTest {
         otherBorrowerOffer.assets = buyerAssets + 1;
         otherBorrowerOffer.tick = tick;
 
-        take(0, 0, obligationUnits, 0, borrower, otherBorrowerOffer);
+        take(0, obligationUnits, 0, borrower, otherBorrowerOffer);
 
         assertEq(morphoV2.debtOf(id, borrower), obligationUnits, "borrower debt");
         assertEq(morphoV2.debtOf(id, otherBorrower), otherBorrowerDebt - obligationUnits, "otherBorrower debt");
@@ -507,7 +507,7 @@ contract TakeTest is BaseTest {
         borrowerOffer.assets = buyerAssets + 1;
         borrowerOffer.tick = tick;
 
-        take(0, 0, 0, obligationShares, otherBorrower, borrowerOffer);
+        take(0, 0, obligationShares, otherBorrower, borrowerOffer);
 
         assertApproxEqAbs(morphoV2.debtOf(id, borrower), expectedUnits, 1, "borrower debt");
         assertApproxEqAbs(
@@ -535,7 +535,7 @@ contract TakeTest is BaseTest {
         otherBorrowerOffer.assets = type(uint256).max;
         otherBorrowerOffer.tick = tick;
 
-        take(0, 0, 0, obligationShares, borrower, otherBorrowerOffer);
+        take(0, 0, obligationShares, borrower, otherBorrowerOffer);
 
         assertApproxEqAbs(morphoV2.debtOf(id, borrower), expectedUnits, 1, "borrower debt");
         assertApproxEqAbs(
@@ -556,10 +556,10 @@ contract TakeTest is BaseTest {
         setupOtherUsers(obligation, otherUnits);
 
         vm.expectRevert(stdError.arithmeticError);
-        take(0, 0, obligationUnits, 0, borrower, otherBorrowerOffer);
+        take(0, obligationUnits, 0, borrower, otherBorrowerOffer);
 
         vm.expectRevert(stdError.arithmeticError);
-        take(0, 0, obligationUnits, 0, otherBorrower, borrowerOffer);
+        take(0, obligationUnits, 0, otherBorrower, borrowerOffer);
     }
 
     // path 4: Borrower exits + lender exits.
@@ -577,7 +577,7 @@ contract TakeTest is BaseTest {
         otherLenderOffer.assets = buyerAssets;
         otherLenderOffer.tick = tick;
 
-        take(buyerAssets, 0, 0, 0, otherBorrower, otherLenderOffer);
+        take(buyerAssets, 0, 0, otherBorrower, otherLenderOffer);
 
         assertApproxEqAbs(
             morphoV2.sharesOf(id, otherLender), otherLenderShares - expectedShares, 1, "otherLender shares"
@@ -605,7 +605,7 @@ contract TakeTest is BaseTest {
         otherBorrowerOffer.assets = buyerAssets;
         otherBorrowerOffer.tick = tick;
 
-        take(buyerAssets, 0, 0, 0, otherLender, otherBorrowerOffer);
+        take(buyerAssets, 0, 0, otherLender, otherBorrowerOffer);
 
         assertApproxEqAbs(
             morphoV2.sharesOf(id, otherLender), otherLenderShares - expectedShares, 1, "otherLender shares"
@@ -633,7 +633,7 @@ contract TakeTest is BaseTest {
         otherLenderOffer.assets = buyerAssets + 1;
         otherLenderOffer.tick = tick;
 
-        take(0, 0, obligationUnits, 0, otherBorrower, otherLenderOffer);
+        take(0, obligationUnits, 0, otherBorrower, otherLenderOffer);
 
         assertApproxEqAbs(
             morphoV2.sharesOf(id, otherLender), otherLenderShares - expectedShares, 1, "otherLender shares"
@@ -661,7 +661,7 @@ contract TakeTest is BaseTest {
         otherBorrowerOffer.assets = buyerAssets + 1;
         otherBorrowerOffer.tick = tick;
 
-        take(0, 0, obligationUnits, 0, otherLender, otherBorrowerOffer);
+        take(0, obligationUnits, 0, otherLender, otherBorrowerOffer);
 
         assertApproxEqAbs(
             morphoV2.sharesOf(id, otherLender), otherLenderShares - expectedShares, 1, "otherLender shares"
@@ -690,7 +690,7 @@ contract TakeTest is BaseTest {
         otherLenderOffer.assets = type(uint256).max;
         otherLenderOffer.tick = tick;
 
-        take(0, 0, 0, obligationShares, otherBorrower, otherLenderOffer);
+        take(0, 0, obligationShares, otherBorrower, otherLenderOffer);
 
         assertApproxEqAbs(
             morphoV2.sharesOf(id, otherLender), otherLenderShares - obligationShares, 1, "otherLender shares"
@@ -719,7 +719,7 @@ contract TakeTest is BaseTest {
         otherBorrowerOffer.assets = type(uint256).max;
         otherBorrowerOffer.tick = tick;
 
-        take(0, 0, 0, obligationShares, otherLender, otherBorrowerOffer);
+        take(0, 0, obligationShares, otherLender, otherBorrowerOffer);
 
         assertApproxEqAbs(
             morphoV2.sharesOf(id, otherLender), otherLenderShares - obligationShares, 1, "otherLender shares"
@@ -752,12 +752,12 @@ contract TakeTest is BaseTest {
         deal(address(loanToken), lender, offerAmount);
         collateralize(obligation, borrower, offerAmount.mulDivDown(WAD, TickLib.tickToPrice(borrowerOffer.tick)));
 
-        take(assets, 0, 0, 0, lender, borrowerOffer);
+        take(assets, 0, 0, lender, borrowerOffer);
 
         vm.expectRevert("consumed");
-        take(secondRevertingTake, 0, 0, 0, lender, borrowerOffer);
+        take(secondRevertingTake, 0, 0, lender, borrowerOffer);
 
-        take(secondPassingTake, 0, 0, 0, lender, borrowerOffer);
+        take(secondPassingTake, 0, 0, lender, borrowerOffer);
     }
 
     function testSellConsumedAssets(
@@ -775,12 +775,12 @@ contract TakeTest is BaseTest {
         deal(address(loanToken), lender, offerAmount);
         collateralize(obligation, borrower, offerAmount.mulDivDown(WAD, TickLib.tickToPrice(lenderOffer.tick)));
 
-        take(assets, 0, 0, 0, borrower, lenderOffer);
+        take(assets, 0, 0, borrower, lenderOffer);
 
         vm.expectRevert("consumed");
-        take(secondRevertingTake, 0, 0, 0, borrower, lenderOffer);
+        take(secondRevertingTake, 0, 0, borrower, lenderOffer);
 
-        take(secondPassingTake, 0, 0, 0, borrower, lenderOffer);
+        take(secondPassingTake, 0, 0, borrower, lenderOffer);
     }
 
     function testBuyGroupAssets(uint256 firstFill, uint256 secondFill) public {
@@ -796,12 +796,12 @@ contract TakeTest is BaseTest {
             borrowerOffer2.obligation, borrower, secondFill.mulDivDown(WAD, TickLib.tickToPrice(borrowerOffer.tick))
         );
 
-        take(firstFill, 0, 0, 0, lender, borrowerOffer);
+        take(firstFill, 0, 0, lender, borrowerOffer);
 
         vm.expectRevert("consumed");
-        take(secondFill + 1, 0, 0, 0, lender, borrowerOffer2);
+        take(secondFill + 1, 0, 0, lender, borrowerOffer2);
 
-        take(secondFill, 0, 0, 0, lender, borrowerOffer2);
+        take(secondFill, 0, 0, lender, borrowerOffer2);
     }
 
     function testSellGroupAssets(uint256 firstFill, uint256 secondFill) public {
@@ -817,12 +817,12 @@ contract TakeTest is BaseTest {
             lenderOffer2.obligation, borrower, secondFill.mulDivDown(WAD, TickLib.tickToPrice(lenderOffer.tick))
         );
 
-        take(firstFill, 0, 0, 0, borrower, lenderOffer);
+        take(firstFill, 0, 0, borrower, lenderOffer);
 
         vm.expectRevert("consumed");
-        take(secondFill + 1, 0, 0, 0, borrower, lenderOffer2);
+        take(secondFill + 1, 0, 0, borrower, lenderOffer2);
 
-        take(secondFill, 0, 0, 0, borrower, lenderOffer2);
+        take(secondFill, 0, 0, borrower, lenderOffer2);
     }
 
     // with obligation units
@@ -842,12 +842,12 @@ contract TakeTest is BaseTest {
         deal(address(loanToken), lender, offerObligationUnits);
         collateralize(obligation, borrower, offerObligationUnits);
 
-        take(0, 0, obligationUnits, 0, lender, borrowerOffer);
+        take(0, obligationUnits, 0, lender, borrowerOffer);
 
         vm.expectRevert("consumed");
-        take(0, 0, secondRevertingTake, 0, lender, borrowerOffer);
+        take(0, secondRevertingTake, 0, lender, borrowerOffer);
 
-        take(0, 0, secondPassingTake, 0, lender, borrowerOffer);
+        take(0, secondPassingTake, 0, lender, borrowerOffer);
     }
 
     function testSellConsumedUnits(
@@ -866,12 +866,12 @@ contract TakeTest is BaseTest {
         deal(address(loanToken), lender, offerObligationUnits);
         collateralize(obligation, borrower, offerObligationUnits);
 
-        take(0, 0, obligationUnits, 0, borrower, lenderOffer);
+        take(0, obligationUnits, 0, borrower, lenderOffer);
 
         vm.expectRevert("consumed");
-        take(0, 0, secondRevertingTake, 0, borrower, lenderOffer);
+        take(0, secondRevertingTake, 0, borrower, lenderOffer);
 
-        take(0, 0, secondPassingTake, 0, borrower, lenderOffer);
+        take(0, secondPassingTake, 0, borrower, lenderOffer);
     }
 
     function testBuyGroupUnits(uint256 firstFill, uint256 secondFill) public {
@@ -886,12 +886,12 @@ contract TakeTest is BaseTest {
         collateralize(obligation, borrower, firstFill);
         collateralize(borrowerOffer2.obligation, borrower, secondFill);
 
-        take(0, 0, firstFill, 0, lender, borrowerOffer);
+        take(0, firstFill, 0, lender, borrowerOffer);
 
         vm.expectRevert("consumed");
-        take(0, 0, secondFill + 1, 0, lender, borrowerOffer2);
+        take(0, secondFill + 1, 0, lender, borrowerOffer2);
 
-        take(0, 0, secondFill, 0, lender, borrowerOffer2);
+        take(0, secondFill, 0, lender, borrowerOffer2);
     }
 
     function testSellGroupUnits(uint256 firstFill, uint256 secondFill) public {
@@ -906,12 +906,12 @@ contract TakeTest is BaseTest {
         collateralize(obligation, borrower, firstFill);
         collateralize(lenderOffer2.obligation, borrower, secondFill);
 
-        take(0, 0, firstFill, 0, borrower, lenderOffer);
+        take(0, firstFill, 0, borrower, lenderOffer);
 
         vm.expectRevert("consumed");
-        take(0, 0, secondFill + 1, 0, borrower, lenderOffer2);
+        take(0, secondFill + 1, 0, borrower, lenderOffer2);
 
-        take(0, 0, secondFill, 0, borrower, lenderOffer2);
+        take(0, secondFill, 0, borrower, lenderOffer2);
     }
 
     // with obligation shares
@@ -931,12 +931,12 @@ contract TakeTest is BaseTest {
         deal(address(loanToken), lender, offerObligationShares);
         collateralize(obligation, borrower, offerObligationShares);
 
-        take(0, 0, 0, obligationShares, lender, borrowerOffer);
+        take(0, 0, obligationShares, lender, borrowerOffer);
 
         vm.expectRevert("consumed");
-        take(0, 0, 0, secondRevertingTake, lender, borrowerOffer);
+        take(0, 0, secondRevertingTake, lender, borrowerOffer);
 
-        take(0, 0, 0, secondPassingTake, lender, borrowerOffer);
+        take(0, 0, secondPassingTake, lender, borrowerOffer);
     }
 
     function testSellConsumedShares(
@@ -955,12 +955,12 @@ contract TakeTest is BaseTest {
         deal(address(loanToken), lender, offerObligationShares);
         collateralize(obligation, borrower, offerObligationShares);
 
-        take(0, 0, 0, obligationShares, borrower, lenderOffer);
+        take(0, 0, obligationShares, borrower, lenderOffer);
 
         vm.expectRevert("consumed");
-        take(0, 0, 0, secondRevertingTake, borrower, lenderOffer);
+        take(0, 0, secondRevertingTake, borrower, lenderOffer);
 
-        take(0, 0, 0, secondPassingTake, borrower, lenderOffer);
+        take(0, 0, secondPassingTake, borrower, lenderOffer);
     }
 
     function testBuyGroupShares(uint256 firstFill, uint256 secondFill) public {
@@ -975,12 +975,12 @@ contract TakeTest is BaseTest {
         collateralize(obligation, borrower, firstFill);
         collateralize(borrowerOffer2.obligation, borrower, secondFill);
 
-        take(0, 0, 0, firstFill, lender, borrowerOffer);
+        take(0, 0, firstFill, lender, borrowerOffer);
 
         vm.expectRevert("consumed");
-        take(0, 0, 0, secondFill + 1, lender, borrowerOffer2);
+        take(0, 0, secondFill + 1, lender, borrowerOffer2);
 
-        take(0, 0, 0, secondFill, lender, borrowerOffer2);
+        take(0, 0, secondFill, lender, borrowerOffer2);
     }
 
     function testSellGroupShares(uint256 firstFill, uint256 secondFill) public {
@@ -995,12 +995,12 @@ contract TakeTest is BaseTest {
         collateralize(obligation, borrower, firstFill);
         collateralize(lenderOffer2.obligation, borrower, secondFill);
 
-        take(0, 0, 0, firstFill, borrower, lenderOffer);
+        take(0, 0, firstFill, borrower, lenderOffer);
 
         vm.expectRevert("consumed");
-        take(0, 0, 0, secondFill + 1, borrower, lenderOffer2);
+        take(0, 0, secondFill + 1, borrower, lenderOffer2);
 
-        take(0, 0, 0, secondFill, borrower, lenderOffer2);
+        take(0, 0, secondFill, borrower, lenderOffer2);
     }
 
     // other tests.
@@ -1024,8 +1024,8 @@ contract TakeTest is BaseTest {
         deal(address(loanToken), address(this), units.mulDivDown(price1, WAD));
         collateralize(obligation, borrower, units);
 
-        take(0, 0, units, 0, address(this), borrowerOffer);
-        take(0, 0, units, 0, address(this), lenderOffer);
+        take(0, units, 0, address(this), borrowerOffer);
+        take(0, units, 0, address(this), lenderOffer);
 
         assertEq(morphoV2.sharesOf(id, address(this)), 0, "shares");
         assertEq(morphoV2.debtOf(id, address(this)), 0, "debt");
@@ -1057,8 +1057,8 @@ contract TakeTest is BaseTest {
         collateralize(obligation, borrower, units);
         collateralize(obligation, address(this), units);
 
-        take(0, 0, units, 0, address(this), lenderOffer);
-        take(0, 0, units, 0, address(this), borrowerOffer);
+        take(0, units, 0, address(this), lenderOffer);
+        take(0, units, 0, address(this), borrowerOffer);
 
         assertEq(morphoV2.sharesOf(id, address(this)), 0, "shares");
         assertEq(morphoV2.debtOf(id, address(this)), 0, "debt");
@@ -1082,7 +1082,7 @@ contract TakeTest is BaseTest {
         deal(address(loanToken), lender, 100);
         collateralize(obligation, borrower, 100);
 
-        take(100, 0, 0, 0, lender, borrowerOffer);
+        take(100, 0, 0, lender, borrowerOffer);
     }
 
     function testSellPastMaturity(uint256 timestamp) public {
@@ -1094,7 +1094,7 @@ contract TakeTest is BaseTest {
         deal(address(loanToken), lender, 100);
         collateralize(obligation, borrower, 100);
 
-        take(100, 0, 0, 0, borrower, lenderOffer);
+        take(100, 0, 0, borrower, lenderOffer);
     }
 
     function testBuyUnhealthy(uint256 units, uint256 tick, uint256 collateralized) public {
@@ -1108,7 +1108,7 @@ contract TakeTest is BaseTest {
         collateralize(obligation, borrower, collateralized);
 
         vm.expectRevert("Seller is unhealthy");
-        take(0, 0, units, 0, lender, borrowerOffer);
+        take(0, units, 0, lender, borrowerOffer);
     }
 
     function testSellUnhealthy(uint256 units, uint256 tick, uint256 collateralized) public {
@@ -1122,7 +1122,7 @@ contract TakeTest is BaseTest {
         collateralize(obligation, borrower, collateralized);
 
         vm.expectRevert("Seller is unhealthy");
-        take(0, 0, units, 0, borrower, lenderOffer);
+        take(0, units, 0, borrower, lenderOffer);
     }
 
     function testSession() public {
@@ -1130,7 +1130,7 @@ contract TakeTest is BaseTest {
         morphoV2.shuffleSession();
 
         vm.expectRevert("invalid session");
-        take(100, 0, 0, 0, borrower, lenderOffer);
+        take(100, 0, 0, borrower, lenderOffer);
     }
 
     // test tree / signatures.
@@ -1139,7 +1139,6 @@ contract TakeTest is BaseTest {
         vm.expectRevert("invalid signature");
         morphoV2.take(
             100,
-            0,
             0,
             0,
             borrower,
@@ -1158,7 +1157,6 @@ contract TakeTest is BaseTest {
             100,
             0,
             0,
-            0,
             borrower,
             lenderOffer,
             Signature({v: 0, r: 0, s: 0}),
@@ -1173,7 +1171,7 @@ contract TakeTest is BaseTest {
         vm.assume(proof.length >= 1);
         vm.expectRevert("invalid proof");
         morphoV2.take(
-            100, 0, 0, 0, borrower, lenderOffer, sig([lenderOffer]), root([lenderOffer]), proof, address(0), hex""
+            100, 0, 0, borrower, lenderOffer, sig([lenderOffer]), root([lenderOffer]), proof, address(0), hex""
         );
     }
 
@@ -1183,7 +1181,6 @@ contract TakeTest is BaseTest {
         vm.expectRevert("invalid proof");
         morphoV2.take(
             100,
-            0,
             0,
             0,
             borrower,
@@ -1204,7 +1201,6 @@ contract TakeTest is BaseTest {
 
         morphoV2.take(
             assets,
-            0,
             0,
             0,
             borrower,
@@ -1230,7 +1226,7 @@ contract TakeTest is BaseTest {
         deal(obligation.collaterals[0].token, borrowerOffer.callback, collateral);
         assertEq(morphoV2.collateralOf(id, borrower, obligation.collaterals[0].token), 0);
 
-        take(assets, 0, 0, 0, lender, borrowerOffer);
+        take(assets, 0, 0, lender, borrowerOffer);
 
         assertEq(morphoV2.collateralOf(id, borrower, obligation.collaterals[0].token), collateral);
         assertEq(BorrowCallback(borrowerOffer.callback).recordedData(), borrowerOffer.callbackData);
@@ -1247,7 +1243,6 @@ contract TakeTest is BaseTest {
 
         morphoV2.take(
             assets,
-            0,
             0,
             0,
             borrower,
@@ -1272,7 +1267,7 @@ contract TakeTest is BaseTest {
         deal(address(loanToken), lenderOffer.callback, assets);
         collateralize(obligation, borrower, assets);
 
-        take(assets, 0, 0, 0, borrower, lenderOffer);
+        take(assets, 0, 0, borrower, lenderOffer);
 
         assertEq(LendCallback(lenderOffer.callback).recordedData(), lenderOffer.callbackData);
     }
@@ -1290,7 +1285,6 @@ contract TakeTest is BaseTest {
 
         morphoV2.take(
             assets,
-            0,
             0,
             0,
             otherLender,

--- a/test/TradingFeeTest.sol
+++ b/test/TradingFeeTest.sol
@@ -55,7 +55,7 @@ contract TradingFeeTest is BaseTest {
         morphoV2.setTradingFeeRecipient(feeRecipient);
     }
 
-    function testBuyBuyerAssets(uint256 buyerAssets, uint256 sellerTick, uint256 tradingFee) public {
+    function testBuyTakerAssets(uint256 buyerAssets, uint256 sellerTick, uint256 tradingFee) public {
         buyerAssets = bound(buyerAssets, 0, MAX_TEST_AMOUNT);
         sellerTick = bound(sellerTick, 0, TICK_RANGE);
         uint256 sellerPrice = TickLib.tickToPrice(sellerTick);
@@ -69,52 +69,12 @@ contract TradingFeeTest is BaseTest {
         uint256 expectedFee = buyerAssets - expectedSellerAssets;
 
         collateralize(obligation, borrower, MAX_TEST_AMOUNT * 3);
-        take(buyerAssets, 0, 0, 0, lender, borrowerOffer);
+        take(buyerAssets, 0, 0, lender, borrowerOffer);
 
         assertApproxEqAbs(loanToken.balanceOf(feeRecipient), expectedFee, 100, "fee recipient balance");
     }
 
-    function testSellBuyerAssets(uint256 tradingFee, uint256 buyerTick, uint256 buyerAssets) public {
-        buyerAssets = bound(buyerAssets, 0, MAX_TEST_AMOUNT);
-        buyerTick = bound(buyerTick, 0, TICK_RANGE);
-        uint256 buyerPrice = TickLib.tickToPrice(buyerTick);
-        vm.assume(buyerPrice >= 0.5e18);
-        tradingFee = bound(tradingFee, 0, min(MAX_FEE, buyerPrice)) / 1e12 * 1e12;
-        morphoV2.setDefaultTradingFee(address(loanToken), 1, tradingFee);
-        lenderOffer.tick = buyerTick;
-
-        uint256 sellerPrice = buyerPrice - tradingFee;
-        uint256 expectedSellerAssets = buyerAssets.mulDivDown(sellerPrice, buyerPrice);
-        uint256 expectedFee = buyerAssets - expectedSellerAssets;
-
-        collateralize(obligation, borrower, MAX_TEST_AMOUNT * 3);
-        take(buyerAssets, 0, 0, 0, borrower, lenderOffer);
-
-        assertApproxEqAbs(
-            loanToken.balanceOf(feeRecipient), expectedFee, buyerAssets / 1e6 + 100, "fee recipient balance"
-        );
-    }
-
-    function testBuySellerAssets(uint256 tradingFee, uint256 sellerTick, uint256 sellerAssets) public {
-        sellerAssets = bound(sellerAssets, 0, MAX_TEST_AMOUNT);
-        sellerTick = bound(sellerTick, 0, TICK_RANGE);
-        uint256 sellerPrice = TickLib.tickToPrice(sellerTick);
-        vm.assume(sellerPrice >= 0.5e18);
-        tradingFee = bound(tradingFee, 0, min(MAX_FEE, 1 ether - sellerPrice)) / 1e12 * 1e12;
-        morphoV2.setDefaultTradingFee(address(loanToken), 1, tradingFee);
-        borrowerOffer.tick = sellerTick;
-
-        uint256 buyerPrice = sellerPrice + tradingFee;
-        uint256 expectedBuyerAssets = sellerAssets.mulDivDown(buyerPrice, sellerPrice);
-        uint256 expectedFee = expectedBuyerAssets - sellerAssets;
-
-        collateralize(obligation, borrower, MAX_TEST_AMOUNT * 3);
-        take(0, sellerAssets, 0, 0, lender, borrowerOffer);
-
-        assertApproxEqAbs(loanToken.balanceOf(feeRecipient), expectedFee, 100, "fee recipient balance");
-    }
-
-    function testSellSellerAssets(uint256 tradingFee, uint256 buyerTick, uint256 sellerAssets) public {
+    function testSellTakerAssets(uint256 tradingFee, uint256 buyerTick, uint256 sellerAssets) public {
         sellerAssets = bound(sellerAssets, 0, MAX_TEST_AMOUNT);
         buyerTick = bound(buyerTick, 0, TICK_RANGE);
         uint256 buyerPrice = TickLib.tickToPrice(buyerTick);
@@ -128,7 +88,7 @@ contract TradingFeeTest is BaseTest {
         uint256 expectedFee = expectedBuyerAssets - sellerAssets;
 
         collateralize(obligation, borrower, MAX_TEST_AMOUNT * 10);
-        take(0, sellerAssets, 0, 0, borrower, lenderOffer);
+        take(sellerAssets, 0, 0, borrower, lenderOffer);
 
         assertApproxEqAbs(loanToken.balanceOf(feeRecipient), expectedFee, 100, "fee recipient balance");
     }
@@ -148,7 +108,7 @@ contract TradingFeeTest is BaseTest {
         uint256 expectedFee = expectedBuyerAssets - expectedSellerAssets;
 
         collateralize(obligation, borrower, MAX_TEST_AMOUNT * 10);
-        take(0, 0, obligationUnits, 0, lender, borrowerOffer);
+        take(0, obligationUnits, 0, lender, borrowerOffer);
 
         assertApproxEqAbs(loanToken.balanceOf(feeRecipient), expectedFee, 100, "fee recipient balance");
     }
@@ -168,7 +128,7 @@ contract TradingFeeTest is BaseTest {
         uint256 expectedFee = expectedBuyerAssets - expectedSellerAssets;
 
         collateralize(obligation, borrower, MAX_TEST_AMOUNT * 3);
-        take(0, 0, obligationUnits, 0, borrower, lenderOffer);
+        take(0, obligationUnits, 0, borrower, lenderOffer);
 
         assertApproxEqAbs(loanToken.balanceOf(feeRecipient), expectedFee, 100, "fee recipient balance");
     }
@@ -188,7 +148,7 @@ contract TradingFeeTest is BaseTest {
         uint256 expectedFee = expectedBuyerAssets - expectedSellerAssets;
 
         collateralize(obligation, borrower, MAX_TEST_AMOUNT * 3);
-        take(0, 0, 0, obligationShares, lender, borrowerOffer);
+        take(0, 0, obligationShares, lender, borrowerOffer);
 
         assertApproxEqAbs(loanToken.balanceOf(feeRecipient), expectedFee, 100, "fee recipient balance");
     }
@@ -208,7 +168,7 @@ contract TradingFeeTest is BaseTest {
         uint256 expectedFee = expectedBuyerAssets - expectedSellerAssets;
 
         collateralize(obligation, borrower, MAX_TEST_AMOUNT * 3);
-        take(0, 0, 0, obligationShares, borrower, lenderOffer);
+        take(0, 0, obligationShares, borrower, lenderOffer);
 
         assertApproxEqAbs(loanToken.balanceOf(feeRecipient), expectedFee, 100, "fee recipient balance");
     }
@@ -227,7 +187,7 @@ contract TradingFeeTest is BaseTest {
         uint256 expectedFee = buyerAssets - expectedSellerAssets;
 
         collateralize(obligation, borrower, MAX_TEST_AMOUNT * 3);
-        take(buyerAssets, 0, 0, 0, lender, borrowerOffer);
+        take(buyerAssets, 0, 0, lender, borrowerOffer);
 
         assertApproxEqAbs(loanToken.balanceOf(feeRecipient), expectedFee, 100, "fee recipient balance");
     }
@@ -258,7 +218,7 @@ contract TradingFeeTest is BaseTest {
         uint256 expectedFee = buyerAssets - expectedSellerAssets;
 
         collateralize(obligation, borrower, MAX_TEST_AMOUNT * 3);
-        take(buyerAssets, 0, 0, 0, lender, borrowerOffer);
+        take(buyerAssets, 0, 0, lender, borrowerOffer);
 
         assertApproxEqAbs(loanToken.balanceOf(feeRecipient), expectedFee, 100, "fee recipient balance");
     }
@@ -285,7 +245,7 @@ contract TradingFeeTest is BaseTest {
         uint256 expectedFee = buyerAssets - expectedSellerAssets;
 
         collateralize(obligation, borrower, MAX_TEST_AMOUNT * 3);
-        take(buyerAssets, 0, 0, 0, lender, borrowerOffer);
+        take(buyerAssets, 0, 0, lender, borrowerOffer);
 
         assertApproxEqAbs(loanToken.balanceOf(feeRecipient), expectedFee, 100, "fee recipient balance");
     }
@@ -313,7 +273,7 @@ contract TradingFeeTest is BaseTest {
         uint256 expectedFee = buyerAssets - expectedSellerAssets;
 
         collateralize(obligation, borrower, MAX_TEST_AMOUNT * 3);
-        take(buyerAssets, 0, 0, 0, lender, borrowerOffer);
+        take(buyerAssets, 0, 0, lender, borrowerOffer);
 
         assertApproxEqAbs(loanToken.balanceOf(feeRecipient), expectedFee, 100, "fee recipient balance");
     }

--- a/test/UtilsLibTest.sol
+++ b/test/UtilsLibTest.sol
@@ -10,13 +10,6 @@ contract UtilsLibTest is Test {
         assertEq(UtilsLib.atMostOneNonZero(x, y), (x != 0 ? 1 : 0) + (y != 0 ? 1 : 0) <= 1);
     }
 
-    function testAtMostOneNonZero(uint256 a, uint256 b, uint256 c, uint256 d) public pure {
-        assertEq(
-            UtilsLib.atMostOneNonZero(a, b, c, d),
-            (a != 0 ? 1 : 0) + (b != 0 ? 1 : 0) + (c != 0 ? 1 : 0) + (d != 0 ? 1 : 0) <= 1
-        );
-    }
-
     function testMin(uint256 a, uint256 b) public pure {
         assertEq(UtilsLib.min(a, b), a < b ? a : b);
     }


### PR DESCRIPTION
Rationale:
- the buyer cares about the `buyerAssets` being exact, for example to invest precisely an amount (could be his exact balance)
- the seller cares about the `sellerAssets` being exact, for exact accounting (which could then be useful to invest precisely)
