### PR TITLE
perf: fast limit collats

### DIFF
--- a/src/libraries/UtilsLib.sol
+++ b/src/libraries/UtilsLib.sol
@@ -68,9 +68,8 @@ library UtilsLib {
         return uint128(x);
     }
 
+    /// @dev Returns the number of set bits in x < 2^256-1, 0 otherwise.
     function countBits(uint256 x) internal pure returns (uint256) {
-        if (x == type(uint256).max) return 256;
-
         unchecked {
             x = x - ((x >> 1) & 0x5555555555555555555555555555555555555555555555555555555555555555);
             x = (x & 0x3333333333333333333333333333333333333333333333333333333333333333)

--- a/src/libraries/UtilsLib.sol
+++ b/src/libraries/UtilsLib.sol
@@ -68,10 +68,15 @@ library UtilsLib {
         return uint128(x);
     }
 
-    function countBits(uint256 bitmap) internal pure returns (uint256 count) {
-        while (bitmap != 0) {
-            bitmap &= bitmap - 1;
-            count++;
+    function countBits(uint256 x) internal pure returns (uint256) {
+        if (x == type(uint256).max) return 256;
+
+        unchecked {
+            x = x - ((x >> 1) & 0x5555555555555555555555555555555555555555555555555555555555555555);
+            x = (x & 0x3333333333333333333333333333333333333333333333333333333333333333)
+                + ((x >> 2) & 0x3333333333333333333333333333333333333333333333333333333333333333);
+            x = (x + (x >> 4)) & 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f;
+            return (x * 0x0101010101010101010101010101010101010101010101010101010101010101) >> 248;
         }
     }
 

--- a/test/UtilsLibTest.sol
+++ b/test/UtilsLibTest.sol
@@ -7,13 +7,17 @@ import {TickLib} from "../src/libraries/TickLib.sol";
 
 contract UtilsLibTest is Test {
     function testFuzzCountBits(uint256 bitmap) public pure {
-        uint256 expected;
-        uint256 word = bitmap;
-        while (word != 0) {
-            word &= word - 1;
-            expected++;
+        if (bitmap == type(uint256).max) {
+            assertEq(UtilsLib.countBits(bitmap), 0);
+        } else {
+            uint256 actual = UtilsLib.countBits(bitmap);
+            uint256 expected;
+            while (bitmap != 0) {
+                bitmap &= bitmap - 1;
+                expected++;
+            }
+            assertEq(actual, expected);
         }
-        assertEq(UtilsLib.countBits(bitmap), expected);
     }
 
     function testAtMostOneNonZero(uint256 x, uint256 y) public pure {

--- a/test/UtilsLibTest.sol
+++ b/test/UtilsLibTest.sol
@@ -6,6 +6,16 @@ import {UtilsLib} from "../src/libraries/UtilsLib.sol";
 import {TickLib} from "../src/libraries/TickLib.sol";
 
 contract UtilsLibTest is Test {
+    function testFuzzCountBits(uint256 bitmap) public pure {
+        uint256 expected;
+        uint256 word = bitmap;
+        while (word != 0) {
+            word &= word - 1;
+            expected++;
+        }
+        assertEq(UtilsLib.countBits(bitmap), expected);
+    }
+
     function testAtMostOneNonZero(uint256 x, uint256 y) public pure {
         assertEq(UtilsLib.atMostOneNonZero(x, y), (x != 0 ? 1 : 0) + (y != 0 ? 1 : 0) <= 1);
     }


### PR DESCRIPTION
uses `popcount64c` from https://en.wikipedia.org/wiki/Hamming_weight

Looping with added unchecked costs 106 gas when 1 bit is set and 583 gas when 10 bits are set.

This is 82 gas.