### PR TITLE
[Certora] Added rule liquidateRequireUnhealthy

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         conf:
           - Hasher
+          - Liquidate
           - MorphoV2
           - SharePrice
           - Solvency

--- a/certora/confs/Liquidate.conf
+++ b/certora/confs/Liquidate.conf
@@ -1,0 +1,19 @@
+{
+  "files": [
+    "src/MorphoV2.sol"
+  ],
+  "verify": "MorphoV2:certora/specs/Liquidate.spec",
+  "solc": "solc-0.8.31",
+  "solc_via_ir": true,
+  "solc_evm_version": "osaka",
+  "optimistic_loop": true,
+  "loop_iter": 2,
+  "optimistic_hashing": true,
+  "hashing_length_bound": 2048,
+  "prover_args": [
+    "-depth 5",
+    "-mediumTimeout 20",
+    "-timeout 3600"
+  ],
+  "msg": "MorphoV2 Liquidation"
+}

--- a/certora/specs/Liquidate.spec
+++ b/certora/specs/Liquidate.spec
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+methods {
+    function multicall(bytes[]) external => HAVOC_ALL DELETE;
+
+    function isHealthy(MorphoV2.Obligation obligation, bytes20 id, address borrower) external returns (bool) envfree;
+
+    function _.price() external => CVL_price(calledContract) expect uint256;
+    function IdLib.toId(MorphoV2.Obligation memory obligation, uint256 chainId, address morphoV2) internal returns (bytes20) => CVL_toId(obligation, chainId, morphoV2);
+    function UtilsLib.msb(uint256 bitmap) internal returns (uint256) => CVL_msb(bitmap);
+    function UtilsLib.mulDivDown(uint256 a, uint256 b, uint256 denominator) internal returns (uint256) => CVL_mulDivDown(a, b, denominator);
+    function UtilsLib.mulDivUp(uint256 a, uint256 b, uint256 denominator) internal returns (uint256) => CVL_mulDivUp(a, b, denominator);
+}
+
+/// HELPERS ///
+
+// IdLib summary: remember the last id returned by toId.
+
+persistent ghost bytes20 lastId;
+function CVL_toId(MorphoV2.Obligation obligation, uint256 chainId, address morphoV2) returns bytes20 {
+    // non-deterministic id
+    bytes20 id;
+    lastId = id;
+    return id;
+}
+
+// UtilsLib summaries: msb, mulDivDown, and mulDivUp are deterministic
+
+ghost CVL_msb(uint256) returns uint256;
+ghost CVL_mulDivDown(uint256, uint256, uint256) returns uint256;
+ghost CVL_mulDivUp(uint256, uint256, uint256) returns uint256;
+
+// Oracle summary: we assume the price does not change during the execution of a transaction.
+
+ghost CVL_price(address) returns uint256;
+
+// RULES ///
+
+rule liquidateRequireUnhealthy(env e, MorphoV2.Obligation obligation, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, bytes data) {
+    bytes20 id;
+    bool isHealtyBefore = isHealthy(obligation, id, borrower);
+    liquidate(e, obligation, collateralIndex, seizedAssets, repaidUnits, borrower, data);
+
+    // it's okay to check only after the call that the prover chose the correct id.
+    require id == lastId, "id should be derived from obligation";
+
+    assert !isHealtyBefore || e.block.timestamp > obligation.maturity, "liquidate can only be called on unhealthy obligations";
+}


### PR DESCRIPTION
Check that if liquidate succeeds, the position must have been unhealthy before or reached maturity.

The rule needs a few summaries:

* `price` is deterministic
* `mulDiv*` are deterministic
* `toId` summary to figure out the id of an obligation.

The rule currently takes the guess and verify approach: We guess some non-deterministic id for isHealthy and after calling liquidate (which computes the id), we verify that we guessed the id correctly.

Alternatively one could add a harness to compute the Id, or make a deterministic summary for toId.