### PR TITLE
Require obligations to include at least one collateral; add invariant and unit test

### DIFF
--- a/certora/specs/CreatedObligations.spec
+++ b/certora/specs/CreatedObligations.spec
@@ -40,9 +40,13 @@ function obligationIsCreated(MorphoV2.Obligation obligation) returns (bool) {
 invariant createdObligationsHaveSortedCollaterals(MorphoV2.Obligation obligation, uint256 i, uint256 j)
     obligationIsCreated(obligation) => i < j => j < obligation.collaterals.length => obligation.collaterals[i].token < obligation.collaterals[j].token;
 
-// Show that a created obligation do not have address(0) collaterals.
+// Show that a created obligation does not have address(0) collaterals.
 invariant createdObligationsHaveNonZeroCollaterals(MorphoV2.Obligation obligation, uint256 i)
     obligationIsCreated(obligation) => i < obligation.collaterals.length => obligation.collaterals[i].token != 0;
+
+// Show that a created obligation has at least one collateral.
+invariant createdObligationsHaveAtLeastOneCollateral(MorphoV2.Obligation obligation)
+    obligationIsCreated(obligation) => obligation.collaterals.length > 0;
 
 // Show that a created obligation cannot be deleted.
 rule obligationCannotBeDeleted(env e, method f, calldataarg args, bytes20 id) {

--- a/src/MorphoV2.sol
+++ b/src/MorphoV2.sol
@@ -547,6 +547,7 @@ contract MorphoV2 is IMorphoV2 {
     function touchObligation(Obligation memory obligation) public returns (bytes20) {
         bytes20 id = IdLib.toId(obligation, block.chainid, address(this));
         if (!obligationState[id].created) {
+            require(obligation.collaterals.length != 0, "no collateral");
             require(obligation.collaterals.length <= MAX_COLLATERALS, "too many collaterals");
             address previousCollateralToken;
             for (uint256 i = 0; i < obligation.collaterals.length; i++) {

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -313,6 +313,15 @@ contract OtherFunctionsTest is BaseTest {
         morphoV2.touchObligation(_obligation);
     }
 
+    function testNoCollateral() public {
+        Obligation memory _obligation;
+        _obligation.loanToken = address(loanToken);
+        _obligation.maturity = block.timestamp + 100;
+
+        vm.expectRevert("no collateral");
+        morphoV2.touchObligation(_obligation);
+    }
+
     function testBelowExactMaxCollaterals(uint256 numCollaterals) public {
         numCollaterals = bound(numCollaterals, 1, MAX_COLLATERALS - 1);
         Obligation memory _obligation = _createMultiCollateralObligation(numCollaterals);


### PR DESCRIPTION
### Motivation
- Prevent creation of obligations with no collaterals by enforcing a runtime check and expressing the property in the verification specs.

### Description
- Add a runtime requirement in `touchObligation` to revert if `obligation.collaterals.length == 0` with message `"no collateral"`.
- Update the Certora spec `CreatedObligations.spec` to add the `createdObligationsHaveAtLeastOneCollateral` invariant and fix a small comment typo.
- Add a unit test `testNoCollateral` in `OtherFunctionsTest.sol` to assert that `touchObligation` reverts with `"no collateral"` for empty collaterals.

### Testing
- Ran the unit test suite with `forge test`, and all tests passed including the new `testNoCollateral`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a1672597948321989238bd9e7b2d72)