### PR TITLE
[min collat] rcf threshold per collat

### DIFF
--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -405,8 +405,8 @@ contract MorphoV2 is IMorphoV2 {
 
     /// @dev At least one of `seizedAssets` or `repaidUnits` should be equal to zero.
     /// @dev Accounts are liquidatable if they are unhealthy or if the maturity has passed.
-    /// @dev Before maturity, the liquidation cannot put the borrower back into health (recovery close factor),
-    /// @dev unless doing so would bring the debt below the rcfThreshold.
+    /// @dev Before maturity, the liquidation cannot put the borrower back into health (recovery close factor), unless
+    /// the collateral's value is not enough to repay rcfThreshold.
     /// @dev Recovery close factor means that debtOf - repaidUnits >= maxDebt - repaidUnits*LIF*LLTV, which is
     /// equivalent to repaidUnits <= (debtOf-maxDebt) / (1 - LIF*LLTV).
     /// @dev If an account is healthy, the LIF grows linearly from 1 at maturity to MAX_LIF at maturity +

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -35,6 +35,7 @@ import {EventsLib} from "./libraries/EventsLib.sol";
 /// @dev Obligations' collaterals must be sorted by token address.
 contract MorphoV2 is IMorphoV2 {
     using UtilsLib for uint256;
+    using UtilsLib for uint128;
 
     /// STORAGE ///
 
@@ -361,7 +362,7 @@ contract MorphoV2 is IMorphoV2 {
         bytes20 id = touchObligation(obligation);
         address collateralToken = obligation.collaterals[collateralIndex].token;
 
-        uint256 newCollateralOf = uint256(collateralOf[id][onBehalf][collateralIndex]) + assets;
+        uint256 newCollateralOf = collateralOf[id][onBehalf][collateralIndex] + assets;
         collateralOf[id][onBehalf][collateralIndex] = UtilsLib.toUint128(newCollateralOf);
 
         if (newCollateralOf == assets && assets > 0) {
@@ -388,7 +389,7 @@ contract MorphoV2 is IMorphoV2 {
         bytes20 id = touchObligation(obligation);
         address collateralToken = obligation.collaterals[collateralIndex].token;
 
-        uint256 newCollateralOf = uint256(collateralOf[id][onBehalf][collateralIndex]) - assets;
+        uint256 newCollateralOf = collateralOf[id][onBehalf][collateralIndex] - assets;
         collateralOf[id][onBehalf][collateralIndex] = UtilsLib.toUint128(newCollateralOf);
 
         if (newCollateralOf == 0 && assets > 0) {
@@ -464,14 +465,14 @@ contract MorphoV2 is IMorphoV2 {
 
             if (block.timestamp <= obligation.maturity) {
                 uint256 lltv = obligation.collaterals[collateralIndex].lltv;
-                uint256 _collateralOf = collateralOf[id][borrower][collateralIndex];
                 // Rounded up to avoid consecutive max liquidations.
                 // Acknowledged that the position could be slightly healthy after a liquidation.
                 uint256 maxRepaid = (_state.debt - maxDebt).mulDivUp(WAD, WAD - lif.mulDivUp(lltv, WAD));
                 require(
                     repaidUnits <= maxRepaid
-                        || _collateralOf.mulDivDown(liquidatedCollatPrice, ORACLE_PRICE_SCALE).mulDivDown(WAD, lif)
-                            .zeroFloorSub(maxRepaid) < obligation.rcfThreshold,
+                        || collateralOf[id][borrower][collateralIndex].mulDivDown(
+                                liquidatedCollatPrice, ORACLE_PRICE_SCALE
+                            ).mulDivDown(WAD, lif).zeroFloorSub(maxRepaid) < obligation.rcfThreshold,
                     "recovery close factor conditions violated"
                 );
             }
@@ -601,7 +602,7 @@ contract MorphoV2 is IMorphoV2 {
             uint256 i = UtilsLib.msb(bitmap);
             Collateral memory collateral = obligation.collaterals[i];
             uint256 price = IOracle(collateral.oracle).price();
-            maxDebt += uint256(collateralOf[id][borrower][i]).mulDivDown(price, ORACLE_PRICE_SCALE)
+            maxDebt += collateralOf[id][borrower][i].mulDivDown(price, ORACLE_PRICE_SCALE)
                 .mulDivDown(collateral.lltv, WAD);
             bitmap ^= (1 << i);
         }
@@ -624,7 +625,7 @@ contract MorphoV2 is IMorphoV2 {
     function tradingFee(bytes20 id, uint256 timeToMaturity) public view returns (uint256) {
         uint16[6] memory _fees = obligationState[id].fees;
 
-        if (timeToMaturity >= 180 days) return uint256(_fees[5]) * FEE_STEP;
+        if (timeToMaturity >= 180 days) return _fees[5] * FEE_STEP;
 
         // forgefmt: disable-start
         (uint256 index, uint256 start, uint256 end) =
@@ -635,8 +636,8 @@ contract MorphoV2 is IMorphoV2 {
                                        (4, 90 days, 180 days);
         // forgefmt: disable-end
 
-        uint256 feeLower = uint256(_fees[index]) * FEE_STEP;
-        uint256 feeUpper = uint256(_fees[index + 1]) * FEE_STEP;
+        uint256 feeLower = _fees[index] * FEE_STEP;
+        uint256 feeUpper = _fees[index + 1] * FEE_STEP;
 
         return (feeLower * (end - timeToMaturity) + feeUpper * (timeToMaturity - start)) / (end - start);
     }

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -362,10 +362,10 @@ contract MorphoV2 is IMorphoV2 {
         bytes20 id = touchObligation(obligation);
         address collateralToken = obligation.collaterals[collateralIndex].token;
 
-        uint256 newCollateralOf = collateralOf[id][onBehalf][collateralIndex] + assets;
-        collateralOf[id][onBehalf][collateralIndex] = UtilsLib.toUint128(newCollateralOf);
+        uint256 oldCollateralOf = collateralOf[id][onBehalf][collateralIndex];
+        collateralOf[id][onBehalf][collateralIndex] = UtilsLib.toUint128(oldCollateralOf + assets);
 
-        if (newCollateralOf == assets && assets > 0) {
+        if (oldCollateralOf == 0 && assets > 0) {
             // forge-lint: disable-next-item(unsafe-typecast) as collateralIndex < MAX_COLLATERALS (128)
             uint128 newBitmap = borrowerState[id][onBehalf].activatedCollaterals | uint128(1 << collateralIndex);
             borrowerState[id][onBehalf].activatedCollaterals = newBitmap;

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -405,9 +405,10 @@ contract MorphoV2 is IMorphoV2 {
 
     /// @dev At least one of `seizedAssets` or `repaidUnits` should be equal to zero.
     /// @dev Accounts are liquidatable if they are unhealthy or if the maturity has passed.
-    /// @dev Before maturity, the liquidation cannot put the borrower back into health (recovery close factor).
-    /// @dev In that case, we want debtOf - repaidUnits >= maxDebt - repaidUnits*LIF*LLTV, which is equivalent to
-    /// repaidUnits <= (debtOf-maxDebt) / (1 - LIF*LLTV).
+    /// @dev Before maturity, the liquidation cannot put the borrower back into health (recovery close factor),
+    /// @dev unless doing so would bring the debt below the rcfThreshold.
+    /// @dev Recovery close factor means that debtOf - repaidUnits >= maxDebt - repaidUnits*LIF*LLTV, which is
+    /// equivalent to repaidUnits <= (debtOf-maxDebt) / (1 - LIF*LLTV).
     /// @dev If an account is healthy, the LIF grows linearly from 1 at maturity to MAX_LIF at maturity +
     /// TIME_TO_MAX_LIF.
     /// @dev Returns the seized assets and the repaid units.
@@ -463,13 +464,12 @@ contract MorphoV2 is IMorphoV2 {
 
             if (block.timestamp <= obligation.maturity) {
                 uint256 lltv = obligation.collaterals[collateralIndex].lltv;
-                uint256 debt = _state.debt;
                 // Rounded up to avoid consecutive max liquidations.
                 // Acknowledged that the position could be slightly healthy after a liquidation.
-                uint256 maxRepaid = (debt - maxDebt).mulDivUp(WAD, WAD - lif.mulDivUp(lltv, WAD));
+                uint256 maxRepaid = (_state.debt - maxDebt).mulDivUp(WAD, WAD - lif.mulDivUp(lltv, WAD));
                 require(
-                    repaidUnits <= maxRepaid || debt.zeroFloorSub(maxRepaid) < obligation.rcfThreshold,
-                    "recovery close factor violated"
+                    repaidUnits <= maxRepaid || uint256(_state.debt).zeroFloorSub(maxRepaid) < obligation.rcfThreshold,
+                    "recovery close factor conditions violated"
                 );
             }
 

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -371,14 +371,6 @@ contract MorphoV2 is IMorphoV2 {
             require(UtilsLib.countBits(newBitmap) <= MAX_COLLATERALS_PER_BORROWER, "too many collaterals per borrower");
         }
 
-        require(
-            newCollateralOf == 0
-                || newCollateralOf.mulDivDown(
-                        IOracle(obligation.collaterals[collateralIndex].oracle).price(), ORACLE_PRICE_SCALE
-                    ) >= obligation.minCollatValue,
-            "Below min collateral"
-        );
-
         emit EventsLib.SupplyCollateral(msg.sender, id, collateralToken, assets, onBehalf);
 
         SafeTransferLib.safeTransferFrom(collateralToken, msg.sender, address(this), assets);
@@ -405,13 +397,6 @@ contract MorphoV2 is IMorphoV2 {
         }
 
         require(isHealthy(obligation, id, onBehalf), "Unhealthy borrower");
-        require(
-            newCollateralOf == 0
-                || newCollateralOf.mulDivDown(
-                        IOracle(obligation.collaterals[collateralIndex].oracle).price(), ORACLE_PRICE_SCALE
-                    ) >= obligation.minCollatValue,
-            "Below min collateral"
-        );
 
         emit EventsLib.WithdrawCollateral(msg.sender, id, collateralToken, assets, onBehalf, receiver);
 
@@ -483,7 +468,7 @@ contract MorphoV2 is IMorphoV2 {
                 // Acknowledged that the position could be slightly healthy after a liquidation.
                 uint256 maxRepaid = (debt - maxDebt).mulDivUp(WAD, WAD - lif.mulDivUp(lltv, WAD));
                 require(
-                    repaidUnits <= maxRepaid || debt.zeroFloorSub(maxRepaid) < obligation.minCollatValue,
+                    repaidUnits <= maxRepaid || debt.zeroFloorSub(maxRepaid) < obligation.rcfThreshold,
                     "recovery close factor violated"
                 );
             }

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -478,10 +478,14 @@ contract MorphoV2 is IMorphoV2 {
 
             if (block.timestamp <= obligation.maturity) {
                 uint256 lltv = obligation.collaterals[collateralIndex].lltv;
+                uint256 debt = _state.debt;
                 // Rounded up to avoid consecutive max liquidations.
                 // Acknowledged that the position could be slightly healthy after a liquidation.
-                uint256 maxRepaid = (uint256(_state.debt) - maxDebt).mulDivUp(WAD, WAD - lif.mulDivUp(lltv, WAD));
-                require(repaidUnits <= maxRepaid, "recovery close factor violated");
+                uint256 maxRepaid = (debt - maxDebt).mulDivUp(WAD, WAD - lif.mulDivUp(lltv, WAD));
+                require(
+                    repaidUnits <= maxRepaid || debt.zeroFloorSub(maxRepaid) < obligation.minCollatValue,
+                    "recovery close factor violated"
+                );
             }
 
             collateralOf[id][borrower][collateralIndex] -= UtilsLib.toUint128(seizedAssets);

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -407,7 +407,7 @@ contract MorphoV2 is IMorphoV2 {
     /// @dev At least one of `seizedAssets` or `repaidUnits` should be equal to zero.
     /// @dev Accounts are liquidatable if they are unhealthy or if the maturity has passed.
     /// @dev Before maturity, the liquidation cannot put the borrower back into health (recovery close factor), unless
-    /// the collateral's value is not enough to repay rcfThreshold.
+    /// the liquidation could leave a collateral with a value that would not be enough to repay rcfThreshold units.
     /// @dev Recovery close factor means that debtOf - repaidUnits >= maxDebt - repaidUnits*LIF*LLTV, which is
     /// equivalent to repaidUnits <= (debtOf-maxDebt) / (1 - LIF*LLTV).
     /// @dev If an account is healthy, the LIF grows linearly from 1 at maturity to MAX_LIF at maturity +

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -464,11 +464,14 @@ contract MorphoV2 is IMorphoV2 {
 
             if (block.timestamp <= obligation.maturity) {
                 uint256 lltv = obligation.collaterals[collateralIndex].lltv;
+                uint256 _collateralOf = collateralOf[id][borrower][collateralIndex];
                 // Rounded up to avoid consecutive max liquidations.
                 // Acknowledged that the position could be slightly healthy after a liquidation.
                 uint256 maxRepaid = (_state.debt - maxDebt).mulDivUp(WAD, WAD - lif.mulDivUp(lltv, WAD));
                 require(
-                    repaidUnits <= maxRepaid || uint256(_state.debt).zeroFloorSub(maxRepaid) < obligation.rcfThreshold,
+                    repaidUnits <= maxRepaid
+                        || _collateralOf.mulDivDown(liquidatedCollatPrice, ORACLE_PRICE_SCALE).mulDivDown(WAD, lif)
+                            .zeroFloorSub(maxRepaid) < obligation.rcfThreshold,
                     "recovery close factor conditions violated"
                 );
             }

--- a/src/interfaces/IMorphoV2.sol
+++ b/src/interfaces/IMorphoV2.sol
@@ -7,7 +7,7 @@ struct Obligation {
     // Must be sorted by address.
     Collateral[] collaterals;
     uint256 maturity;
-    // Recovery close factor threshold: below this remaining debt, full liquidation is allowed.
+    // If liquidating back to health brings the debt below this threshold, full liquidation is allowed.
     uint256 rcfThreshold;
 }
 

--- a/src/interfaces/IMorphoV2.sol
+++ b/src/interfaces/IMorphoV2.sol
@@ -7,7 +7,8 @@ struct Obligation {
     // Must be sorted by address.
     Collateral[] collaterals;
     uint256 maturity;
-    // If a collateral's value is not enough to repay rcfThreshold, RCF is deactivated for this collateral.
+    // If a collateral's value (quoted in loan token) is not enough to repay rcfThreshold, RCF is deactivated for this
+    // collateral.
     uint256 rcfThreshold;
 }
 

--- a/src/interfaces/IMorphoV2.sol
+++ b/src/interfaces/IMorphoV2.sol
@@ -7,7 +7,7 @@ struct Obligation {
     // Must be sorted by address.
     Collateral[] collaterals;
     uint256 maturity;
-    // If liquidating back to health brings the debt below this threshold, full liquidation is allowed.
+    // If a collateral's value is not enough to repay rcfThreshold, RCF is deactivated for this collateral.
     uint256 rcfThreshold;
 }
 

--- a/src/interfaces/IMorphoV2.sol
+++ b/src/interfaces/IMorphoV2.sol
@@ -7,7 +7,7 @@ struct Obligation {
     // Must be sorted by address.
     Collateral[] collaterals;
     uint256 maturity;
-    // Recovery close factor threshold (quoted in loan token). Below this remaining debt, full liquidation is allowed.
+    // Recovery close factor threshold: below this remaining debt, full liquidation is allowed.
     uint256 rcfThreshold;
 }
 

--- a/src/interfaces/IMorphoV2.sol
+++ b/src/interfaces/IMorphoV2.sol
@@ -7,8 +7,8 @@ struct Obligation {
     // Must be sorted by address.
     Collateral[] collaterals;
     uint256 maturity;
-    // Minimum collateral value (quoted in loan token) to be left on supply & withdraw collateral.
-    uint256 minCollatValue;
+    // Recovery close factor threshold (quoted in loan token). Below this remaining debt, full liquidation is allowed.
+    uint256 rcfThreshold;
 }
 
 struct Collateral {

--- a/src/interfaces/IMorphoV2.sol
+++ b/src/interfaces/IMorphoV2.sol
@@ -7,8 +7,8 @@ struct Obligation {
     // Must be sorted by address.
     Collateral[] collaterals;
     uint256 maturity;
-    // The recovery close factor is deactivated for a collateral if the collateral's value is not enough to repay
-    // rcfThreshold, and if doing a max liquidation would lead to such a situation.
+    // The recovery close factor is deactivated for a collateral if the liquidation could leave a collateral value that
+    // would not be enough to repay rcfThreshold units.
     uint256 rcfThreshold;
 }
 

--- a/src/interfaces/IMorphoV2.sol
+++ b/src/interfaces/IMorphoV2.sol
@@ -7,8 +7,8 @@ struct Obligation {
     // Must be sorted by address.
     Collateral[] collaterals;
     uint256 maturity;
-    // If a collateral's value (quoted in loan token) is not enough to repay rcfThreshold, RCF is deactivated for this
-    // collateral.
+    // The recovery close factor is deactivated for a collateral if the collateral's value is not enough to repay
+    // rcfThreshold, and if doing a max liquidation would lead to such a situation.
     uint256 rcfThreshold;
 }
 

--- a/test/IdLibTest.sol
+++ b/test/IdLibTest.sol
@@ -16,7 +16,7 @@ contract IdLibTest is Test {
         bool sameLoanToken = obligation1.loanToken == obligation2.loanToken;
         bool sameMaturity = obligation1.maturity == obligation2.maturity;
         bool sameCollaterals = obligation1.collaterals.length == obligation2.collaterals.length;
-        bool sameMinCollatValue = obligation1.minCollatValue == obligation2.minCollatValue;
+        bool sameRcfThreshold = obligation1.rcfThreshold == obligation2.rcfThreshold;
         if (sameCollaterals) {
             for (uint256 i = 0; i < obligation1.collaterals.length; i++) {
                 if (obligation1.collaterals[i].token != obligation2.collaterals[i].token) sameCollaterals = false;
@@ -25,7 +25,7 @@ contract IdLibTest is Test {
             }
         }
 
-        vm.assume(!(sameLoanToken && sameMaturity && sameCollaterals && sameMinCollatValue));
+        vm.assume(!(sameLoanToken && sameMaturity && sameCollaterals && sameRcfThreshold));
 
         bytes32 id1 = IdLib.toId(obligation1, chainid, morphoV2);
         bytes32 id2 = IdLib.toId(obligation2, chainid, morphoV2);

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -391,9 +391,9 @@ contract LiquidationTest is BaseTest {
         uint256 collatAmount = units.mulDivUp(WAD, lltv);
         uint256 _maxDebt = collatAmount.mulDivDown(liquidationOraclePrice, ORACLE_PRICE_SCALE).mulDivDown(lltv, WAD);
         uint256 maxRepaid = (units - _maxDebt).mulDivUp(WAD, WAD - MAX_LIF.mulDivUp(lltv, WAD));
-        uint256 remainingDebt = units.zeroFloorSub(maxRepaid);
-
-        obligation.rcfThreshold = bound(rcfThreshold, remainingDebt + 1, type(uint256).max);
+        uint256 remainingRepayable = collatAmount.mulDivDown(liquidationOraclePrice, ORACLE_PRICE_SCALE)
+            .mulDivDown(WAD, MAX_LIF).zeroFloorSub(maxRepaid);
+        obligation.rcfThreshold = bound(rcfThreshold, remainingRepayable + 1, type(uint256).max);
 
         collateralize(obligation, borrower, units);
         setupObligation(obligation, units);
@@ -419,8 +419,9 @@ contract LiquidationTest is BaseTest {
         uint256 _maxDebt = collatAmount.mulDivDown(liquidationOraclePrice, ORACLE_PRICE_SCALE).mulDivDown(lltv, WAD);
         uint256 maxRepaid = (units - _maxDebt).mulDivUp(WAD, WAD - MAX_LIF.mulDivUp(lltv, WAD));
         vm.assume(maxRepaid < units); // needed because of the round up.
-
-        obligation.rcfThreshold = bound(rcfThreshold, 0, units.zeroFloorSub(maxRepaid));
+        uint256 remainingRepayable = collatAmount.mulDivDown(liquidationOraclePrice, ORACLE_PRICE_SCALE)
+            .mulDivDown(WAD, MAX_LIF).zeroFloorSub(maxRepaid);
+        obligation.rcfThreshold = bound(rcfThreshold, 0, remainingRepayable);
 
         collateralize(obligation, borrower, units);
         setupObligation(obligation, units);

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -418,6 +418,7 @@ contract LiquidationTest is BaseTest {
         uint256 collatAmount = units.mulDivUp(WAD, lltv);
         uint256 _maxDebt = collatAmount.mulDivDown(liquidationOraclePrice, ORACLE_PRICE_SCALE).mulDivDown(lltv, WAD);
         uint256 maxRepaid = (units - _maxDebt).mulDivUp(WAD, WAD - MAX_LIF.mulDivUp(lltv, WAD));
+        vm.assume(maxRepaid < units); // needed because of the round up.
 
         obligation.rcfThreshold = bound(rcfThreshold, 0, units.zeroFloorSub(maxRepaid));
 

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -329,7 +329,7 @@ contract LiquidationTest is BaseTest {
         uint256 maxR = (units - _maxDebt).mulDivUp(WAD, WAD - MAX_LIF.mulDivUp(obligation.collaterals[0].lltv, WAD));
 
         repaid = bound(repaid, maxR + 1, units);
-        vm.expectRevert("recovery close factor violated");
+        vm.expectRevert("recovery close factor conditions violated");
         morphoV2.liquidate(obligation, 0, 0, repaid, borrower, "");
 
         repaid = bound(repaid, 1, maxR);
@@ -418,16 +418,15 @@ contract LiquidationTest is BaseTest {
         uint256 collatAmount = units.mulDivUp(WAD, lltv);
         uint256 _maxDebt = collatAmount.mulDivDown(liquidationOraclePrice, ORACLE_PRICE_SCALE).mulDivDown(lltv, WAD);
         uint256 maxRepaid = (units - _maxDebt).mulDivUp(WAD, WAD - MAX_LIF.mulDivUp(lltv, WAD));
-        uint256 remainingDebt = units.zeroFloorSub(maxRepaid);
 
-        obligation.rcfThreshold = bound(rcfThreshold, 0, remainingDebt);
+        obligation.rcfThreshold = bound(rcfThreshold, 0, units.zeroFloorSub(maxRepaid));
 
         collateralize(obligation, borrower, units);
         setupObligation(obligation, units);
         Oracle(obligation.collaterals[0].oracle).setPrice(liquidationOraclePrice);
 
         // Full liquidation should revert because remaining debt >= rcfThreshold.
-        vm.expectRevert("recovery close factor violated");
+        vm.expectRevert("recovery close factor conditions violated");
         morphoV2.liquidate(obligation, 0, 0, units, borrower, "");
     }
 
@@ -441,7 +440,7 @@ contract LiquidationTest is BaseTest {
 
         // At exact maturity: recovery close factor applies.
         vm.warp(obligation.maturity);
-        vm.expectRevert("recovery close factor violated");
+        vm.expectRevert("recovery close factor conditions violated");
         morphoV2.liquidate(obligation, 0, 0, units, borrower, "");
 
         // One second later: recovery close factor no longer applies.

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -29,7 +29,7 @@ contract LiquidationTest is BaseTest {
         obligation.collaterals
             .push(Collateral({token: address(collateralToken2), lltv: 0.85e18, oracle: address(oracle2)}));
         obligation.collaterals = sortCollaterals(obligation.collaterals);
-        obligation.minCollatValue = 0;
+        obligation.rcfThreshold = 0;
 
         id = toId(obligation);
 

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -379,6 +379,58 @@ contract LiquidationTest is BaseTest {
         assertEq(morphoV2.debtOf(id, borrower), 0, "all remaining debt repaid");
     }
 
+    /// @dev When rcfThreshold > remaining debt after max repayment, full liquidation is allowed pre-maturity.
+    function testRcfThresholdAllowsFullLiquidation(uint256 units, uint256 liquidationOraclePrice, uint256 rcfThreshold)
+        public
+    {
+        units = bound(units, 100, MAX_TEST_AMOUNT);
+        liquidationOraclePrice = bound(liquidationOraclePrice, badDebtPrice() * 1.01e18 / 1e18, ORACLE_PRICE_SCALE - 1);
+
+        // Compute remaining debt after max repayment from the input parameters.
+        uint256 lltv = obligation.collaterals[0].lltv;
+        uint256 collatAmount = units.mulDivUp(WAD, lltv);
+        uint256 _maxDebt = collatAmount.mulDivDown(liquidationOraclePrice, ORACLE_PRICE_SCALE).mulDivDown(lltv, WAD);
+        uint256 maxRepaid = (units - _maxDebt).mulDivUp(WAD, WAD - MAX_LIF.mulDivUp(lltv, WAD));
+        uint256 remainingDebt = units.zeroFloorSub(maxRepaid);
+
+        obligation.rcfThreshold = bound(rcfThreshold, remainingDebt + 1, type(uint256).max);
+
+        collateralize(obligation, borrower, units);
+        setupObligation(obligation, units);
+        Oracle(obligation.collaterals[0].oracle).setPrice(liquidationOraclePrice);
+
+        // Full liquidation should succeed because remaining debt < rcfThreshold.
+        morphoV2.liquidate(obligation, 0, 0, units, borrower, "");
+        assertEq(morphoV2.debtOf(toId(obligation), borrower), 0, "debt should be zero");
+    }
+
+    /// @dev When rcfThreshold <= remaining debt after max repayment, recovery close factor is enforced.
+    function testRcfThresholdEnforcesRecoveryCloseFactor(
+        uint256 units,
+        uint256 liquidationOraclePrice,
+        uint256 rcfThreshold
+    ) public {
+        units = bound(units, 100, MAX_TEST_AMOUNT);
+        liquidationOraclePrice = bound(liquidationOraclePrice, badDebtPrice() * 1.01e18 / 1e18, ORACLE_PRICE_SCALE - 1);
+
+        // Compute remaining debt after max repayment from the input parameters.
+        uint256 lltv = obligation.collaterals[0].lltv;
+        uint256 collatAmount = units.mulDivUp(WAD, lltv);
+        uint256 _maxDebt = collatAmount.mulDivDown(liquidationOraclePrice, ORACLE_PRICE_SCALE).mulDivDown(lltv, WAD);
+        uint256 maxRepaid = (units - _maxDebt).mulDivUp(WAD, WAD - MAX_LIF.mulDivUp(lltv, WAD));
+        uint256 remainingDebt = units.zeroFloorSub(maxRepaid);
+
+        obligation.rcfThreshold = bound(rcfThreshold, 0, remainingDebt);
+
+        collateralize(obligation, borrower, units);
+        setupObligation(obligation, units);
+        Oracle(obligation.collaterals[0].oracle).setPrice(liquidationOraclePrice);
+
+        // Full liquidation should revert because remaining debt >= rcfThreshold.
+        vm.expectRevert("recovery close factor violated");
+        morphoV2.liquidate(obligation, 0, 0, units, borrower, "");
+    }
+
     /// @dev Recovery close factor applies at exact maturity but not one second after.
     function testRecoveryCloseFactorMaturityBoundary(uint256 units, uint256 liquidationOraclePrice) public {
         units = bound(units, 100, MAX_TEST_AMOUNT);

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -225,7 +225,7 @@ contract OtherFunctionsTest is BaseTest {
     }
 
     function testSupplyCollateralDoesNotCallOracle(uint256 collateral) public {
-        collateral = bound(collateral, 1, MAX_TEST_AMOUNT);
+        collateral = bound(collateral, 0, MAX_TEST_AMOUNT);
         RevertingOracle revertingOracle = new RevertingOracle();
         Collateral[] memory collaterals = new Collateral[](1);
         collaterals[0] = Collateral({token: address(collateralToken1), lltv: 0.75e18, oracle: address(revertingOracle)});
@@ -243,7 +243,7 @@ contract OtherFunctionsTest is BaseTest {
     }
 
     function testWithdrawCollateralToZeroDoesNotCallOracle(uint256 collateral) public {
-        collateral = bound(collateral, 1, MAX_TEST_AMOUNT);
+        collateral = bound(collateral, 0, MAX_TEST_AMOUNT);
 
         RevertingOracle revertingOracle = new RevertingOracle();
         Collateral[] memory collaterals = new Collateral[](1);

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -9,7 +9,7 @@ import {ERC20} from "./helpers/ERC20.sol";
 import {Oracle} from "./helpers/Oracle.sol";
 import {RevertingOracle} from "./helpers/RevertingOracle.sol";
 import {BaseTest, MAX_TEST_AMOUNT} from "./BaseTest.sol";
-import {ORACLE_PRICE_SCALE, MAX_COLLATERALS, MAX_COLLATERALS_PER_BORROWER} from "../src/libraries/ConstantsLib.sol";
+import {MAX_COLLATERALS, MAX_COLLATERALS_PER_BORROWER} from "../src/libraries/ConstantsLib.sol";
 import {UtilsLib} from "../src/libraries/UtilsLib.sol";
 
 contract OtherFunctionsTest is BaseTest {
@@ -28,7 +28,7 @@ contract OtherFunctionsTest is BaseTest {
         obligation.collaterals
             .push(Collateral({token: address(collateralToken2), lltv: 0.75e18, oracle: address(oracle2)}));
         obligation.collaterals = sortCollaterals(obligation.collaterals);
-        obligation.minCollatValue = 0;
+        obligation.rcfThreshold = 0;
 
         id = toId(obligation);
     }
@@ -224,55 +224,8 @@ contract OtherFunctionsTest is BaseTest {
         assertEq(morphoV2.session(user), keccak256(abi.encode(0, blockhash(block.number - 1))), "session");
     }
 
-    function testMinCollatValueInSupplyCollateral(uint256 collateral, uint256 price, uint256 minCollatValue) public {
+    function testSupplyCollateralDoesNotCallOracle(uint256 collateral) public {
         collateral = bound(collateral, 1, MAX_TEST_AMOUNT);
-        price = bound(price, 1, ORACLE_PRICE_SCALE);
-        Oracle(obligation.collaterals[0].oracle).setPrice(price);
-
-        uint256 collateralValue = collateral.mulDivDown(price, ORACLE_PRICE_SCALE);
-        minCollatValue = bound(minCollatValue, collateralValue + 1, type(uint256).max);
-        obligation.minCollatValue = minCollatValue;
-
-        address collateralToken = obligation.collaterals[0].token;
-        deal(collateralToken, address(this), collateral);
-        ERC20(collateralToken).approve(address(morphoV2), collateral);
-        vm.expectRevert("Below min collateral");
-        morphoV2.supplyCollateral(obligation, 0, collateral, borrower);
-    }
-
-    function testMinCollatValueInWithdrawCollateral(
-        uint256 collateral,
-        uint256 price,
-        uint256 withdrawnCollateral,
-        uint256 minCollatValue
-    ) public {
-        collateral = bound(collateral, 2, MAX_TEST_AMOUNT);
-        price = bound(price, 1, ORACLE_PRICE_SCALE);
-        Oracle(obligation.collaterals[0].oracle).setPrice(price);
-
-        uint256 initialValue = collateral.mulDivDown(price, ORACLE_PRICE_SCALE);
-        vm.assume(initialValue > 0);
-
-        // withdrawnCollateral must leave some remaining (can't withdraw all)
-        withdrawnCollateral = bound(withdrawnCollateral, 1, collateral - 1);
-        uint256 remainingValue = (collateral - withdrawnCollateral).mulDivDown(price, ORACLE_PRICE_SCALE);
-
-        // minCollatValue must be in (remainingValue, initialValue] for supply to succeed and withdraw to fail
-        vm.assume(remainingValue < initialValue);
-        minCollatValue = bound(minCollatValue, remainingValue + 1, initialValue);
-        obligation.minCollatValue = minCollatValue;
-
-        address collateralToken = obligation.collaterals[0].token;
-        deal(collateralToken, address(this), collateral);
-        ERC20(collateralToken).approve(address(morphoV2), collateral);
-        morphoV2.supplyCollateral(obligation, 0, collateral, borrower);
-
-        vm.prank(borrower);
-        vm.expectRevert("Below min collateral");
-        morphoV2.withdrawCollateral(obligation, 0, withdrawnCollateral, borrower, borrower);
-    }
-
-    function testSupplyCollateralZeroDoesNotCallOracle() public {
         RevertingOracle revertingOracle = new RevertingOracle();
         Collateral[] memory collaterals = new Collateral[](1);
         collaterals[0] = Collateral({token: address(collateralToken1), lltv: 0.75e18, oracle: address(revertingOracle)});
@@ -285,11 +238,8 @@ contract OtherFunctionsTest is BaseTest {
         // Make the oracle revert.
         revertingOracle.stopOracle();
 
-        // Should succeed if oracle is not called.
-        morphoV2.supplyCollateral(obligationWithRevertingOracle, 0, 0, borrower);
-
-        vm.expectRevert("Oracle should not be called");
-        morphoV2.supplyCollateral(obligationWithRevertingOracle, 0, 1, borrower);
+        deal(address(collateralToken1), address(this), collateral);
+        morphoV2.supplyCollateral(obligationWithRevertingOracle, 0, collateral, borrower);
     }
 
     function testWithdrawCollateralToZeroDoesNotCallOracle(uint256 collateral) public {
@@ -314,8 +264,6 @@ contract OtherFunctionsTest is BaseTest {
 
         vm.prank(borrower);
         morphoV2.withdrawCollateral(obligationWithRevertingOracle, 0, collateral, borrower, borrower);
-
-        assertEq(morphoV2.collateralOf(_id, borrower, 0), 0, "collateral should be 0 after withdrawal");
     }
 
     // Bitmap tests.
@@ -331,7 +279,7 @@ contract OtherFunctionsTest is BaseTest {
         _obligation.loanToken = address(loanToken);
         _obligation.maturity = block.timestamp + 100;
         _obligation.collaterals = collaterals;
-        _obligation.minCollatValue = 0;
+        _obligation.rcfThreshold = 0;
     }
 
     function testMaxCollaterals(uint256 numCollaterals) public {

--- a/test/SettersTest.sol
+++ b/test/SettersTest.sol
@@ -61,10 +61,7 @@ contract SettersTest is BaseTest {
 
         // touch obligation with this loan token
         Obligation memory obligation = Obligation({
-            loanToken: loanToken,
-            maturity: block.timestamp + 1 days,
-            collaterals: new Collateral[](0),
-            minCollatValue: 0
+            loanToken: loanToken, maturity: block.timestamp + 1 days, collaterals: new Collateral[](0), rcfThreshold: 0
         });
         bytes32 id = toId(obligation);
         morphoV2.touchObligation(obligation);
@@ -140,10 +137,7 @@ contract SettersTest is BaseTest {
 
         // touch obligation with this loan token
         Obligation memory obligation = Obligation({
-            loanToken: loanToken,
-            maturity: block.timestamp + 1 days,
-            collaterals: new Collateral[](0),
-            minCollatValue: 0
+            loanToken: loanToken, maturity: block.timestamp + 1 days, collaterals: new Collateral[](0), rcfThreshold: 0
         });
         bytes32 id = toId(obligation);
         morphoV2.touchObligation(obligation);
@@ -183,10 +177,7 @@ contract SettersTest is BaseTest {
 
         // touch obligation with this loan token
         Obligation memory obligation = Obligation({
-            loanToken: loanToken,
-            maturity: block.timestamp + 1 days,
-            collaterals: new Collateral[](0),
-            minCollatValue: 0
+            loanToken: loanToken, maturity: block.timestamp + 1 days, collaterals: new Collateral[](0), rcfThreshold: 0
         });
         bytes32 id = toId(obligation);
         morphoV2.touchObligation(obligation);
@@ -227,10 +218,7 @@ contract SettersTest is BaseTest {
 
         // touch obligation with this loan token
         Obligation memory obligation = Obligation({
-            loanToken: loanToken,
-            maturity: block.timestamp + 1 days,
-            collaterals: new Collateral[](0),
-            minCollatValue: 0
+            loanToken: loanToken, maturity: block.timestamp + 1 days, collaterals: new Collateral[](0), rcfThreshold: 0
         });
         bytes32 id = toId(obligation);
         morphoV2.touchObligation(obligation);

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -36,7 +36,7 @@ contract TakeTest is BaseTest {
         obligation.collaterals
             .push(Collateral({token: address(collateralToken2), lltv: 0.75e18, oracle: address(oracle2)}));
         obligation.collaterals = sortCollaterals(obligation.collaterals);
-        obligation.minCollatValue = 0;
+        obligation.rcfThreshold = 0;
 
         id = toId(obligation);
 


### PR DESCRIPTION
- [initial thread](https://morpholabs.slack.com/archives/C02N7CZ088N/p1771584258512549)
- we just want to break the collat value reduction loop caused by RCF liquidations. with this change, it shouldn't drop below the threshold (in OOM).
- more precisely, we want the RCF to deactivate if c * P / LIF <= T. we could multiply by LIF and/or by LLTV to have a nicer "LI equivalent", but the easy property for the borrower matters more.
- to avoid double liquidations, we "pre-shot" the max liquidation:
  - the condition becomes (c - maxSeized) * P / LIF <= T
  - <=> c * P / LIF - maxRepaid <= T (because maxRepaid = maxSeized * P / LIF)
- borrower guarantees:
  - no deactivation if their collat are all enough to repay rcfThreshold.
  - in single-collat, d > t => no rcf deactivation ([proof](https://morpholabs.slack.com/archives/C02N7CZ088N/p1771855886129019?thread_ts=1771854302.609329&cid=C02N7CZ088N))