### PR TITLE
 Share/asset ratio  + Share Price does not decrease

### DIFF
--- a/certora/confs/SharePrice.conf
+++ b/certora/confs/SharePrice.conf
@@ -6,18 +6,16 @@
   "verify": "MorphoV2:certora/specs/SharePrice.spec",
   "solc": "solc-0.8.31",
   "solc_via_ir": true,
-  "solc_evm_version": "osaka",
   "optimistic_loop": true,
   "loop_iter": 2,
   "optimistic_hashing": true,
   "hashing_length_bound": 1024,
-  "rule_sanity": "none",
+  "rule_sanity": "basic",
   "multi_assert_check": true,
-  "smt_timeout": 7200,
+  "smt_timeout": 600,
   "prover_args": [
     "-destructiveOptimizations twostage",
     "-s [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:def{randomSeed=8},z3:def{randomSeed=9},z3:def{randomSeed=10}]",
-    "-timeout 7200"
   ],
   "msg": "Morpho V2 Share Price"
 }

--- a/certora/specs/SharePrice.spec
+++ b/certora/specs/SharePrice.spec
@@ -14,5 +14,82 @@ methods {
     function SafeTransferLib.safeTransfer(address, address, uint256) internal => NONDET;
 }
 
-// strong invariant sharePriceBelowOne(bytes20 id)
-//     totalShares(id) >= totalUnits(id);
+// absolute 1 bound --> share price (units/shares) ≤ 1 at all times
+strong invariant sharePriceBelowOrEqOne(bytes20 id)
+    totalShares(id) >= totalUnits(id)
+{
+    preserved take(uint256 buyerAssets,
+        uint256 sellerAssets,
+        uint256 obligationUnits,
+        uint256 obligationShares,
+        address taker,
+        address takerCallback,
+        bytes takerCallbackData,
+        address receiverIfTakerIsSeller,
+        MorphoV2.Offer offer,
+        MorphoV2.Signature signature,
+        bytes32 root,
+        bytes32[] proof) with (env e) {
+            if (buyerAssets != 0) {
+                assert(true);
+            } else if (sellerAssets != 0) {
+                assert(true);
+            } else if (obligationUnits != 0) {
+                assert(true);
+            } else {
+                assert(true);
+            }
+        }
+}
+
+
+
+/// Liquidation without bad debt preserves virtual share price.
+rule sharePricePreservedByLiquidateNoBadDebt(env e, MorphoV2.Obligation obligation, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, bytes data, bytes20 id
+) {
+    requireInvariant sharePriceBelowOrEqOne(id);
+
+    mathint unitsBefore = totalUnits(id);
+    mathint sharesBefore = totalShares(id);
+
+    liquidate(e, obligation, collateralIndex, seizedAssets, repaidUnits, borrower, data);
+
+    mathint unitsAfter = totalUnits(id);
+    mathint sharesAfter = totalShares(id);
+
+    // unitsAfter == unitsBefore <==> badDebt == 0 (no bad debt socialization occurred)
+    assert unitsAfter == unitsBefore => (unitsAfter + 1) * (sharesBefore + 1) >= (unitsBefore + 1) * (sharesAfter + 1), "liquidation without bad debt must not decrease virtual share price";
+}
+
+
+
+/// Virtual share price = (totalUnits+1)/(totalShares+1) monotonicity.
+rule sharePriceDoesNotDecrease(bytes20 id, method f) filtered {
+    f -> f.selector != sig:multicall(bytes[]).selector
+      && f.selector != sig:liquidate(MorphoV2.Obligation, uint256, uint256, uint256, address, bytes).selector
+} {
+
+    // We need it otherwise rounding down to 0 creates shares with no backing units
+    // for withdraw +1 virtual liquidity makes exchange rate differ from actual pool ratio when totalShares > totalUnits
+    requireInvariant sharePriceBelowOrEqOne(id);
+
+    mathint unitsBefore = totalUnits(id);
+    mathint sharesBefore = totalShares(id);
+
+    env e;
+    calldataarg args;
+    f(e, args);
+
+    mathint unitsAfter = totalUnits(id);
+    mathint sharesAfter = totalShares(id);
+
+    // new lenders + new borrowers (case 1) + shares unchanged (cases 2,3 of take) => virtual share price must not decrease
+        // NOTE: code uses mulDivDown in take's else-branch (obligationShares input), which cause this to fail for that case
+    assert sharesAfter >= sharesBefore =>
+        (unitsAfter + 1) * (sharesBefore + 1) >= (unitsBefore + 1) * (sharesAfter + 1);
+
+    // borrower exits + existing lender exits (case 4) => obligation shrinks   
+        // FINDING : we have a rounding error of sharesBefore due to ceil rounding up to sharesBefore, that's why we need to include it in the inequality
+    assert sharesAfter < sharesBefore =>
+        (unitsAfter + 1) * (sharesBefore + 1) + sharesBefore >= (unitsBefore + 1) * (sharesAfter + 1);
+}


### PR DESCRIPTION
Still in Draft 

- `sharePriceBelowOrEqOne` should work against main code
- `sharePricePreservedByLiquidateNoBadDebt` should work against main code
- `sharePriceDoesNotDecrease` catch rounding issue on case 4 `muldivDown` [we discussed here](https://certora.slack.com/archives/C09EAFEJUMV/p1771844203301919)