### PR TITLE
Certora/share price below one

### DIFF
--- a/certora/confs/FeeProperties.conf
+++ b/certora/confs/FeeProperties.conf
@@ -1,0 +1,23 @@
+{
+  "files": [
+    "certora/helpers/MorphoV2Harness.sol",
+    "certora/dispatch/ERC20Standard.sol"
+  ],
+  "verify": "MorphoV2Harness:certora/specs/FeeProperties.spec",
+  "solc": "solc-0.8.31",
+  "solc_via_ir": true,
+  "optimistic_loop": true,
+  "loop_iter": 2,
+  "optimistic_hashing": true,
+  "hashing_length_bound": 1024,
+  "rule_sanity": "none",
+  "multi_assert_check": true,
+  "smt_timeout": 600,
+  "prover_args": [
+    "-destructiveOptimizations twostage",
+    "-s [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5}]",
+    "-split",
+		"false"
+  ],
+  "msg": "Fee Properties"
+}

--- a/certora/confs/SharePrice.conf
+++ b/certora/confs/SharePrice.conf
@@ -6,18 +6,16 @@
   "verify": "MorphoV2:certora/specs/SharePrice.spec",
   "solc": "solc-0.8.31",
   "solc_via_ir": true,
-  "solc_evm_version": "osaka",
   "optimistic_loop": true,
   "loop_iter": 2,
   "optimistic_hashing": true,
   "hashing_length_bound": 1024,
-  "rule_sanity": "none",
+  "rule_sanity": "basic",
   "multi_assert_check": true,
-  "smt_timeout": 7200,
+  "smt_timeout": 600,
   "prover_args": [
     "-destructiveOptimizations twostage",
     "-s [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:def{randomSeed=8},z3:def{randomSeed=9},z3:def{randomSeed=10}]",
-    "-timeout 7200"
   ],
   "msg": "Morpho V2 Share Price"
 }

--- a/certora/confs/SharePrice.conf
+++ b/certora/confs/SharePrice.conf
@@ -12,7 +12,7 @@
   "hashing_length_bound": 1024,
   "rule_sanity": "basic",
   "multi_assert_check": true,
