### PR TITLE
opti health check and limit max number of collaterals

### DIFF
--- a/certora/confs/Hasher.conf
+++ b/certora/confs/Hasher.conf
@@ -5,6 +5,7 @@
   "verify": "Hasher:certora/specs/Hasher.spec",
   "solc": "solc-0.8.31",
   "solc_via_ir": true,
+  "solc_evm_version": "osaka",
   "server": "production",
   "msg": "MorphoV2 Hasher"
 }

--- a/certora/confs/MorphoV2.conf
+++ b/certora/confs/MorphoV2.conf
@@ -5,6 +5,7 @@
   "verify": "MorphoV2:certora/specs/MorphoV2.spec",
   "solc": "solc-0.8.31",
   "solc_via_ir": true,
+  "solc_evm_version": "osaka",
   "optimistic_loop": true,
   "loop_iter": 2,
   "optimistic_hashing": true,

--- a/certora/confs/SharePrice.conf
+++ b/certora/confs/SharePrice.conf
@@ -6,6 +6,7 @@
   "verify": "MorphoV2:certora/specs/SharePrice.spec",
   "solc": "solc-0.8.31",
   "solc_via_ir": true,
+  "solc_evm_version": "osaka",
   "optimistic_loop": true,
   "loop_iter": 2,
   "optimistic_hashing": true,

--- a/certora/specs/MorphoV2.spec
+++ b/certora/specs/MorphoV2.spec
@@ -30,7 +30,7 @@ persistent ghost mapping(bytes32 => mathint) sumDebtOf {
     init_state axiom (forall bytes32 id. sumDebtOf[id] == 0);
 }
 
