### PR TITLE
[count bits] remove assumption

### DIFF
--- a/src/libraries/UtilsLib.sol
+++ b/src/libraries/UtilsLib.sol
@@ -68,14 +68,15 @@ library UtilsLib {
         return uint128(x);
     }
 
-    /// @dev Returns the number of set bits in x < 2^256-1, 0 otherwise.
+    /// @dev Returns the number of set bits.
     function countBits(uint256 x) internal pure returns (uint256) {
         unchecked {
             x = x - ((x >> 1) & 0x5555555555555555555555555555555555555555555555555555555555555555);
             x = (x & 0x3333333333333333333333333333333333333333333333333333333333333333)
                 + ((x >> 2) & 0x3333333333333333333333333333333333333333333333333333333333333333);
             x = (x + (x >> 4)) & 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f;
-            return (x * 0x0101010101010101010101010101010101010101010101010101010101010101) >> 248;
+            x = (x + (x >> 8)) & 0x00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff;
+            return (x * 0x0001000100010001000100010001000100010001000100010001000100010001) >> 240;
         }
     }
 

--- a/test/UtilsLibTest.sol
+++ b/test/UtilsLibTest.sol
@@ -7,17 +7,13 @@ import {TickLib} from "../src/libraries/TickLib.sol";
 
 contract UtilsLibTest is Test {
     function testFuzzCountBits(uint256 bitmap) public pure {
-        if (bitmap == type(uint256).max) {
-            assertEq(UtilsLib.countBits(bitmap), 0);
-        } else {
-            uint256 actual = UtilsLib.countBits(bitmap);
-            uint256 expected;
-            while (bitmap != 0) {
-                bitmap &= bitmap - 1;
-                expected++;
-            }
-            assertEq(actual, expected);
+        uint256 actual = UtilsLib.countBits(bitmap);
+        uint256 expected;
+        while (bitmap != 0) {
+            bitmap &= bitmap - 1;
+            expected++;
         }
+        assertEq(actual, expected);
     }
 
     function testAtMostOneNonZero(uint256 x, uint256 y) public pure {


### PR DESCRIPTION
The assumption is that the max number of collaterals is **strictly less than 255** (not 256), which is an invariant of the protocol but not immediately intuitive. Indeed, before this PR, if `MAX_COLLATERALS_PER_BORROWER` is 255 or more, then the check `UtilsLib.countBits(newBitmap) <= MAX_COLLATERALS_PER_BORROWER` is always true

Another option is to more explicitly rely on this assumption, by adding a comment. It also allows to make the `countBits` function slightly cheaper, see [this branch](https://github.com/morpho-org/morpho-v2/compare/main...refactor/faster-limit-collateral)