-  "smt_timeout": 600,
+  "smt_timeout": 7200,
   "prover_args": [
     "-destructiveOptimizations twostage",
     "-s [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:def{randomSeed=8},z3:def{randomSeed=9},z3:def{randomSeed=10}]",

--- a/certora/confs/SharePriceBelowOne.conf
+++ b/certora/confs/SharePriceBelowOne.conf
@@ -1,0 +1,21 @@
+{
+  "files": [
+    "src/MorphoV2.sol",
+    "certora/dispatch/ERC20Standard.sol"
+  ],
+  "verify": "MorphoV2:certora/specs/SharePriceBelowOne.spec",
+  "solc": "solc-0.8.31",
+  "solc_via_ir": true,
+  "optimistic_loop": true,
+  "loop_iter": 2,
+  "optimistic_hashing": true,
+  "hashing_length_bound": 1024,
+  "rule_sanity": "basic",
+  "multi_assert_check": true,
+  "smt_timeout": 7200,
+  "prover_args": [
+    "-destructiveOptimizations twostage",
+    "-s [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:def{randomSeed=8},z3:def{randomSeed=9},z3:def{randomSeed=10}]"
+  ],
+  "msg": "Morpho V2 Share Price Below One"
+}

--- a/certora/helpers/MorphoV2Harness.sol
+++ b/certora/helpers/MorphoV2Harness.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.31;
+
+import {MorphoV2} from "../../src/MorphoV2.sol";
+import {IdLib} from "../../src/libraries/IdLib.sol";
+import {TickLib} from "../../src/libraries/TickLib.sol";
+import {UtilsLib} from "../../src/libraries/UtilsLib.sol";
+import {Obligation, Offer} from "../../src/interfaces/IMorphoV2.sol";
+import {IOracle} from "../../src/interfaces/IOracle.sol";
+import {FEE_STEP} from "../../src/libraries/ConstantsLib.sol";
+
+contract MorphoV2Harness is MorphoV2 {
+    function getOfferPrice(uint256 tick) external pure returns (uint256) {
+        return TickLib.tickToPrice(tick);
+    }
+
+    function getDefaultFee(address loanToken, uint256 index) external view returns (uint256) {
+        return uint256(defaultFees[loanToken][index]) * FEE_STEP;
+    }
+
+    /// @dev Returns the trading fee rate that `take` would use for the given offer at the current block.
+    function computeTradingFeeForOffer(Offer memory offer) external view returns (uint256) {
+        bytes20 id = IdLib.toId(offer.obligation, block.chainid, address(this));
+        uint256 timeToMaturity = UtilsLib.zeroFloorSub(offer.obligation.maturity, block.timestamp);
+        return tradingFee(id, timeToMaturity);
+    }
+
+    function getCollateralPrice(Obligation memory obligation, uint256 collateralIndex) external view returns (uint256) {
+        return IOracle(obligation.collaterals[collateralIndex].oracle).price();
+    }
+
+    function getCollateralToken(Obligation memory obligation, uint256 collateralIndex) external pure returns (address) {
+        return obligation.collaterals[collateralIndex].token;
+    }
+
+    function getCollateralsLength(Obligation memory obligation) external pure returns (uint256) {
+        return obligation.collaterals.length;
+    }
+
+}

--- a/certora/specs/FeeProperties.spec
+++ b/certora/specs/FeeProperties.spec
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+methods {
+    function multicall(bytes[]) external => HAVOC_ALL DELETE;
+
+    function tradingFee(bytes20 id, uint256 timeToMaturity) external returns (uint256) envfree;
+    function getDefaultFee(address loanToken, uint256 index) external returns (uint256) envfree;
+    function getOfferPrice(uint256 tick) external returns (uint256) envfree;
+    function feeSetter() external returns (address) envfree;
+
+    function _.price() external => NONDET;
+
+    function _.transfer(address, uint256) external => DISPATCHER(true);
+    function _.transferFrom(address, address, uint256) external => DISPATCHER(true);
+
+    // NONDET is sound here: these are external calls (not delegatecalls) that cannot
+    // directly write MorphoV2 storage; fee-modifying functions enforce <= MAX_FEE even under reentrancy.
+    function _.onBuy(MorphoV2Harness.Obligation, address, uint256, uint256, uint256, uint256, bytes) external => NONDET;
+    function _.onSell(MorphoV2Harness.Obligation, address, uint256, uint256, uint256, uint256, bytes) external => NONDET;
+    function _.onFlashLoan(address, uint256, bytes) external => NONDET;
+    function _.onLiquidate(MorphoV2Harness.Obligation, uint256, uint256, uint256, address, bytes) external => NONDET;
+}
+
+definition MAX_FEE() returns uint256 = 10000000000000000; // 0.01e18 = 1%
+definition FEE_STEP() returns uint256 = 1000000000000; // 1e12
+definition MAX_FEE_UNITS() returns uint256 = 10000; // MAX_FEE / FEE_STEP
+definition WAD() returns mathint = 1000000000000000000;
+
+// Ghost mirrors of the raw uint16 fee storage, updated on every Sstore/Sload.
+ghost mapping(bytes20 => mapping(uint256 => mathint)) ghostObligationFeeUnits {
+    init_state axiom forall bytes20 id. forall uint256 i. ghostObligationFeeUnits[id][i] == 0;
+}
+ghost mapping(address => mapping(uint256 => mathint)) ghostDefaultFeeUnits {
+    init_state axiom forall address t. forall uint256 i. ghostDefaultFeeUnits[t][i] == 0;
+}
+
+hook Sstore obligationState[KEY bytes20 id].fees[INDEX uint256 idx] uint16 newVal {
+    ghostObligationFeeUnits[id][idx] = to_mathint(newVal);
+}
+
+hook Sload uint16 val obligationState[KEY bytes20 id].fees[INDEX uint256 idx] {
+    require ghostObligationFeeUnits[id][idx] == to_mathint(val);
+}
+
+hook Sstore defaultFees[KEY address token][INDEX uint256 idx] uint16 newVal {
+    ghostDefaultFeeUnits[token][idx] = to_mathint(newVal);
+}
+hook Sload uint16 val defaultFees[KEY address token][INDEX uint256 idx] {
+    require ghostDefaultFeeUnits[token][idx] == to_mathint(val);
+}
+
+/// Default fees for any loan token are bounded by MAX_FEE.
+invariant defaultFeeWithinMaxFee(address loanToken, uint256 index)
+    index <= 5 => ghostDefaultFeeUnits[loanToken][index] <= MAX_FEE_UNITS();
+
+
+/// Every obligation's fee breakpoints are bounded by MAX_FEE.
+invariant obligationFeeWithinMaxFee(bytes20 id, uint256 index)
+    index <= 5 => ghostObligationFeeUnits[id][index] <= MAX_FEE_UNITS()
+    {
+        preserved with (env e) {
+            require forall address t. forall uint256 i.
+                i <= 5 => ghostDefaultFeeUnits[t][i] <= MAX_FEE_UNITS();
+        }
+    }
+
+/// --- feePct = 0 => fee = 0 and more --- ///
+
+/// tradingFee(id, t) <= MAX_FEE for any time to maturity.
+rule tradingFeeAlwaysWithinMaxFee(bytes20 id, uint256 timeToMaturity) {
+    requireInvariant obligationFeeWithinMaxFee(id, 0);
+    requireInvariant obligationFeeWithinMaxFee(id, 1);
+    requireInvariant obligationFeeWithinMaxFee(id, 2);
+    requireInvariant obligationFeeWithinMaxFee(id, 3);
+    requireInvariant obligationFeeWithinMaxFee(id, 4);
+    requireInvariant obligationFeeWithinMaxFee(id, 5);
+
+    assert tradingFee(id, timeToMaturity) <= MAX_FEE();
+}
+
+/// Fee linear interpolation never exceeds an upper bound that covers all breakpoints.
+rule tradingFeeBoundedByBreakpoints(bytes20 id, uint256 timeToMaturity, uint256 upperBound) {
+    require tradingFee(id, 0) <= upperBound;
+    require tradingFee(id, 86400) <= upperBound;
+    require tradingFee(id, 604800) <= upperBound;
+    require tradingFee(id, 2592000) <= upperBound;
+    require tradingFee(id, 7776000) <= upperBound;
+    require tradingFee(id, 15552000) <= upperBound;
+
+    assert tradingFee(id, timeToMaturity) <= upperBound;
+}
+
+/// The interpolation never goes below a lower bound that all breakpoints satisfy.
+rule tradingFeeLowerBoundedByBreakpoints(bytes20 id, uint256 timeToMaturity, uint256 lowerBound) {
+    require tradingFee(id, 0) >= lowerBound;
+    require tradingFee(id, 86400) >= lowerBound;
+    require tradingFee(id, 604800) >= lowerBound;
+    require tradingFee(id, 2592000) >= lowerBound;
+    require tradingFee(id, 7776000) >= lowerBound;
+    require tradingFee(id, 15552000) >= lowerBound;
+
+    assert tradingFee(id, timeToMaturity) >= lowerBound;
+}
+
+/// If all fee breakpoints are zero, the interpolated fee is zero everywhere.
+rule zeroFeesImplyZeroTradingFee(bytes20 id, uint256 timeToMaturity) {
+    require tradingFee(id, 0) == 0;
+    require tradingFee(id, 86400) == 0;
+    require tradingFee(id, 604800) == 0;
+    require tradingFee(id, 2592000) == 0;
+    require tradingFee(id, 7776000) == 0;
+    require tradingFee(id, 15552000) == 0;
+
+    assert tradingFee(id, timeToMaturity) == 0;
+}
+
+/// setObligationTradingFee reverts if caller is not feeSetter.
+rule setObligationTradingFeeRequiresFeeSetter(env e, bytes20 id, uint256 index, uint256 newFee) {
+    setObligationTradingFee(e, id, index, newFee);
+
+    assert e.msg.sender == feeSetter();
+}
+
+/// setDefaultTradingFee reverts if caller is not feeSetter.
+rule setDefaultTradingFeeRequiresFeeSetter(env e, address loanToken, uint256 index, uint256 newFee) {
+    setDefaultTradingFee(e, loanToken, index, newFee);
+
+    assert e.msg.sender == feeSetter();
+}
+
+/// Default fee breakpoints can only change via setDefaultTradingFee.
+rule defaultFeesOnlyChangeViaSetDefault(env e, method f, address loanToken, uint256 index) {
+    require index <= 5;
+    uint256 feeBefore = getDefaultFee(loanToken, index);
+
+    calldataarg args;
+    f(e, args);
+
+    assert getDefaultFee(loanToken, index) != feeBefore =>
+        f.selector == sig:setDefaultTradingFee(address, uint256, uint256).selector;
+}
+
+
+
+
+/// buyerAssets >= sellerAssets, and fee bounded by buyer's notional.
+rule actualFeeChargedNonNegative(
+    env e, uint256 buyerAssets, uint256 sellerAssets,
+    uint256 obligationUnits, uint256 obligationShares, address taker,
+    address takerCallback, bytes takerCallbackData, address receiverIfTakerIsSeller,
+    MorphoV2Harness.Offer offer, MorphoV2Harness.Signature signature,
+    bytes32 root, bytes32[] proof
+) {
+    require forall bytes20 _id. forall uint256 _i.
+        _i <= 5 => ghostObligationFeeUnits[_id][_i] <= MAX_FEE_UNITS();
+    require forall address _t. forall uint256 _i.
+        _i <= 5 => ghostDefaultFeeUnits[_t][_i] <= MAX_FEE_UNITS();
+
+    uint256 offerPrice = getOfferPrice(offer.tick);
+
+    uint256 buyerAssetsOut;
+    uint256 sellerAssetsOut;
+    uint256 obligationUnitsOut;
+    uint256 obligationSharesOut;
+
+    buyerAssetsOut, sellerAssetsOut, obligationUnitsOut, obligationSharesOut =
+        take(e, buyerAssets, sellerAssets, obligationUnits, obligationShares, taker, takerCallback, takerCallbackData, receiverIfTakerIsSeller, offer, signature, root, proof);
+
+    assert buyerAssetsOut >= sellerAssetsOut;
+
+    // fee is bounded by buyer's notional
+    uint256 feeRate = computeTradingFeeForOffer(e, offer);
+    mathint buyerPrice = offer.buy
+        ? to_mathint(offerPrice)
+        : to_mathint(offerPrice) + to_mathint(feeRate);
+
+    assert (obligationUnits > 0 && buyerAssets == 0 && sellerAssets == 0 && obligationShares == 0)
+    || (obligationShares > 0 && buyerAssets == 0 && sellerAssets == 0 && obligationUnits == 0) =>
+    (to_mathint(buyerAssetsOut) - to_mathint(sellerAssetsOut)) * WAD() <= to_mathint(obligationUnitsOut) * buyerPrice;
+}
+
+// buyerPrice >= sellerPrice (feeRate <= offerPrice for buy offers)
+/// for sell offers buyerPrice >= sellerPrice is trivially true
+rule feeRateDoesNotExceedOfferPrice(
+    env e, uint256 buyerAssets, uint256 sellerAssets, uint256 obligationUnits, uint256 obligationShares, address taker,
+    address takerCallback, bytes takerCallbackData, address receiverIfTakerIsSeller,
+    MorphoV2Harness.Offer offer, MorphoV2Harness.Signature signature, bytes32 root, bytes32[] proof
+) {
+    uint256 buyerAssetsOut;
+    uint256 sellerAssetsOut;
+    uint256 obligationUnitsOut;
+    uint256 obligationSharesOut;
+
+    buyerAssetsOut, sellerAssetsOut, obligationUnitsOut, obligationSharesOut =
+        take(e, buyerAssets, sellerAssets, obligationUnits, obligationShares, taker, takerCallback, takerCallbackData, receiverIfTakerIsSeller, offer, signature, root, proof);
+
+    uint256 feeRate = computeTradingFeeForOffer(e, offer);
+    uint256 offerPrice = getOfferPrice(offer.tick);
+
+    // For buy offers: sellerPrice = offerPrice − feeRate, so feeRate must not exceed offerPrice
+    assert offer.buy => to_mathint(feeRate) <= to_mathint(offerPrice);
+}
+
+/// When the non-zero input is obligationUnits, the maker's asset amount is the exact floor of the notional value at the offer price.
+/// makerAssets = floor(obligationUnits * offerPrice / WAD).
+rule makerAssetsEqualsBondsTimesPrice(
+    env e, uint256 buyerAssets, uint256 sellerAssets, uint256 obligationUnits, uint256 obligationShares,
+    address taker, address takerCallback, bytes takerCallbackData, address receiverIfTakerIsSeller,
+    MorphoV2Harness.Offer offer, MorphoV2Harness.Signature signature, bytes32 root, bytes32[] proof
+) {
+    require obligationUnits > 0;
+    require buyerAssets == 0 && sellerAssets == 0 && obligationShares == 0;
+
+    uint256 offerPrice = getOfferPrice(offer.tick);
+
+    uint256 buyerAssetsOut;
+    uint256 sellerAssetsOut;
+    uint256 obligationUnitsOut;
+    uint256 obligationSharesOut;
+
+    buyerAssetsOut, sellerAssetsOut, obligationUnitsOut, obligationSharesOut =
+        take(e, buyerAssets, sellerAssets, obligationUnits, obligationShares, taker, takerCallback, takerCallbackData, receiverIfTakerIsSeller, offer, signature, root, proof);
+
+    mathint makerAssets = offer.buy ? to_mathint(buyerAssetsOut) : to_mathint(sellerAssetsOut);
+
+    // encode floor 
+    assert makerAssets * WAD() <= to_mathint(obligationUnitsOut) * to_mathint(offerPrice);
+    assert (makerAssets + 1) * WAD() > to_mathint(obligationUnitsOut) * to_mathint(offerPrice);
+}
+
+/// During a take with obligationUnits input, the fee charged (buyerAssets − sellerAssets)
+/// equals floor(obligationUnits × tradingFeeRate / WAD), possibly +1 due to two separate floors.
+rule feeAmountEqualsBondsTimesRate(
+    env e, uint256 buyerAssets, uint256 sellerAssets, uint256 obligationUnits, uint256 obligationShares, address taker,
+    address takerCallback, bytes takerCallbackData, address receiverIfTakerIsSeller,
+    MorphoV2Harness.Offer offer, MorphoV2Harness.Signature signature, bytes32 root, bytes32[] proof
+) {
+    require obligationUnits > 0;
+    require buyerAssets == 0 && sellerAssets == 0 && obligationShares == 0;
+
+    uint256 buyerAssetsOut;
+    uint256 sellerAssetsOut;
+    uint256 obligationUnitsOut;
+    uint256 obligationSharesOut;
+
+    buyerAssetsOut, sellerAssetsOut, obligationUnitsOut, obligationSharesOut =
+        take(e, buyerAssets, sellerAssets, obligationUnits, obligationShares, taker, takerCallback, takerCallbackData, receiverIfTakerIsSeller, offer, signature, root, proof);
+
+    uint256 feeRate = computeTradingFeeForOffer(e, offer);
+
+    mathint feeAmount = to_mathint(buyerAssetsOut) - to_mathint(sellerAssetsOut);
+    mathint oUxFee = to_mathint(obligationUnitsOut) * to_mathint(feeRate);
+
+    // feeAmount >= floor(oU * feeRate / WAD)
+    assert (feeAmount + 1) * WAD() > oUxFee;
+
+    // feeAmount <= floor(oU * feeRate / WAD) + 1
+    assert (feeAmount - 1) * WAD() <= oUxFee;
+}

--- a/certora/specs/SharePrice.spec
+++ b/certora/specs/SharePrice.spec
@@ -14,5 +14,82 @@ methods {
     function SafeTransferLib.safeTransfer(address, address, uint256) internal => NONDET;
 }
 
-// strong invariant sharePriceBelowOne(bytes20 id)
-//     totalShares(id) >= totalUnits(id);
+// absolute 1 bound --> share price (units/shares) ≤ 1 at all times
+strong invariant sharePriceBelowOrEqOne(bytes20 id)
+    totalShares(id) >= totalUnits(id)
+{
+    preserved take(uint256 buyerAssets,
+        uint256 sellerAssets,
+        uint256 obligationUnits,
+        uint256 obligationShares,
+        address taker,
+        address takerCallback,
+        bytes takerCallbackData,
+        address receiverIfTakerIsSeller,
+        MorphoV2.Offer offer,
+        MorphoV2.Signature signature,
+        bytes32 root,
+        bytes32[] proof) with (env e) {
+            if (buyerAssets != 0) {
+                assert(true);
+            } else if (sellerAssets != 0) {
+                assert(true);
+            } else if (obligationUnits != 0) {
+                assert(true);
+            } else {
+                assert(true);
+            }
+        }
+}
+
+
+
+/// Liquidation without bad debt preserves virtual share price.
+rule sharePricePreservedByLiquidateNoBadDebt(env e, MorphoV2.Obligation obligation, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, bytes data, bytes20 id
+) {
+    requireInvariant sharePriceBelowOrEqOne(id);
+
+    mathint unitsBefore = totalUnits(id);
+    mathint sharesBefore = totalShares(id);
+
+    liquidate(e, obligation, collateralIndex, seizedAssets, repaidUnits, borrower, data);
+
+    mathint unitsAfter = totalUnits(id);
+    mathint sharesAfter = totalShares(id);
+
+    // unitsAfter == unitsBefore <==> badDebt == 0 (no bad debt socialization occurred)
+    assert unitsAfter == unitsBefore => (unitsAfter + 1) * (sharesBefore + 1) >= (unitsBefore + 1) * (sharesAfter + 1), "liquidation without bad debt must not decrease virtual share price";
+}
+
+
+
+/// Virtual share price = (totalUnits+1)/(totalShares+1) monotonicity.
+rule sharePriceDoesNotDecrease(bytes20 id, method f) filtered {
+    f -> f.selector != sig:multicall(bytes[]).selector
+      && f.selector != sig:liquidate(MorphoV2.Obligation, uint256, uint256, uint256, address, bytes).selector
+} {
+
+    // We need it otherwise rounding down to 0 creates shares with no backing units
+    // for withdraw +1 virtual liquidity makes exchange rate differ from actual pool ratio when totalShares > totalUnits
+    requireInvariant sharePriceBelowOrEqOne(id);
+
+    mathint unitsBefore = totalUnits(id);
+    mathint sharesBefore = totalShares(id);
+
+    env e;
+    calldataarg args;
+    f(e, args);
+
+    mathint unitsAfter = totalUnits(id);
+    mathint sharesAfter = totalShares(id);
+
+    // new lenders + new borrowers (case 1) + shares unchanged (cases 2,3 of take) => virtual share price must not decrease
+        // NOTE: code uses mulDivDown in take's else-branch (obligationShares input), which cause this to fail for that case
+    assert sharesAfter >= sharesBefore =>
+        (unitsAfter + 1) * (sharesBefore + 1) >= (unitsBefore + 1) * (sharesAfter + 1);
+
+    // borrower exits + existing lender exits (case 4) => obligation shrinks   
+        // FINDING : we have a rounding error of sharesBefore due to ceil rounding up to sharesBefore, that's why we need to include it in the inequality
+    assert sharesAfter < sharesBefore =>
+        (unitsAfter + 1) * (sharesBefore + 1) + sharesBefore >= (unitsBefore + 1) * (sharesAfter + 1);
+}

--- a/certora/specs/SharePrice.spec
+++ b/certora/specs/SharePrice.spec
@@ -12,8 +12,13 @@ methods {
     function tradingFee(bytes20, uint256) internal returns (uint256) => NONDET;
     function SafeTransferLib.safeTransferFrom(address, address, address, uint256) internal => NONDET;
     function SafeTransferLib.safeTransfer(address, address, uint256) internal => NONDET;
+
+    function TickLib.tickToPrice(uint256) internal returns (uint256) => NONDET;
+    function TickLib.wExp(int256) internal returns (uint256) => NONDET;
+    function UtilsLib.isLeaf(bytes32, bytes32, bytes32[] memory) internal returns (bool) => NONDET;
 }
 
+/*
 // absolute 1 bound --> share price (units/shares) ≤ 1 at all times
 strong invariant sharePriceBelowOrEqOne(bytes20 id)
     totalShares(id) >= totalUnits(id)
@@ -40,14 +45,95 @@ strong invariant sharePriceBelowOrEqOne(bytes20 id)
                 assert(true);
             }
         }
+}*/
+
+strong invariant sharePriceBelowOrEqOne1(bytes20 id)
+    totalShares(id) >= totalUnits(id)
+{
+    preserved take(uint256 buyerAssets,
+        uint256 sellerAssets,
+        uint256 obligationUnits,
+        uint256 obligationShares,
+        address taker,
+        address takerCallback,
+        bytes takerCallbackData,
+        address receiverIfTakerIsSeller,
+        MorphoV2.Offer offer,
+        MorphoV2.Signature signature,
+        bytes32 root,
+        bytes32[] proof) with (env e) {
+            require buyerAssets != 0 && sellerAssets == 0 && obligationUnits == 0 && obligationShares == 0, "other cases checked separately";
+            require buyerAssets < 2^128;
+        }
 }
 
 
+strong invariant sharePriceBelowOrEqOne2(bytes20 id)
+    totalShares(id) >= totalUnits(id)
+{
+    preserved take(uint256 buyerAssets,
+        uint256 sellerAssets,
+        uint256 obligationUnits,
+        uint256 obligationShares,
+        address taker,
+        address takerCallback,
+        bytes takerCallbackData,
+        address receiverIfTakerIsSeller,
+        MorphoV2.Offer offer,
+        MorphoV2.Signature signature,
+        bytes32 root,
+        bytes32[] proof) with (env e) {
+            require buyerAssets == 0 && sellerAssets != 0 && obligationUnits == 0 && obligationShares == 0, "other cases checked separately";
+            require sellerAssets < 2^128;
+        }
+}
+
+strong invariant sharePriceBelowOrEqOne3(bytes20 id)
+    totalShares(id) >= totalUnits(id)
+{
+    preserved take(uint256 buyerAssets,
+        uint256 sellerAssets,
+        uint256 obligationUnits,
+        uint256 obligationShares,
+        address taker,
+        address takerCallback,
+        bytes takerCallbackData,
+        address receiverIfTakerIsSeller,
+        MorphoV2.Offer offer,
+        MorphoV2.Signature signature,
+        bytes32 root,
+        bytes32[] proof) with (env e) {
+            require buyerAssets == 0 && sellerAssets == 0 && obligationUnits != 0 && obligationShares == 0, "other cases checked separately";
+        }
+}
+
+strong invariant sharePriceBelowOrEqOne4(bytes20 id)
+    totalShares(id) >= totalUnits(id)
+{
+    preserved take(uint256 buyerAssets,
+        uint256 sellerAssets,
+        uint256 obligationUnits,
+        uint256 obligationShares,
+        address taker,
+        address takerCallback,
+        bytes takerCallbackData,
+        address receiverIfTakerIsSeller,
+        MorphoV2.Offer offer,
+        MorphoV2.Signature signature,
+        bytes32 root,
+        bytes32[] proof) with (env e) {
+            require buyerAssets == 0 && sellerAssets == 0 && obligationUnits == 0, "other cases checked separately";
+        }
+}
+
 
 /// Liquidation without bad debt preserves virtual share price.
-rule sharePricePreservedByLiquidateNoBadDebt(env e, MorphoV2.Obligation obligation, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, bytes data, bytes20 id
+rule sharePriceDoesNotDecreaseByLiquidateNoBadDebt(env e, MorphoV2.Obligation obligation, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, bytes data, bytes20 id
 ) {
-    requireInvariant sharePriceBelowOrEqOne(id);
+    requireInvariant sharePriceBelowOrEqOne1(id);
+    requireInvariant sharePriceBelowOrEqOne2(id);
+    requireInvariant sharePriceBelowOrEqOne3(id);
+    requireInvariant sharePriceBelowOrEqOne4(id);
 
     mathint unitsBefore = totalUnits(id);
     mathint sharesBefore = totalShares(id);
@@ -71,7 +157,10 @@ rule sharePriceDoesNotDecrease(bytes20 id, method f) filtered {
 
     // We need it otherwise rounding down to 0 creates shares with no backing units
     // for withdraw +1 virtual liquidity makes exchange rate differ from actual pool ratio when totalShares > totalUnits
-    requireInvariant sharePriceBelowOrEqOne(id);
+    requireInvariant sharePriceBelowOrEqOne1(id);
+    requireInvariant sharePriceBelowOrEqOne2(id);
+    requireInvariant sharePriceBelowOrEqOne3(id);
+    requireInvariant sharePriceBelowOrEqOne4(id);
 
     mathint unitsBefore = totalUnits(id);
     mathint sharesBefore = totalShares(id);

--- a/certora/specs/SharePriceBelowOne.spec
+++ b/certora/specs/SharePriceBelowOne.spec
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+methods {
+    function multicall(bytes[]) external => HAVOC_ALL DELETE;
+
+    function totalUnits(bytes20 id) external returns (uint256) envfree;
+    function totalShares(bytes20 id) external returns (uint256) envfree;
+
+    function _.price() external => NONDET;
+
+    // Summaries to avoid SMT solver timeout.
+    function tradingFee(bytes20, uint256) internal returns (uint256) => NONDET;
+    function SafeTransferLib.safeTransferFrom(address, address, address, uint256) internal => NONDET;
+    function SafeTransferLib.safeTransfer(address, address, uint256) internal => NONDET;
+
+    function TickLib.tickToPrice(uint256) internal returns (uint256) => NONDET;
+    function TickLib.wExp(int256) internal returns (uint256) => NONDET;
+    function UtilsLib.isLeaf(bytes32, bytes32, bytes32[] memory) internal returns (bool) => NONDET;
+}
+
+// Share/asset ratio is never above 1: totalShares >= totalUnits at all times.
+
+strong invariant sharePriceBelowOrEqOne1(bytes20 id)
+    totalShares(id) >= totalUnits(id)
+{
+    preserved take(uint256 buyerAssets,
+        uint256 sellerAssets,
+        uint256 obligationUnits,
+        uint256 obligationShares,
+        address taker,
+        address takerCallback,
+        bytes takerCallbackData,
+        address receiverIfTakerIsSeller,
+        MorphoV2.Offer offer,
+        MorphoV2.Signature signature,
+        bytes32 root,
+        bytes32[] proof) with (env e) {
+            require buyerAssets != 0 && sellerAssets == 0 && obligationUnits == 0 && obligationShares == 0, "other cases checked separately";
+            require buyerAssets < 2^128;
+        }
+}
+
+
+strong invariant sharePriceBelowOrEqOne2(bytes20 id)
+    totalShares(id) >= totalUnits(id)
+{
+    preserved take(uint256 buyerAssets,
+        uint256 sellerAssets,
+        uint256 obligationUnits,
+        uint256 obligationShares,
+        address taker,
+        address takerCallback,
+        bytes takerCallbackData,
+        address receiverIfTakerIsSeller,
+        MorphoV2.Offer offer,
+        MorphoV2.Signature signature,
+        bytes32 root,
+        bytes32[] proof) with (env e) {
+            require buyerAssets == 0 && sellerAssets != 0 && obligationUnits == 0 && obligationShares == 0, "other cases checked separately";
+            require sellerAssets < 2^128;
+        }
+}
+
+strong invariant sharePriceBelowOrEqOne3(bytes20 id)
+    totalShares(id) >= totalUnits(id)
+{
+    preserved take(uint256 buyerAssets,
+        uint256 sellerAssets,
+        uint256 obligationUnits,
+        uint256 obligationShares,
+        address taker,
+        address takerCallback,
+        bytes takerCallbackData,
+        address receiverIfTakerIsSeller,
+        MorphoV2.Offer offer,
+        MorphoV2.Signature signature,
+        bytes32 root,
+        bytes32[] proof) with (env e) {
+            require buyerAssets == 0 && sellerAssets == 0 && obligationUnits != 0 && obligationShares == 0, "other cases checked separately";
+        }
+}
+
+strong invariant sharePriceBelowOrEqOne4(bytes20 id)
+    totalShares(id) >= totalUnits(id)
+{
+    preserved take(uint256 buyerAssets,
+        uint256 sellerAssets,
+        uint256 obligationUnits,
+        uint256 obligationShares,
+        address taker,
+        address takerCallback,
+        bytes takerCallbackData,
+        address receiverIfTakerIsSeller,
+        MorphoV2.Offer offer,
+        MorphoV2.Signature signature,
+        bytes32 root,
+        bytes32[] proof) with (env e) {
+            require buyerAssets == 0 && sellerAssets == 0 && obligationUnits == 0, "other cases checked separately";
+        }
+}


### PR DESCRIPTION
Proves that the share/asset ratio (`totalUnits/totalShares`) never exceeds 1, split across four take parameter cases (to make prover life easier for now)

[last run](https://prover.certora.com/output/7508195/cb9379e3cab54bdda0ab5415b3081640/?anonymousKey=6a4993b36dde81f08245ba1be0ad4cf82111708a)