-hook Sstore debtOf[KEY bytes32 id][KEY address owner] uint256 newDebt (uint256 oldDebt) {
+hook Sstore borrowerState[KEY bytes32 id][KEY address owner].debt uint128 newDebt (uint128 oldDebt) {
     sumDebtOf[id] = sumDebtOf[id] - oldDebt + newDebt;
 }
 

--- a/certora/specs/MorphoV2.spec
+++ b/certora/specs/MorphoV2.spec
@@ -8,7 +8,7 @@ methods {
     function totalShares(bytes32 id) external returns (uint256) envfree;
     function consumed(address user, bytes32 group) external returns (uint256) envfree;
     function sharesOf(bytes32 id, address owner) external returns (uint256) envfree;
-    function debtOf(bytes32 id, address owner) external returns (uint256) envfree;
+    function debtOf(bytes32 id, address user) external returns (uint256) envfree;
 
     function _.price() external => NONDET;
     function IdLib.toId(MorphoV2.Obligation memory, uint256, address) internal returns (bytes32) => NONDET;

--- a/foundry.toml
+++ b/foundry.toml
@@ -9,4 +9,4 @@ fs_permissions = [{ access = "read", path = "test/ticks_exact.json" }]
 wrap_comments = true
 
 [lint]
-exclude_lints = ["asm-keccak256", "unsafe-cheatcode"]
+exclude_lints = ["asm-keccak256", "unsafe-cheatcode", "incorrect-shift"]

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -364,7 +364,7 @@ contract MorphoV2 is IMorphoV2 {
         uint256 newCollateralOf = collateralOf[id][onBehalf][collateralToken] + assets;
         collateralOf[id][onBehalf][collateralToken] = newCollateralOf;
 
-        if (newCollateralOf != assets && assets != 0) {
+        if (newCollateralOf == assets && assets > 0) {
             // forge-lint: disable-next-item(unsafe-typecast) as collateralIndex < MAX_COLLATERALS (128)
             uint128 newBitmap = borrowerState[id][onBehalf].activatedCollaterals | uint128(1 << collateralIndex);
             borrowerState[id][onBehalf].activatedCollaterals = newBitmap;
@@ -399,7 +399,7 @@ contract MorphoV2 is IMorphoV2 {
         uint256 newCollateralOf = collateralOf[id][onBehalf][collateralToken] - assets;
         collateralOf[id][onBehalf][collateralToken] = newCollateralOf;
 
-        if (newCollateralOf == 0 && assets != 0) {
+        if (newCollateralOf == 0) {
             // forge-lint: disable-next-item(unsafe-typecast) as collateralIndex < MAX_COLLATERALS (128)
             borrowerState[id][onBehalf].activatedCollaterals &= ~uint128(1 << collateralIndex);
         }

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -13,6 +13,8 @@ import {
     MAX_FEE,
     MAX_LIF,
     TIME_TO_MAX_LIF,
+    MAX_COLLATERALS,
+    MAX_COLLATERALS_PER_BORROWER,
     EIP712_DOMAIN_TYPEHASH,
     ROOT_TYPEHASH
 } from "./libraries/ConstantsLib.sol";
@@ -31,6 +33,7 @@ contract MorphoV2 is IMorphoV2 {
     mapping(bytes32 id => mapping(address user => uint256)) public sharesOf;
     mapping(bytes32 id => mapping(address user => uint256)) public debtOf;
     mapping(bytes32 id => mapping(address user => mapping(address collateralToken => uint256))) public collateralOf;
+    mapping(bytes32 id => mapping(address user => uint256)) public activatedCollaterals;
     mapping(bytes32 id => ObligationState) public obligationState;
 
     /// @dev Groups are useful to have a global offered amount shared accross multiple offers ("OCO").
@@ -331,6 +334,12 @@ contract MorphoV2 is IMorphoV2 {
 
         collateralOf[id][onBehalf][collateralToken] += assets;
 
+        if (collateralOf[id][onBehalf][collateralToken] != 0) {
+            uint256 newBitmap = activatedCollaterals[id][onBehalf] | (1 << collateralIndex);
+            activatedCollaterals[id][onBehalf] = newBitmap;
+            require(UtilsLib.countBits(newBitmap) <= MAX_COLLATERALS_PER_BORROWER, "too many collaterals per borrower");
+        }
+
         address oracle = obligation.collaterals[collateralIndex].oracle;
         uint256 _collateralOf = collateralOf[id][onBehalf][collateralToken];
         require(
@@ -353,6 +362,9 @@ contract MorphoV2 is IMorphoV2 {
         address collateralToken = obligation.collaterals[collateralIndex].token;
 
         collateralOf[id][onBehalf][collateralToken] -= assets;
+        if (collateralOf[id][onBehalf][collateralToken] == 0) {
+            activatedCollaterals[id][onBehalf] &= ~(1 << collateralIndex);
+        }
 
         require(isHealthy(obligation, id, onBehalf), "Unhealthy borrower");
 
@@ -392,13 +404,16 @@ contract MorphoV2 is IMorphoV2 {
         uint256 repayableDebt;
         uint256 maxDebt;
         uint256 liquidatedCollateralPrice;
-        for (uint256 i = 0; i < obligation.collaterals.length; i++) {
+        uint256 bitmap = activatedCollaterals[id][borrower];
+        while (bitmap != 0) {
+            uint256 i = UtilsLib.ctz(bitmap);
             Collateral memory _collateral = obligation.collaterals[i];
             uint256 price = IOracle(_collateral.oracle).price();
             if (i == collateralIndex) liquidatedCollateralPrice = price;
             uint256 _collateralOf = collateralOf[id][borrower][_collateral.token];
             maxDebt += _collateralOf.mulDivDown(price, ORACLE_PRICE_SCALE).mulDivDown(_collateral.lltv, WAD);
             repayableDebt += _collateralOf.mulDivUp(WAD, MAX_LIF).mulDivUp(price, ORACLE_PRICE_SCALE);
+            bitmap &= bitmap - 1;
         }
 
         uint256 originalDebt = debtOf[id][borrower];
@@ -435,6 +450,9 @@ contract MorphoV2 is IMorphoV2 {
             }
 
             collateralOf[id][borrower][liquidatedCollateralToken] -= seizedAssets;
+            if (collateralOf[id][borrower][liquidatedCollateralToken] == 0) {
+                activatedCollaterals[id][borrower] &= ~(1 << collateralIndex);
+            }
             _obligationState.withdrawable += repaidUnits;
             debtOf[id][borrower] -= repaidUnits;
         }
@@ -485,6 +503,7 @@ contract MorphoV2 is IMorphoV2 {
     function touchObligation(Obligation memory obligation) public returns (bytes32) {
         bytes32 id = IdLib.toId(obligation, block.chainid, address(this));
         if (!obligationState[id].created) {
+            require(obligation.collaterals.length <= MAX_COLLATERALS, "too many collaterals");
             address previousCollateralToken;
             for (uint256 i = 0; i < obligation.collaterals.length; i++) {
                 address collateralToken = obligation.collaterals[i].token;
@@ -528,11 +547,14 @@ contract MorphoV2 is IMorphoV2 {
     function isHealthy(Obligation memory obligation, bytes32 id, address borrower) public view returns (bool) {
         uint256 debt = debtOf[id][borrower];
         uint256 maxDebt;
-        for (uint256 i = 0; i < obligation.collaterals.length && maxDebt < debt; i++) {
+        uint256 bitmap = activatedCollaterals[id][borrower];
+        while (bitmap != 0 && maxDebt < debt) {
+            uint256 i = UtilsLib.ctz(bitmap);
             Collateral memory collateral = obligation.collaterals[i];
             uint256 price = IOracle(collateral.oracle).price();
             maxDebt += collateralOf[id][borrower][collateral.token].mulDivDown(price, ORACLE_PRICE_SCALE)
                 .mulDivDown(collateral.lltv, WAD);
+            bitmap &= bitmap - 1;
         }
         return maxDebt >= debt;
     }

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -361,20 +361,21 @@ contract MorphoV2 is IMorphoV2 {
         bytes32 id = touchObligation(obligation);
         address collateralToken = obligation.collaterals[collateralIndex].token;
 
-        collateralOf[id][onBehalf][collateralToken] += assets;
+        uint256 newCollateralOf = collateralOf[id][onBehalf][collateralToken] + assets;
+        collateralOf[id][onBehalf][collateralToken] = newCollateralOf;
 
-        if (collateralOf[id][onBehalf][collateralToken] != 0) {
+        if (newCollateralOf != assets && assets != 0) {
             // forge-lint: disable-next-item(unsafe-typecast) as collateralIndex < MAX_COLLATERALS (128)
             uint128 newBitmap = borrowerState[id][onBehalf].activatedCollaterals | uint128(1 << collateralIndex);
             borrowerState[id][onBehalf].activatedCollaterals = newBitmap;
             require(UtilsLib.countBits(newBitmap) <= MAX_COLLATERALS_PER_BORROWER, "too many collaterals per borrower");
         }
 
-        address oracle = obligation.collaterals[collateralIndex].oracle;
-        uint256 _collateralOf = collateralOf[id][onBehalf][collateralToken];
         require(
-            _collateralOf == 0
-                || _collateralOf.mulDivDown(IOracle(oracle).price(), ORACLE_PRICE_SCALE) >= obligation.minCollatValue,
+            newCollateralOf == 0
+                || newCollateralOf.mulDivDown(
+                        IOracle(obligation.collaterals[collateralIndex].oracle).price(), ORACLE_PRICE_SCALE
+                    ) >= obligation.minCollatValue,
             "Below min collateral"
         );
 
@@ -395,19 +396,20 @@ contract MorphoV2 is IMorphoV2 {
         bytes32 id = touchObligation(obligation);
         address collateralToken = obligation.collaterals[collateralIndex].token;
 
-        collateralOf[id][onBehalf][collateralToken] -= assets;
-        if (collateralOf[id][onBehalf][collateralToken] == 0) {
+        uint256 newCollateralOf = collateralOf[id][onBehalf][collateralToken] - assets;
+        collateralOf[id][onBehalf][collateralToken] = newCollateralOf;
+
+        if (newCollateralOf == 0 && assets != 0) {
             // forge-lint: disable-next-item(unsafe-typecast) as collateralIndex < MAX_COLLATERALS (128)
             borrowerState[id][onBehalf].activatedCollaterals &= ~uint128(1 << collateralIndex);
         }
 
         require(isHealthy(obligation, id, onBehalf), "Unhealthy borrower");
-
-        address oracle = obligation.collaterals[collateralIndex].oracle;
-        uint256 _collateralOf = collateralOf[id][onBehalf][collateralToken];
         require(
-            _collateralOf == 0
-                || _collateralOf.mulDivDown(IOracle(oracle).price(), ORACLE_PRICE_SCALE) >= obligation.minCollatValue,
+            newCollateralOf == 0
+                || newCollateralOf.mulDivDown(
+                        IOracle(obligation.collaterals[collateralIndex].oracle).price(), ORACLE_PRICE_SCALE
+                    ) >= obligation.minCollatValue,
             "Below min collateral"
         );
 
@@ -589,11 +591,11 @@ contract MorphoV2 is IMorphoV2 {
     /// @dev This function should be called with the id corresponding to the obligation.
     /// @dev This function does not call any oracle if debt is 0.
     function isHealthy(Obligation memory obligation, bytes32 id, address borrower) public view returns (bool) {
-        BorrowerState storage _state = borrowerState[id][borrower];
-        uint256 debt = _state.debt;
+        BorrowerState storage _borrowerState = borrowerState[id][borrower];
+        uint256 debt = _borrowerState.debt;
         uint256 maxDebt;
-        uint256 bitmap = _state.activatedCollaterals;
-        while (bitmap != 0 && maxDebt < debt) {
+        uint256 bitmap = _borrowerState.activatedCollaterals;
+        while (maxDebt < debt && bitmap != 0) {
             uint256 i = UtilsLib.ctz(bitmap);
             Collateral memory collateral = obligation.collaterals[i];
             uint256 price = IOracle(collateral.oracle).price();

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -39,7 +39,7 @@ contract MorphoV2 is IMorphoV2 {
     /// STORAGE ///
 
     mapping(bytes32 id => mapping(address user => uint256)) public sharesOf;
-    mapping(bytes32 id => mapping(address user => BorrowerState)) internal _borrowerState;
+    mapping(bytes32 id => mapping(address user => BorrowerState)) public borrowerState;
     mapping(bytes32 id => mapping(address user => mapping(address collateralToken => uint256))) public collateralOf;
     mapping(bytes32 id => ObligationState) public obligationState;
 
@@ -236,12 +236,12 @@ contract MorphoV2 is IMorphoV2 {
             require(newConsumed <= offer.obligationShares, "consumed");
         }
 
-        bool buyerIsLender = (_borrowerState[id][buyer].debt == 0);
+        bool buyerIsLender = (borrowerState[id][buyer].debt == 0);
         bool sellerIsBorrower = (sharesOf[id][seller] == 0);
         if (buyerIsLender && sellerIsBorrower) {
             // Lender enters + borrower enters.
             sharesOf[id][buyer] += obligationShares;
-            _borrowerState[id][seller].debt += UtilsLib.toUint128(obligationUnits);
+            borrowerState[id][seller].debt += UtilsLib.toUint128(obligationUnits);
             _obligationState.totalShares += UtilsLib.toUint128(obligationShares);
             _obligationState.totalUnits += UtilsLib.toUint128(obligationUnits);
         } else if (buyerIsLender && !sellerIsBorrower) {
@@ -250,11 +250,11 @@ contract MorphoV2 is IMorphoV2 {
             sharesOf[id][seller] -= obligationShares;
         } else if (!buyerIsLender && sellerIsBorrower) {
             // Borrower exits + borrower enters.
-            _borrowerState[id][buyer].debt -= UtilsLib.toUint128(obligationUnits);
-            _borrowerState[id][seller].debt += UtilsLib.toUint128(obligationUnits);
+            borrowerState[id][buyer].debt -= UtilsLib.toUint128(obligationUnits);
+            borrowerState[id][seller].debt += UtilsLib.toUint128(obligationUnits);
         } else {
             // Borrower exits + lender exits.
-            _borrowerState[id][buyer].debt -= UtilsLib.toUint128(obligationUnits);
+            borrowerState[id][buyer].debt -= UtilsLib.toUint128(obligationUnits);
             sharesOf[id][seller] -= obligationShares;
             _obligationState.totalShares -= UtilsLib.toUint128(obligationShares);
             _obligationState.totalUnits -= UtilsLib.toUint128(obligationUnits);
@@ -347,7 +347,7 @@ contract MorphoV2 is IMorphoV2 {
     function repay(Obligation memory obligation, uint256 obligationUnits, address onBehalf) external {
         bytes32 id = touchObligation(obligation);
 
-        _borrowerState[id][onBehalf].debt -= UtilsLib.toUint128(obligationUnits);
+        borrowerState[id][onBehalf].debt -= UtilsLib.toUint128(obligationUnits);
         obligationState[id].withdrawable += obligationUnits;
 
         emit EventsLib.Repay(msg.sender, id, obligationUnits, onBehalf);
@@ -365,8 +365,8 @@ contract MorphoV2 is IMorphoV2 {
 
         if (collateralOf[id][onBehalf][collateralToken] != 0) {
             // forge-lint: disable-next-item(unsafe-typecast) as collateralIndex < MAX_COLLATERALS (128)
-            uint128 newBitmap = _borrowerState[id][onBehalf].activatedCollaterals | uint128(1 << collateralIndex);
-            _borrowerState[id][onBehalf].activatedCollaterals = newBitmap;
+            uint128 newBitmap = borrowerState[id][onBehalf].activatedCollaterals | uint128(1 << collateralIndex);
+            borrowerState[id][onBehalf].activatedCollaterals = newBitmap;
             require(UtilsLib.countBits(newBitmap) <= MAX_COLLATERALS_PER_BORROWER, "too many collaterals per borrower");
         }
 
@@ -398,7 +398,7 @@ contract MorphoV2 is IMorphoV2 {
         collateralOf[id][onBehalf][collateralToken] -= assets;
         if (collateralOf[id][onBehalf][collateralToken] == 0) {
             // forge-lint: disable-next-item(unsafe-typecast) as collateralIndex < MAX_COLLATERALS (128)
-            _borrowerState[id][onBehalf].activatedCollaterals &= ~uint128(1 << collateralIndex);
+            borrowerState[id][onBehalf].activatedCollaterals &= ~uint128(1 << collateralIndex);
         }
 
         require(isHealthy(obligation, id, onBehalf), "Unhealthy borrower");
@@ -440,7 +440,7 @@ contract MorphoV2 is IMorphoV2 {
         uint256 repayableDebt;
         uint256 maxDebt;
         uint256 liquidatedCollatPrice;
-        BorrowerState storage _state = _borrowerState[id][borrower];
+        BorrowerState storage _state = borrowerState[id][borrower];
         uint256 bitmap = _state.activatedCollaterals;
         while (bitmap != 0) {
             uint256 i = UtilsLib.ctz(bitmap);
@@ -559,11 +559,11 @@ contract MorphoV2 is IMorphoV2 {
     /// VIEW FUNCTIONS ///
 
     function debtOf(bytes32 id, address user) external view returns (uint256) {
-        return _borrowerState[id][user].debt;
+        return borrowerState[id][user].debt;
     }
 
     function activatedCollaterals(bytes32 id, address user) external view returns (uint256) {
-        return _borrowerState[id][user].activatedCollaterals;
+        return borrowerState[id][user].activatedCollaterals;
     }
 
     function totalUnits(bytes32 id) external view returns (uint256) {
@@ -589,7 +589,7 @@ contract MorphoV2 is IMorphoV2 {
     /// @dev This function should be called with the id corresponding to the obligation.
     /// @dev This function does not call any oracle if debt is 0.
     function isHealthy(Obligation memory obligation, bytes32 id, address borrower) public view returns (bool) {
-        BorrowerState storage _state = _borrowerState[id][borrower];
+        BorrowerState storage _state = borrowerState[id][borrower];
         uint256 debt = _state.debt;
         uint256 maxDebt;
         uint256 bitmap = _state.activatedCollaterals;

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -19,7 +19,15 @@ import {
     ROOT_TYPEHASH
 } from "./libraries/ConstantsLib.sol";
 import {IOracle} from "./interfaces/IOracle.sol";
-import {IMorphoV2, Obligation, Offer, Signature, Collateral, ObligationState} from "./interfaces/IMorphoV2.sol";
+import {
+    IMorphoV2,
+    Obligation,
+    Offer,
+    Signature,
+    Collateral,
+    BorrowerState,
+    ObligationState
+} from "./interfaces/IMorphoV2.sol";
 import {ICallbacks, IFlashLoanCallback} from "./interfaces/ICallbacks.sol";
 import {EventsLib} from "./libraries/EventsLib.sol";
 
@@ -31,9 +39,8 @@ contract MorphoV2 is IMorphoV2 {
     /// STORAGE ///
 
     mapping(bytes32 id => mapping(address user => uint256)) public sharesOf;
-    mapping(bytes32 id => mapping(address user => uint256)) public debtOf;
+    mapping(bytes32 id => mapping(address user => BorrowerState)) internal _borrowerState;
     mapping(bytes32 id => mapping(address user => mapping(address collateralToken => uint256))) public collateralOf;
-    mapping(bytes32 id => mapping(address user => uint256)) public activatedCollaterals;
     mapping(bytes32 id => ObligationState) public obligationState;
 
     /// @dev Groups are useful to have a global offered amount shared accross multiple offers ("OCO").
@@ -229,12 +236,12 @@ contract MorphoV2 is IMorphoV2 {
             require(newConsumed <= offer.obligationShares, "consumed");
         }
 
-        bool buyerIsLender = (debtOf[id][buyer] == 0);
+        bool buyerIsLender = (_borrowerState[id][buyer].debt == 0);
         bool sellerIsBorrower = (sharesOf[id][seller] == 0);
         if (buyerIsLender && sellerIsBorrower) {
             // Lender enters + borrower enters.
             sharesOf[id][buyer] += obligationShares;
-            debtOf[id][seller] += obligationUnits;
+            _borrowerState[id][seller].debt += UtilsLib.toUint128(obligationUnits);
             _obligationState.totalShares += UtilsLib.toUint128(obligationShares);
             _obligationState.totalUnits += UtilsLib.toUint128(obligationUnits);
         } else if (buyerIsLender && !sellerIsBorrower) {
@@ -243,11 +250,11 @@ contract MorphoV2 is IMorphoV2 {
             sharesOf[id][seller] -= obligationShares;
         } else if (!buyerIsLender && sellerIsBorrower) {
             // Borrower exits + borrower enters.
-            debtOf[id][buyer] -= obligationUnits;
-            debtOf[id][seller] += obligationUnits;
+            _borrowerState[id][buyer].debt -= UtilsLib.toUint128(obligationUnits);
+            _borrowerState[id][seller].debt += UtilsLib.toUint128(obligationUnits);
         } else {
             // Borrower exits + lender exits.
-            debtOf[id][buyer] -= obligationUnits;
+            _borrowerState[id][buyer].debt -= UtilsLib.toUint128(obligationUnits);
             sharesOf[id][seller] -= obligationShares;
             _obligationState.totalShares -= UtilsLib.toUint128(obligationShares);
             _obligationState.totalUnits -= UtilsLib.toUint128(obligationUnits);
@@ -340,7 +347,7 @@ contract MorphoV2 is IMorphoV2 {
     function repay(Obligation memory obligation, uint256 obligationUnits, address onBehalf) external {
         bytes32 id = touchObligation(obligation);
 
-        debtOf[id][onBehalf] -= obligationUnits;
+        _borrowerState[id][onBehalf].debt -= UtilsLib.toUint128(obligationUnits);
         obligationState[id].withdrawable += obligationUnits;
 
         emit EventsLib.Repay(msg.sender, id, obligationUnits, onBehalf);
@@ -357,8 +364,9 @@ contract MorphoV2 is IMorphoV2 {
         collateralOf[id][onBehalf][collateralToken] += assets;
 
         if (collateralOf[id][onBehalf][collateralToken] != 0) {
-            uint256 newBitmap = activatedCollaterals[id][onBehalf] | (1 << collateralIndex);
-            activatedCollaterals[id][onBehalf] = newBitmap;
+            // forge-lint: disable-next-item(unsafe-typecast) as collateralIndex < MAX_COLLATERALS (128)
+            uint128 newBitmap = _borrowerState[id][onBehalf].activatedCollaterals | uint128(1 << collateralIndex);
+            _borrowerState[id][onBehalf].activatedCollaterals = newBitmap;
             require(UtilsLib.countBits(newBitmap) <= MAX_COLLATERALS_PER_BORROWER, "too many collaterals per borrower");
         }
 
@@ -389,7 +397,8 @@ contract MorphoV2 is IMorphoV2 {
 
         collateralOf[id][onBehalf][collateralToken] -= assets;
         if (collateralOf[id][onBehalf][collateralToken] == 0) {
-            activatedCollaterals[id][onBehalf] &= ~(1 << collateralIndex);
+            // forge-lint: disable-next-item(unsafe-typecast) as collateralIndex < MAX_COLLATERALS (128)
+            _borrowerState[id][onBehalf].activatedCollaterals &= ~uint128(1 << collateralIndex);
         }
 
         require(isHealthy(obligation, id, onBehalf), "Unhealthy borrower");
@@ -431,7 +440,8 @@ contract MorphoV2 is IMorphoV2 {
         uint256 repayableDebt;
         uint256 maxDebt;
         uint256 liquidatedCollatPrice;
-        uint256 bitmap = activatedCollaterals[id][borrower];
+        BorrowerState storage _state = _borrowerState[id][borrower];
+        uint256 bitmap = _state.activatedCollaterals;
         while (bitmap != 0) {
             uint256 i = UtilsLib.ctz(bitmap);
             Collateral memory _collateral = obligation.collaterals[i];
@@ -443,12 +453,12 @@ contract MorphoV2 is IMorphoV2 {
             bitmap &= bitmap - 1;
         }
 
-        uint256 originalDebt = debtOf[id][borrower];
+        uint256 originalDebt = _state.debt;
         require(block.timestamp > obligation.maturity || originalDebt > maxDebt, "position is not liquidatable");
 
         uint256 badDebt = originalDebt.zeroFloorSub(repayableDebt);
         if (badDebt > 0) {
-            debtOf[id][borrower] -= badDebt;
+            _state.debt -= UtilsLib.toUint128(badDebt);
             _obligationState.totalUnits -= UtilsLib.toUint128(badDebt);
         }
 
@@ -469,16 +479,17 @@ contract MorphoV2 is IMorphoV2 {
                 uint256 lltv = obligation.collaterals[collateralIndex].lltv;
                 // Rounded up to avoid consecutive max liquidations.
                 // Acknowledged that the position could be slightly healthy after a liquidation.
-                uint256 maxRepaid = (debtOf[id][borrower] - maxDebt).mulDivUp(WAD, WAD - lif.mulDivUp(lltv, WAD));
+                uint256 maxRepaid = (uint256(_state.debt) - maxDebt).mulDivUp(WAD, WAD - lif.mulDivUp(lltv, WAD));
                 require(repaidUnits <= maxRepaid, "recovery close factor violated");
             }
 
             collateralOf[id][borrower][liquidatedCollatToken] -= seizedAssets;
             if (collateralOf[id][borrower][liquidatedCollatToken] == 0) {
-                activatedCollaterals[id][borrower] &= ~(1 << collateralIndex);
+                // forge-lint: disable-next-item(unsafe-typecast) as collateralIndex < MAX_COLLATERALS (128)
+                _state.activatedCollaterals &= ~uint128(1 << collateralIndex);
             }
             _obligationState.withdrawable += repaidUnits;
-            debtOf[id][borrower] -= repaidUnits;
+            _state.debt -= UtilsLib.toUint128(repaidUnits);
         }
 
         emit EventsLib.Liquidate(msg.sender, id, collateralIndex, seizedAssets, repaidUnits, borrower, badDebt);
@@ -547,6 +558,14 @@ contract MorphoV2 is IMorphoV2 {
 
     /// VIEW FUNCTIONS ///
 
+    function debtOf(bytes32 id, address user) external view returns (uint256) {
+        return _borrowerState[id][user].debt;
+    }
+
+    function activatedCollaterals(bytes32 id, address user) external view returns (uint256) {
+        return _borrowerState[id][user].activatedCollaterals;
+    }
+
     function totalUnits(bytes32 id) external view returns (uint256) {
         return obligationState[id].totalUnits;
     }
@@ -570,9 +589,10 @@ contract MorphoV2 is IMorphoV2 {
     /// @dev This function should be called with the id corresponding to the obligation.
     /// @dev This function does not call any oracle if debt is 0.
     function isHealthy(Obligation memory obligation, bytes32 id, address borrower) public view returns (bool) {
-        uint256 debt = debtOf[id][borrower];
+        BorrowerState storage _state = _borrowerState[id][borrower];
+        uint256 debt = _state.debt;
         uint256 maxDebt;
-        uint256 bitmap = activatedCollaterals[id][borrower];
+        uint256 bitmap = _state.activatedCollaterals;
         while (bitmap != 0 && maxDebt < debt) {
             uint256 i = UtilsLib.ctz(bitmap);
             Collateral memory collateral = obligation.collaterals[i];

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -149,7 +149,7 @@ contract MorphoV2 is IMorphoV2 {
         Signature memory sig,
         bytes32 root,
         bytes32[] memory proof
-    ) public returns (uint256, uint256, uint256, uint256) {
+    ) external returns (uint256, uint256, uint256, uint256) {
         require(taker == msg.sender || isAuthorized[taker][msg.sender], "UNAUTHORIZED");
         require(
             UtilsLib.atMostOneNonZero(buyerAssets, sellerAssets, obligationUnits, obligationShares),

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -399,7 +399,7 @@ contract MorphoV2 is IMorphoV2 {
         uint256 newCollateralOf = collateralOf[id][onBehalf][collateralToken] - assets;
         collateralOf[id][onBehalf][collateralToken] = newCollateralOf;
 
-        if (newCollateralOf == 0) {
+        if (newCollateralOf == 0 && assets > 0) {
             // forge-lint: disable-next-item(unsafe-typecast) as collateralIndex < MAX_COLLATERALS (128)
             borrowerState[id][onBehalf].activatedCollaterals &= ~uint128(1 << collateralIndex);
         }
@@ -445,14 +445,14 @@ contract MorphoV2 is IMorphoV2 {
         BorrowerState storage _state = borrowerState[id][borrower];
         uint256 bitmap = _state.activatedCollaterals;
         while (bitmap != 0) {
-            uint256 i = UtilsLib.ctz(bitmap);
+            uint256 i = UtilsLib.msb(bitmap);
             Collateral memory _collateral = obligation.collaterals[i];
             uint256 price = IOracle(_collateral.oracle).price();
             if (i == collateralIndex) liquidatedCollatPrice = price;
             uint256 _collateralOf = collateralOf[id][borrower][_collateral.token];
             maxDebt += _collateralOf.mulDivDown(price, ORACLE_PRICE_SCALE).mulDivDown(_collateral.lltv, WAD);
             repayableDebt += _collateralOf.mulDivUp(WAD, MAX_LIF).mulDivUp(price, ORACLE_PRICE_SCALE);
-            bitmap &= bitmap - 1;
+            bitmap ^= (1 << i);
         }
 
         uint256 originalDebt = _state.debt;
@@ -486,7 +486,7 @@ contract MorphoV2 is IMorphoV2 {
             }
 
             collateralOf[id][borrower][liquidatedCollatToken] -= seizedAssets;
-            if (collateralOf[id][borrower][liquidatedCollatToken] == 0) {
+            if (collateralOf[id][borrower][liquidatedCollatToken] == 0 && seizedAssets > 0) {
                 // forge-lint: disable-next-item(unsafe-typecast) as collateralIndex < MAX_COLLATERALS (128)
                 _state.activatedCollaterals &= ~uint128(1 << collateralIndex);
             }
@@ -596,12 +596,12 @@ contract MorphoV2 is IMorphoV2 {
         uint256 maxDebt;
         uint256 bitmap = _borrowerState.activatedCollaterals;
         while (maxDebt < debt && bitmap != 0) {
-            uint256 i = UtilsLib.ctz(bitmap);
+            uint256 i = UtilsLib.msb(bitmap);
             Collateral memory collateral = obligation.collaterals[i];
             uint256 price = IOracle(collateral.oracle).price();
             maxDebt += collateralOf[id][borrower][collateral.token].mulDivDown(price, ORACLE_PRICE_SCALE)
                 .mulDivDown(collateral.lltv, WAD);
-            bitmap &= bitmap - 1;
+            bitmap ^= (1 << i);
         }
         return maxDebt >= debt;
     }

--- a/src/interfaces/IMorphoV2.sol
+++ b/src/interfaces/IMorphoV2.sol
@@ -40,6 +40,11 @@ struct Signature {
     bytes32 s;
 }
 
+struct BorrowerState {
+    uint128 debt;
+    uint128 activatedCollaterals;
+}
+
 /// @dev Fee indices: 0=0d, 1=1d, 2=7d, 3=30d, 4=90d, 5=180d TTM buckets.
 /// @dev Fees are stored divided by FEE_STEP (1e12) to fit in 16 bits. Max fee is 1% (0.01e18).
 struct ObligationState {

--- a/src/libraries/ConstantsLib.sol
+++ b/src/libraries/ConstantsLib.sol
@@ -10,3 +10,5 @@ uint256 constant MAX_LIF = 1.15e18; // Liquidation Incentive Factor
 uint256 constant TIME_TO_MAX_LIF = 15 minutes; // Time to reach MAX_LIF
 bytes32 constant EIP712_DOMAIN_TYPEHASH = keccak256("EIP712Domain(uint256 chainId,address verifyingContract)");
 bytes32 constant ROOT_TYPEHASH = keccak256("Root(bytes32 root)");
+uint256 constant MAX_COLLATERALS = 256;
+uint256 constant MAX_COLLATERALS_PER_BORROWER = 10;

--- a/src/libraries/ConstantsLib.sol
+++ b/src/libraries/ConstantsLib.sol
@@ -10,5 +10,5 @@ uint256 constant MAX_LIF = 1.15e18; // Liquidation Incentive Factor
 uint256 constant TIME_TO_MAX_LIF = 15 minutes; // Time to reach MAX_LIF
 bytes32 constant EIP712_DOMAIN_TYPEHASH = keccak256("EIP712Domain(uint256 chainId,address verifyingContract)");
 bytes32 constant ROOT_TYPEHASH = keccak256("Root(bytes32 root)");
-uint256 constant MAX_COLLATERALS = 256;
+uint256 constant MAX_COLLATERALS = 128;
 uint256 constant MAX_COLLATERALS_PER_BORROWER = 10;

--- a/src/libraries/UtilsLib.sol
+++ b/src/libraries/UtilsLib.sol
@@ -68,9 +68,8 @@ library UtilsLib {
         return uint128(x);
     }
 
+    /// @dev Returns the number of set bits in x < 2^256-1, 0 otherwise.
     function countBits(uint256 x) internal pure returns (uint256) {
-        if (x == type(uint256).max) return 256;
-
         unchecked {
             x = x - ((x >> 1) & 0x5555555555555555555555555555555555555555555555555555555555555555);
             x = (x & 0x3333333333333333333333333333333333333333333333333333333333333333)

--- a/src/libraries/UtilsLib.sol
+++ b/src/libraries/UtilsLib.sol
@@ -67,4 +67,17 @@ library UtilsLib {
         // forge-lint: disable-next-item(unsafe-typecast) as x is less than type(uint128).max
         return uint128(x);
     }
+
+    function countBits(uint256 bitmap) internal pure returns (uint256 count) {
+        while (bitmap != 0) {
+            bitmap &= bitmap - 1;
+            count++;
+        }
+    }
+
+    function ctz(uint256 bitmap) internal pure returns (uint256 res) {
+        assembly {
+            res := sub(255, clz(and(bitmap, sub(0, bitmap))))
+        }
+    }
 }

--- a/src/libraries/UtilsLib.sol
+++ b/src/libraries/UtilsLib.sol
@@ -68,10 +68,15 @@ library UtilsLib {
         return uint128(x);
     }
 
-    function countBits(uint256 bitmap) internal pure returns (uint256 count) {
-        while (bitmap != 0) {
-            bitmap &= bitmap - 1;
-            count++;
+    function countBits(uint256 x) internal pure returns (uint256) {
+        if (x == type(uint256).max) return 256;
+
+        unchecked {
+            x = x - ((x >> 1) & 0x5555555555555555555555555555555555555555555555555555555555555555);
+            x = (x & 0x3333333333333333333333333333333333333333333333333333333333333333)
+                + ((x >> 2) & 0x3333333333333333333333333333333333333333333333333333333333333333);
+            x = (x + (x >> 4)) & 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f;
+            return (x * 0x0101010101010101010101010101010101010101010101010101010101010101) >> 248;
         }
     }
 

--- a/src/libraries/UtilsLib.sol
+++ b/src/libraries/UtilsLib.sol
@@ -79,9 +79,9 @@ library UtilsLib {
         }
     }
 
-    function ctz(uint256 bitmap) internal pure returns (uint256 res) {
+    function msb(uint256 bitmap) internal pure returns (uint256 res) {
         assembly {
-            res := sub(255, clz(and(bitmap, sub(0, bitmap))))
+            res := sub(255, clz(bitmap))
         }
     }
 }

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -8,7 +8,13 @@ import {Oracle} from "./helpers/Oracle.sol";
 import {UtilsLib} from "../src/libraries/UtilsLib.sol";
 import {IdLib} from "../src/libraries/IdLib.sol";
 import {TICK_RANGE} from "../src/libraries/TickLib.sol";
-import {WAD, ORACLE_PRICE_SCALE, EIP712_DOMAIN_TYPEHASH, ROOT_TYPEHASH} from "../src/libraries/ConstantsLib.sol";
+import {
+    WAD,
+    ORACLE_PRICE_SCALE,
+    MAX_COLLATERALS,
+    EIP712_DOMAIN_TYPEHASH,
+    ROOT_TYPEHASH
+} from "../src/libraries/ConstantsLib.sol";
 import {Obligation, Offer, Signature, Collateral} from "../src/interfaces/IMorphoV2.sol";
 import {MorphoV2} from "../src/MorphoV2.sol";
 
@@ -227,8 +233,9 @@ abstract contract BaseTest is Test {
         pure
         returns (Obligation memory)
     {
-        Collateral[] memory collaterals = new Collateral[](obligation.collaterals.length);
-        for (uint256 i = 0; i < obligation.collaterals.length; i++) {
+        uint256 len = obligation.collaterals.length > MAX_COLLATERALS ? MAX_COLLATERALS : obligation.collaterals.length;
+        Collateral[] memory collaterals = new Collateral[](len);
+        for (uint256 i = 0; i < len; i++) {
             collaterals[i].token = address(uint160(uint256(keccak256(abi.encode(obligation.collaterals[i].token, i)))));
         }
         collaterals = sortCollaterals(collaterals);

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -2,7 +2,7 @@
 // Copyright (c) 2025 Morpho Association
 pragma solidity ^0.8.0;
 
-import {MAX_LIF, WAD, ORACLE_PRICE_SCALE, TIME_TO_MAX_LIF} from "../src/libraries/ConstantsLib.sol";
+import {MAX_LIF, WAD, ORACLE_PRICE_SCALE, TIME_TO_MAX_LIF, MAX_COLLATERALS_PER_BORROWER} from "../src/libraries/ConstantsLib.sol";
 import {Obligation, Collateral} from "../src/interfaces/IMorphoV2.sol";
 import {UtilsLib} from "../src/libraries/UtilsLib.sol";
 import {Oracle} from "./helpers/Oracle.sol";
@@ -246,6 +246,7 @@ contract LiquidationTest is BaseTest {
         morphoV2.liquidate(obligation, 0, initialCollateral, 0, borrower, "");
 
         assertEq(morphoV2.collateralOf(id, borrower, obligation.collaterals[0].token), 0);
+        assertEq(UtilsLib.countBits(morphoV2.activatedCollaterals(id, borrower)), 0, "no bits should be set");
     }
 
     // post maturity liquidation.

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -2,7 +2,7 @@
 // Copyright (c) 2025 Morpho Association
 pragma solidity ^0.8.0;
 
-import {MAX_LIF, WAD, ORACLE_PRICE_SCALE, TIME_TO_MAX_LIF, MAX_COLLATERALS_PER_BORROWER} from "../src/libraries/ConstantsLib.sol";
+import {MAX_LIF, WAD, ORACLE_PRICE_SCALE, TIME_TO_MAX_LIF} from "../src/libraries/ConstantsLib.sol";
 import {Obligation, Collateral} from "../src/interfaces/IMorphoV2.sol";
 import {UtilsLib} from "../src/libraries/UtilsLib.sol";
 import {Oracle} from "./helpers/Oracle.sol";

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -9,7 +9,7 @@ import {ERC20} from "./helpers/ERC20.sol";
 import {Oracle} from "./helpers/Oracle.sol";
 import {RevertingOracle} from "./helpers/RevertingOracle.sol";
 import {BaseTest, MAX_TEST_AMOUNT} from "./BaseTest.sol";
-import {ORACLE_PRICE_SCALE} from "../src/libraries/ConstantsLib.sol";
+import {ORACLE_PRICE_SCALE, WAD, MAX_COLLATERALS, MAX_COLLATERALS_PER_BORROWER} from "../src/libraries/ConstantsLib.sol";
 import {UtilsLib} from "../src/libraries/UtilsLib.sol";
 
 contract OtherFunctionsTest is BaseTest {
@@ -310,5 +310,116 @@ contract OtherFunctionsTest is BaseTest {
             0,
             "collateral should be 0 after withdrawal"
         );
+    }
+
+    // Bitmap tests.
+
+    function _createMultiCollateralObligation(uint256 numCollaterals)
+        internal
+        returns (Obligation memory _obligation)
+    {
+        Collateral[] memory collaterals = new Collateral[](numCollaterals);
+        for (uint256 i = 0; i < numCollaterals; i++) {
+            ERC20 token = new ERC20("", "");
+            Oracle _oracle = new Oracle();
+            collaterals[i] = Collateral({token: address(token), lltv: 0.75e18, oracle: address(_oracle)});
+        }
+        collaterals = sortCollaterals(collaterals);
+        _obligation.loanToken = address(loanToken);
+        _obligation.maturity = block.timestamp + 100;
+        _obligation.collaterals = collaterals;
+        _obligation.minCollatValue = 0;
+    }
+
+    function testMaxCollaterals(uint256 numCollaterals) public {
+        numCollaterals = bound(numCollaterals, MAX_COLLATERALS + 1, 1000);
+        Obligation memory _obligation = _createMultiCollateralObligation(numCollaterals);
+
+        vm.expectRevert("too many collaterals");
+        morphoV2.touchObligation(_obligation);
+    }
+
+    function testBelowExactMaxCollaterals(uint256 numCollaterals) public {
+        numCollaterals = bound(numCollaterals, 1, MAX_COLLATERALS - 1);
+        Obligation memory _obligation = _createMultiCollateralObligation(numCollaterals);
+
+        morphoV2.touchObligation(_obligation);
+    }
+
+    function testMaxCollateralsPerBorrower() public {
+        uint256 numCollaterals = MAX_COLLATERALS_PER_BORROWER + 1;
+        Obligation memory _obligation = _createMultiCollateralObligation(numCollaterals);
+
+        for (uint256 i = 0; i < MAX_COLLATERALS_PER_BORROWER; i++) {
+            address token = _obligation.collaterals[i].token;
+            deal(token, address(this), 1e18);
+            ERC20(token).approve(address(morphoV2), 1e18);
+            morphoV2.supplyCollateral(_obligation, i, 1e18, borrower);
+        }
+
+        address lastToken = _obligation.collaterals[numCollaterals - 1].token;
+        deal(lastToken, address(this), 1e18);
+        ERC20(lastToken).approve(address(morphoV2), 1e18);
+        vm.expectRevert("too many collaterals per borrower");
+        morphoV2.supplyCollateral(_obligation, numCollaterals - 1, 1e18, borrower);
+    }
+
+    function testBitmapCtzSingleCollateral(uint256 collateralIndex) public {
+        uint256 numCollaterals = MAX_COLLATERALS_PER_BORROWER;
+        collateralIndex = bound(collateralIndex, 0, numCollaterals - 1);
+        Obligation memory _obligation = _createMultiCollateralObligation(numCollaterals);
+
+        address token = _obligation.collaterals[collateralIndex].token;
+        deal(token, address(this), 1e18);
+        ERC20(token).approve(address(morphoV2), 1e18);
+        morphoV2.supplyCollateral(_obligation, collateralIndex, 1e18, borrower);
+
+        uint256 bitmap = morphoV2.activatedCollaterals(toId(_obligation), borrower);
+
+        assertEq(bitmap, 1 << collateralIndex, "bitmap should have only bit at collateralIndex");
+        assertEq(UtilsLib.msb(bitmap), collateralIndex, "msb should equal collateralIndex");
+    }
+
+    function testBitmapCountBitsAfterMultipleSupplies(uint256 k) public {
+        uint256 numCollaterals = MAX_COLLATERALS_PER_BORROWER;
+        k = bound(k, 1, numCollaterals);
+        Obligation memory _obligation = _createMultiCollateralObligation(numCollaterals);
+
+        for (uint256 i = 0; i < k; i++) {
+            address token = _obligation.collaterals[i].token;
+            deal(token, address(this), 1e18);
+            ERC20(token).approve(address(morphoV2), 1e18);
+            morphoV2.supplyCollateral(_obligation, i, 1e18, borrower);
+        }
+
+        bytes32 _id = toId(_obligation);
+        uint256 bitmap = morphoV2.activatedCollaterals(_id, borrower);
+        assertEq(UtilsLib.countBits(bitmap), k, "countBits should equal number of supplied collaterals");
+        assertEq(UtilsLib.msb(bitmap), k - 1, "msb should equal number of supplied collaterals - 1");
+    }
+
+    function testBitmapClearedOnFullWithdraw(uint256 collateralIndex) public {
+        uint256 numCollaterals = MAX_COLLATERALS_PER_BORROWER;
+        collateralIndex = bound(collateralIndex, 0, numCollaterals - 1);
+        Obligation memory _obligation = _createMultiCollateralObligation(numCollaterals);
+
+        // Supply all collaterals.
+        for (uint256 i = 0; i < numCollaterals; i++) {
+            address token = _obligation.collaterals[i].token;
+            deal(token, address(this), 1e18);
+            ERC20(token).approve(address(morphoV2), 1e18);
+            morphoV2.supplyCollateral(_obligation, i, 1e18, borrower);
+        }
+
+        bytes32 _id = toId(_obligation);
+        assertEq(UtilsLib.countBits(morphoV2.activatedCollaterals(_id, borrower)), numCollaterals, "all bits set");
+
+        // Withdraw one collateral fully.
+        vm.prank(borrower);
+        morphoV2.withdrawCollateral(_obligation, collateralIndex, 1e18, borrower, borrower);
+
+        uint256 bitmap = morphoV2.activatedCollaterals(_id, borrower);
+        assertEq(UtilsLib.countBits(bitmap), numCollaterals - 1, "one bit cleared");
+        assertEq(bitmap & (1 << collateralIndex), 0, "withdrawn collateral bit should be cleared");
     }
 }

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -9,7 +9,7 @@ import {ERC20} from "./helpers/ERC20.sol";
 import {Oracle} from "./helpers/Oracle.sol";
 import {RevertingOracle} from "./helpers/RevertingOracle.sol";
 import {BaseTest, MAX_TEST_AMOUNT} from "./BaseTest.sol";
-import {ORACLE_PRICE_SCALE, WAD, MAX_COLLATERALS, MAX_COLLATERALS_PER_BORROWER} from "../src/libraries/ConstantsLib.sol";
+import {ORACLE_PRICE_SCALE, MAX_COLLATERALS, MAX_COLLATERALS_PER_BORROWER} from "../src/libraries/ConstantsLib.sol";
 import {UtilsLib} from "../src/libraries/UtilsLib.sol";
 
 contract OtherFunctionsTest is BaseTest {
@@ -314,10 +314,7 @@ contract OtherFunctionsTest is BaseTest {
 
     // Bitmap tests.
 
-    function _createMultiCollateralObligation(uint256 numCollaterals)
-        internal
-        returns (Obligation memory _obligation)
-    {
+    function _createMultiCollateralObligation(uint256 numCollaterals) internal returns (Obligation memory _obligation) {
         Collateral[] memory collaterals = new Collateral[](numCollaterals);
         for (uint256 i = 0; i < numCollaterals; i++) {
             ERC20 token = new ERC20("", "");

--- a/test/UtilsLibTest.sol
+++ b/test/UtilsLibTest.sol
@@ -7,13 +7,17 @@ import {TickLib} from "../src/libraries/TickLib.sol";
 
 contract UtilsLibTest is Test {
     function testFuzzCountBits(uint256 bitmap) public pure {
-        uint256 expected;
-        uint256 word = bitmap;
-        while (word != 0) {
-            word &= word - 1;
-            expected++;
+        if (bitmap == type(uint256).max) {
+            assertEq(UtilsLib.countBits(bitmap), 0);
+        } else {
+            uint256 actual = UtilsLib.countBits(bitmap);
+            uint256 expected;
+            while (bitmap != 0) {
+                bitmap &= bitmap - 1;
+                expected++;
+            }
+            assertEq(actual, expected);
         }
-        assertEq(UtilsLib.countBits(bitmap), expected);
     }
 
     function testAtMostOneNonZero(uint256 x, uint256 y) public pure {

--- a/test/UtilsLibTest.sol
+++ b/test/UtilsLibTest.sol
@@ -6,6 +6,16 @@ import {UtilsLib} from "../src/libraries/UtilsLib.sol";
 import {TickLib} from "../src/libraries/TickLib.sol";
 
 contract UtilsLibTest is Test {
+    function testFuzzCountBits(uint256 bitmap) public pure {
+        uint256 expected;
+        uint256 word = bitmap;
+        while (word != 0) {
+            word &= word - 1;
+            expected++;
+        }
+        assertEq(UtilsLib.countBits(bitmap), expected);
+    }
+
     function testAtMostOneNonZero(uint256 x, uint256 y) public pure {
         assertEq(UtilsLib.atMostOneNonZero(x, y), (x != 0 ? 1 : 0) + (y != 0 ? 1 : 0) <= 1);
     }


### PR DESCRIPTION
- limits the number of active collat per borrower to 10 to avoid gas issues.
- limits the max number of collats per obligation to 128 as a side effect of the implementation.
- perf: avoids reading all collat balances

[useful](https://github.com/morpho-org/morpho-v2/pull/364#discussion_r2817002111) for intuition on the bit tricks