### PR TITLE
ids as bytes32

### DIFF
--- a/certora/specs/CreatedObligations.spec
+++ b/certora/specs/CreatedObligations.spec
@@ -7,11 +7,11 @@ methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;
     function _.price() external => NONDET;
 
-    function Midnight.totalUnits(bytes20) external returns (uint256) envfree;
-    function Midnight.totalShares(bytes20) external returns (uint256) envfree;
-    function Midnight.withdrawable(bytes20) external returns (uint256) envfree;
-    function Midnight.fees(bytes20) external returns (uint16[7]) envfree;
-    function Midnight.obligationCreated(bytes20) external returns (bool) envfree;
+    function Midnight.totalUnits(bytes32) external returns (uint256) envfree;
+    function Midnight.totalShares(bytes32) external returns (uint256) envfree;
+    function Midnight.withdrawable(bytes32) external returns (uint256) envfree;
+    function Midnight.fees(bytes32) external returns (uint16[7]) envfree;
+    function Midnight.obligationCreated(bytes32) external returns (bool) envfree;
     function Utils.hashObligation(Midnight.Obligation) external returns (bytes32) envfree;
 
     function UtilsLib.mulDivDown(uint256, uint256, uint256) internal returns (uint256) => NONDET;
@@ -23,18 +23,13 @@ methods {
     function TickLib.wExp(int256) internal returns (uint256) => NONDET;
 
     // Summary is required because abi.encodePacked doesn't ensure injectivity of the hash function in CVL, for an unknown reason.
-    function IdLib.toId(Midnight.Obligation memory obligation, uint256, address) internal returns (bytes20) => summaryToId(obligation);
+    function IdLib.toId(Midnight.Obligation memory obligation, uint256, address) internal returns (bytes32) => summaryToId(obligation);
 }
 
 definition WAD() returns uint256 = 10 ^ 18;
 
-// Since the toId function returns a truncated hash, we need to rehash the obligation to ensure injectivity.
-persistent ghost mapping(bytes32 => bytes20) rehash {
-    axiom forall bytes32 h1. forall bytes32 h2. h1 != h2 => rehash[h1] != rehash[h2];
-}
-
-function summaryToId(Midnight.Obligation obligation) returns (bytes20) {
-    return rehash[Utils.hashObligation(obligation)];
+function summaryToId(Midnight.Obligation obligation) returns (bytes32) {
+    return Utils.hashObligation(obligation);
 }
 
 function obligationIsCreated(Midnight.Obligation obligation) returns (bool) {
@@ -58,7 +53,7 @@ invariant createdObligationsHaveLltvLessThanOrEqualToOne(Midnight.Obligation obl
     obligationIsCreated(obligation) => i < obligation.collaterals.length => obligation.collaterals[i].lltv <= WAD();
 
 // Show that a created obligation cannot be deleted.
-rule obligationCannotBeDeleted(env e, method f, calldataarg args, bytes20 id) {
+rule obligationCannotBeDeleted(env e, method f, calldataarg args, bytes32 id) {
     require Midnight.obligationCreated(id), "Assume that the obligation is created";
     f(e, args);
     assert Midnight.obligationCreated(id);
@@ -102,10 +97,10 @@ rule obligationIsCreatedAfterLiquidate(env e, Midnight.Obligation obligation, ui
 }
 
 // Show that an obligation state is empty if it is not created.
-invariant obligationStateIsEmptyIfNotCreated(bytes20 id)
+invariant obligationStateIsEmptyIfNotCreated(bytes32 id)
     !Midnight.obligationCreated(id) => obligationStateIsEmpty(id);
 
-function obligationStateIsEmpty(bytes20 id) returns (bool) {
+function obligationStateIsEmpty(bytes32 id) returns (bool) {
     if (Midnight.totalUnits(id) != 0) return false;
     if (Midnight.totalShares(id) != 0) return false;
     if (Midnight.withdrawable(id) != 0) return false;

--- a/certora/specs/Liquidate.spec
+++ b/certora/specs/Liquidate.spec
@@ -3,10 +3,10 @@
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;
 
-    function isHealthy(Midnight.Obligation obligation, bytes20 id, address borrower) external returns (bool) envfree;
+    function isHealthy(Midnight.Obligation obligation, bytes32 id, address borrower) external returns (bool) envfree;
 
     function _.price() external => CVL_price(calledContract) expect(uint256);
-    function IdLib.toId(Midnight.Obligation memory obligation, uint256 chainId, address midnight) internal returns (bytes20) => CVL_toId(obligation, chainId, midnight);
+    function IdLib.toId(Midnight.Obligation memory obligation, uint256 chainId, address midnight) internal returns (bytes32) => CVL_toId(obligation, chainId, midnight);
     function UtilsLib.msb(uint256 bitmap) internal returns (uint256) => CVL_msb(bitmap);
     function UtilsLib.mulDivDown(uint256 a, uint256 b, uint256 denominator) internal returns (uint256) => CVL_mulDivDown(a, b, denominator);
     function UtilsLib.mulDivUp(uint256 a, uint256 b, uint256 denominator) internal returns (uint256) => CVL_mulDivUp(a, b, denominator);
@@ -16,11 +16,11 @@ methods {
 
 // IdLib summary: remember the last id returned by toId.
 
-persistent ghost bytes20 lastId;
+persistent ghost bytes32 lastId;
 
-function CVL_toId(Midnight.Obligation obligation, uint256 chainId, address midnight) returns bytes20 {
+function CVL_toId(Midnight.Obligation obligation, uint256 chainId, address midnight) returns bytes32 {
     // non-deterministic id
-    bytes20 id;
+    bytes32 id;
     lastId = id;
     return id;
 }
@@ -40,7 +40,7 @@ ghost CVL_price(address) returns uint256;
 // RULES ///
 
 rule liquidateRequireUnhealthy(env e, Midnight.Obligation obligation, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, bytes data) {
-    bytes20 id;
+    bytes32 id;
     bool isHealthyBefore = isHealthy(obligation, id, borrower);
     liquidate(e, obligation, collateralIndex, seizedAssets, repaidUnits, borrower, data);
 

--- a/certora/specs/Midnight.spec
+++ b/certora/specs/Midnight.spec
@@ -3,34 +3,34 @@
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;
 
-    function withdrawable(bytes20 id) external returns (uint256) envfree;
-    function totalUnits(bytes20 id) external returns (uint256) envfree;
-    function totalShares(bytes20 id) external returns (uint256) envfree;
+    function withdrawable(bytes32 id) external returns (uint256) envfree;
+    function totalUnits(bytes32 id) external returns (uint256) envfree;
+    function totalShares(bytes32 id) external returns (uint256) envfree;
     function consumed(address user, bytes32 group) external returns (uint256) envfree;
-    function sharesOf(bytes20 id, address owner) external returns (uint256) envfree;
-    function debtOf(bytes20 id, address user) external returns (uint256) envfree;
+    function sharesOf(bytes32 id, address owner) external returns (uint256) envfree;
+    function debtOf(bytes32 id, address user) external returns (uint256) envfree;
 
     function _.price() external => NONDET;
-    function IdLib.toId(Midnight.Obligation memory, uint256, address) internal returns (bytes20) => NONDET;
+    function IdLib.toId(Midnight.Obligation memory, uint256, address) internal returns (bytes32) => NONDET;
     function UtilsLib.mulDivDown(uint256 x, uint256 y, uint256 d) internal returns (uint256) => summaryMulDiv(x, y, d);
     function UtilsLib.mulDivUp(uint256 x, uint256 y, uint256 d) internal returns (uint256) => summaryMulDiv(x, y, d);
 }
 
 /// HELPERS ///
 
-persistent ghost mapping(bytes20 => mathint) sumSharesOf {
-    init_state axiom (forall bytes20 id. sumSharesOf[id] == 0);
+persistent ghost mapping(bytes32 => mathint) sumSharesOf {
+    init_state axiom (forall bytes32 id. sumSharesOf[id] == 0);
 }
 
-hook Sstore sharesOf[KEY bytes20 id][KEY address owner] uint256 newShares (uint256 oldShares) {
+hook Sstore sharesOf[KEY bytes32 id][KEY address owner] uint256 newShares (uint256 oldShares) {
     sumSharesOf[id] = sumSharesOf[id] - oldShares + newShares;
 }
 
-persistent ghost mapping(bytes20 => mathint) sumDebtOf {
-    init_state axiom (forall bytes20 id. sumDebtOf[id] == 0);
+persistent ghost mapping(bytes32 => mathint) sumDebtOf {
+    init_state axiom (forall bytes32 id. sumDebtOf[id] == 0);
 }
 
-hook Sstore borrowerState[KEY bytes20 id][KEY address owner].debt uint128 newDebt (uint128 oldDebt) {
+hook Sstore borrowerState[KEY bytes32 id][KEY address owner].debt uint128 newDebt (uint128 oldDebt) {
     sumDebtOf[id] = sumDebtOf[id] - oldDebt + newDebt;
 }
 
@@ -101,11 +101,11 @@ rule liquidateInputOutputConsistency(env e, Midnight.Obligation obligation, uint
 
 /// INVARIANTS ///
 
-strong invariant notBorrowerAndLender(bytes20 id, address user)
+strong invariant notBorrowerAndLender(bytes32 id, address user)
     sharesOf(id, user) == 0 || debtOf(id, user) == 0;
 
-strong invariant totalUnitsEqualsSumDebtPlusWithdrawable(bytes20 id)
+strong invariant totalUnitsEqualsSumDebtPlusWithdrawable(bytes32 id)
     totalUnits(id) == sumDebtOf[id] + withdrawable(id);
 
-strong invariant totalSharesEqualsSumSharesOf(bytes20 id)
+strong invariant totalSharesEqualsSumSharesOf(bytes32 id)
     totalShares(id) == sumSharesOf[id];

--- a/certora/specs/SharePrice.spec
+++ b/certora/specs/SharePrice.spec
@@ -3,13 +3,13 @@
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;
 
-    function totalUnits(bytes20 id) external returns (uint256) envfree;
-    function totalShares(bytes20 id) external returns (uint256) envfree;
+    function totalUnits(bytes32 id) external returns (uint256) envfree;
+    function totalShares(bytes32 id) external returns (uint256) envfree;
 
     function _.price() external => NONDET;
 
     // Summaries to avoid SMT solver timeout.
-    function tradingFee(bytes20, uint256) internal returns (uint256) => NONDET;
+    function tradingFee(bytes32, uint256) internal returns (uint256) => NONDET;
     function SafeTransferLib.safeTransferFrom(address, address, address, uint256) internal => NONDET;
     function SafeTransferLib.safeTransfer(address, address, uint256) internal => NONDET;
 }

--- a/certora/specs/Solvency.spec
+++ b/certora/specs/Solvency.spec
@@ -10,7 +10,7 @@ methods {
     function UtilsLib.mulDivUp(uint256 a, uint256 b, uint256 denominator) internal returns (uint256) => CVL_mulDivUp(a, b, denominator);
 
     // Summarize toId, this adds no assumption but allows to retrieve the loan token from the obligation id.
-    function IdLib.toId(Midnight.Obligation memory obligation, uint256 chainId, address midnight) internal returns (bytes20) => CVL_toId(obligation, chainId, midnight);
+    function IdLib.toId(Midnight.Obligation memory obligation, uint256 chainId, address midnight) internal returns (bytes32) => CVL_toId(obligation, chainId, midnight);
 
     // Hook on callbacks, this adds no assumption: see FlashLiquidateCallback.sol and the summaries below.
     function _.onFlashLoan(address token, uint256 amount, bytes data) external => DISPATCHER(true);
@@ -53,16 +53,16 @@ ghost CVL_mulDivUp(uint256, uint256, uint256) returns uint256;
 // IdLib summaries.
 
 // Mapping from obligation id to its loan token.
-ghost mapping(bytes20 => address) loantoken;
+ghost mapping(bytes32 => address) loantoken;
 
 // Mapping from obligation id and collateral index to the corresponding collateral token.
-ghost mapping(bytes20 => mapping(uint128 => address)) collateralToken;
+ghost mapping(bytes32 => mapping(uint128 => address)) collateralToken;
 
-ghost hash(address, uint256, uint256, address) returns bytes20;
+ghost hash(address, uint256, uint256, address) returns bytes32;
 
-function CVL_toId(Midnight.Obligation obligation, uint256 chainId, address midnight) returns bytes20 {
+function CVL_toId(Midnight.Obligation obligation, uint256 chainId, address midnight) returns bytes32 {
     // Deterministically derive the obligation id.
-    bytes20 id = hash(obligation.loanToken, obligation.maturity, chainId, midnight);
+    bytes32 id = hash(obligation.loanToken, obligation.maturity, chainId, midnight);
 
     // Assume the obligation id already maps to this loan token.
     // We could also initialize on first use, but then token(0) handling needs extra constraints.
@@ -90,35 +90,35 @@ function CVL_flashLoanEnd(address token, uint256 amount) {
 
 // Define collateral sum and withdrawable sum.
 
-definition collateralSum(address token) returns mathint = usum bytes20 id, address owner. collateralOfMirror[id][owner][token];
+definition collateralSum(address token) returns mathint = usum bytes32 id, address owner. collateralOfMirror[id][owner][token];
 
-ghost mapping(bytes20 => mapping(address => mapping(address => mathint))) collateralOfMirror {
-    init_state axiom (forall bytes20 id. forall address owner. forall address token. collateralOfMirror[id][owner][token] == 0);
+ghost mapping(bytes32 => mapping(address => mapping(address => mathint))) collateralOfMirror {
+    init_state axiom (forall bytes32 id. forall address owner. forall address token. collateralOfMirror[id][owner][token] == 0);
     init_state axiom (forall address token. collateralSum(token) == 0);
 }
 
 // Safe require as obligations limit the number of collaterals.
-hook Sload uint128 value collateralOf[KEY bytes20 id][KEY address owner][INDEX uint256 collateralIndex] {
+hook Sload uint128 value collateralOf[KEY bytes32 id][KEY address owner][INDEX uint256 collateralIndex] {
     require value == collateralOfMirror[id][owner][collateralToken[id][require_uint128(collateralIndex)]], "ghost mirror";
 }
 
 // Safe require as obligations limit the number of collaterals.
-hook Sstore collateralOf[KEY bytes20 id][KEY address owner][INDEX uint256 collateralIndex] uint128 newCollateral (uint128 oldCollateral) {
+hook Sstore collateralOf[KEY bytes32 id][KEY address owner][INDEX uint256 collateralIndex] uint128 newCollateral (uint128 oldCollateral) {
     collateralOfMirror[id][owner][collateralToken[id][require_uint128(collateralIndex)]] = newCollateral;
 }
 
-definition withdrawableSum(address token) returns mathint = usum bytes20 id. withdrawableMirror[id][token];
+definition withdrawableSum(address token) returns mathint = usum bytes32 id. withdrawableMirror[id][token];
 
-ghost mapping(bytes20 => mapping(address => mathint)) withdrawableMirror {
-    init_state axiom (forall bytes20 id. forall address token. withdrawableMirror[id][token] == 0);
+ghost mapping(bytes32 => mapping(address => mathint)) withdrawableMirror {
+    init_state axiom (forall bytes32 id. forall address token. withdrawableMirror[id][token] == 0);
     init_state axiom (forall address token. withdrawableSum(token) == 0);
 }
 
-hook Sload uint256 value obligationState[KEY bytes20 id].withdrawable {
+hook Sload uint256 value obligationState[KEY bytes32 id].withdrawable {
     require value == withdrawableMirror[id][loantoken[id]], "ghost mirror";
 }
 
-hook Sstore obligationState[KEY bytes20 id].withdrawable uint256 newWithdrawable (uint256 oldWithdrawable) {
+hook Sstore obligationState[KEY bytes32 id].withdrawable uint256 newWithdrawable (uint256 oldWithdrawable) {
     withdrawableMirror[id][loantoken[id]] = newWithdrawable;
 }
 

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -50,10 +50,10 @@ contract Midnight is IMidnight {
 
     /// STORAGE ///
 
-    mapping(bytes20 id => mapping(address user => uint256)) public sharesOf;
-    mapping(bytes20 id => mapping(address user => BorrowerState)) public borrowerState;
-    mapping(bytes20 id => mapping(address user => uint128[128])) public collateralOf;
-    mapping(bytes20 id => ObligationState) public obligationState;
+    mapping(bytes32 id => mapping(address user => uint256)) public sharesOf;
+    mapping(bytes32 id => mapping(address user => BorrowerState)) public borrowerState;
+    mapping(bytes32 id => mapping(address user => uint128[128])) public collateralOf;
+    mapping(bytes32 id => ObligationState) public obligationState;
 
     /// @dev Groups are useful to have a global offered amount shared across multiple offers ("OCO").
     /// @dev To work as expected, all offers in a same group should have the same obligationShares, obligationUnits, and
@@ -113,7 +113,7 @@ contract Midnight is IMidnight {
     }
 
     /// @dev Overrides the fee of a specific obligation.
-    function setObligationTradingFee(bytes20 id, uint256 index, uint256 newTradingFee) external {
+    function setObligationTradingFee(bytes32 id, uint256 index, uint256 newTradingFee) external {
         require(msg.sender == feeSetter, "only fee setter");
         require(index <= 6, "invalid index");
         require(newTradingFee <= maxTradingFee(index), "value too high");
@@ -170,7 +170,7 @@ contract Midnight is IMidnight {
         require(signer(root, sig) == offer.maker, "invalid signature");
         require(UtilsLib.isLeaf(root, keccak256(abi.encode(offer)), proof), "invalid proof");
         require(offer.session == session[offer.maker], "invalid session");
-        bytes20 id = touchObligation(offer.obligation);
+        bytes32 id = touchObligation(offer.obligation);
         ObligationState storage _obligationState = obligationState[id];
 
         (
@@ -312,7 +312,7 @@ contract Midnight is IMidnight {
     ) external returns (uint256, uint256) {
         require(onBehalf == msg.sender || isAuthorized[onBehalf][msg.sender], "unauthorized");
         require(UtilsLib.atMostOneNonZero(obligationUnits, shares), "inconsistent input");
-        bytes20 id = touchObligation(obligation);
+        bytes32 id = touchObligation(obligation);
         ObligationState storage _obligationState = obligationState[id];
 
         if (obligationUnits > 0) {
@@ -334,7 +334,7 @@ contract Midnight is IMidnight {
     }
 
     function repay(Obligation memory obligation, uint256 obligationUnits, address onBehalf) external {
-        bytes20 id = touchObligation(obligation);
+        bytes32 id = touchObligation(obligation);
 
         borrowerState[id][onBehalf].debt -= UtilsLib.toUint128(obligationUnits);
         obligationState[id].withdrawable += obligationUnits;
@@ -347,7 +347,7 @@ contract Midnight is IMidnight {
     function supplyCollateral(Obligation memory obligation, uint256 collateralIndex, uint256 assets, address onBehalf)
         external
     {
-        bytes20 id = touchObligation(obligation);
+        bytes32 id = touchObligation(obligation);
         address collateralToken = obligation.collaterals[collateralIndex].token;
 
         uint256 oldCollateralOf = collateralOf[id][onBehalf][collateralIndex];
@@ -374,7 +374,7 @@ contract Midnight is IMidnight {
         address receiver
     ) external {
         require(onBehalf == msg.sender || isAuthorized[onBehalf][msg.sender], "unauthorized");
-        bytes20 id = touchObligation(obligation);
+        bytes32 id = touchObligation(obligation);
         address collateralToken = obligation.collaterals[collateralIndex].token;
 
         uint256 newCollateralOf = collateralOf[id][onBehalf][collateralIndex] - assets;
@@ -411,7 +411,7 @@ contract Midnight is IMidnight {
         bytes calldata data
     ) external returns (uint256, uint256) {
         require(UtilsLib.atMostOneNonZero(repaidUnits, seizedAssets), "inconsistent input");
-        bytes20 id = touchObligation(obligation);
+        bytes32 id = touchObligation(obligation);
         ObligationState storage _obligationState = obligationState[id];
 
         uint256 maxDebt;
@@ -520,8 +520,8 @@ contract Midnight is IMidnight {
     }
 
     /// @dev Returns the obligation id and creates the obligation if it doesn't exist yet.
-    function touchObligation(Obligation memory obligation) public returns (bytes20) {
-        bytes20 id = IdLib.toId(obligation, block.chainid, address(this));
+    function touchObligation(Obligation memory obligation) public returns (bytes32) {
+        bytes32 id = IdLib.toId(obligation, block.chainid, address(this));
         if (!obligationState[id].created) {
             require(obligation.collaterals.length > 0, "no collaterals");
             require(obligation.collaterals.length <= MAX_COLLATERALS, "too many collaterals");
@@ -550,48 +550,49 @@ contract Midnight is IMidnight {
 
     /// VIEW FUNCTIONS ///
 
-    function toId(Obligation memory obligation) public view returns (bytes20) {
+    function toId(Obligation memory obligation) public view returns (bytes32) {
         return IdLib.toId(obligation, block.chainid, address(this));
     }
 
-    /// @dev For valid ids of touched obligations, returns the corresponding obligation.
-    /// @dev Reverts if the code cannot be abi-decoded as an obligation.
-    /// @dev If the id given is not the result of toId, the returned obligation is arbitrary.
-    function toObligation(bytes20 id) public view returns (Obligation memory) {
-        return IdLib.toObligation(id);
+    /// @dev Returns the obligation corresponding to the given id.
+    /// @dev Reverts if the id is not a valid id of a touched obligation.
+    function toObligation(bytes32 id) public view returns (Obligation memory) {
+        require(obligationState[id].created, "not created");
+        address create2Address = address(uint160(uint256(id)));
+        return abi.decode(create2Address.code, (Obligation));
     }
 
-    function debtOf(bytes20 id, address user) external view returns (uint256) {
+    function debtOf(bytes32 id, address user) external view returns (uint256) {
         return borrowerState[id][user].debt;
     }
 
-    function activatedCollaterals(bytes20 id, address user) external view returns (uint128) {
+    function activatedCollaterals(bytes32 id, address user) external view returns (uint128) {
         return borrowerState[id][user].activatedCollaterals;
     }
 
-    function totalUnits(bytes20 id) external view returns (uint256) {
+    function totalUnits(bytes32 id) external view returns (uint256) {
         return obligationState[id].totalUnits;
     }
 
-    function totalShares(bytes20 id) external view returns (uint256) {
+    function totalShares(bytes32 id) external view returns (uint256) {
         return obligationState[id].totalShares;
     }
 
-    function obligationCreated(bytes20 id) external view returns (bool) {
+    function obligationCreated(bytes32 id) external view returns (bool) {
         return obligationState[id].created;
     }
 
-    function withdrawable(bytes20 id) external view returns (uint256) {
+    function withdrawable(bytes32 id) external view returns (uint256) {
         return obligationState[id].withdrawable;
     }
 
-    function fees(bytes20 id) external view returns (uint16[7] memory) {
+    function fees(bytes32 id) external view returns (uint16[7] memory) {
         return obligationState[id].fees;
     }
 
     /// @dev This function should be called with the id corresponding to the obligation.
     /// @dev This function does not call any oracle if debt is 0.
-    function isHealthy(Obligation memory obligation, bytes20 id, address borrower) public view returns (bool) {
+    function isHealthy(Obligation memory obligation, bytes32 id, address borrower) public view returns (bool) {
         BorrowerState storage _borrowerState = borrowerState[id][borrower];
         uint256 debt = _borrowerState.debt;
         uint256 maxDebt;
@@ -629,7 +630,7 @@ contract Midnight is IMidnight {
     }
 
     /// @dev Returns the trading fee using piecewise linear interpolation between breakpoints.
-    function tradingFee(bytes20 id, uint256 timeToMaturity) public view returns (uint256) {
+    function tradingFee(bytes32 id, uint256 timeToMaturity) public view returns (uint256) {
         require(obligationState[id].created, "not created");
 
         uint16[7] memory _fees = obligationState[id].fees;

--- a/src/libraries/EventsLib.sol
+++ b/src/libraries/EventsLib.sol
@@ -10,14 +10,14 @@ library EventsLib {
 
     event SetOwner(address indexed owner);
     event SetFeeSetter(address indexed feeSetter);
-    event SetObligationTradingFee(bytes20 indexed id_, uint256 indexed index, uint256 newTradingFee);
+    event SetObligationTradingFee(bytes32 indexed id_, uint256 indexed index, uint256 newTradingFee);
     event SetDefaultTradingFee(address indexed loanToken, uint256 indexed index, uint256 newTradingFee);
     event SetTradingFeeRecipient(address indexed feeRecipient);
 
-    event ObligationCreated(bytes20 indexed id_, Obligation obligation);
+    event ObligationCreated(bytes32 indexed id_, Obligation obligation);
     event Take(
         address caller,
-        bytes20 indexed id_,
+        bytes32 indexed id_,
         address indexed maker,
         address indexed taker,
         bool offerIsBuy,
@@ -33,20 +33,20 @@ library EventsLib {
     );
     event Withdraw(
         address caller,
-        bytes20 indexed id_,
+        bytes32 indexed id_,
         uint256 obligationUnits,
         uint256 shares,
         address indexed onBehalf,
         address indexed receiver
     );
-    event Repay(address indexed caller, bytes20 indexed id_, uint256 obligationUnits, address indexed onBehalf);
+    event Repay(address indexed caller, bytes32 indexed id_, uint256 obligationUnits, address indexed onBehalf);
     event SupplyCollateral(
-        address caller, bytes20 indexed id_, address indexed collateral, uint256 assets, address indexed onBehalf
+        address caller, bytes32 indexed id_, address indexed collateral, uint256 assets, address indexed onBehalf
     );
 
     event WithdrawCollateral(
         address caller,
-        bytes20 indexed id_,
+        bytes32 indexed id_,
         address indexed collateral,
         uint256 assets,
         address indexed onBehalf,
@@ -55,7 +55,7 @@ library EventsLib {
 
     event Liquidate(
         address indexed caller,
-        bytes20 indexed id_,
+        bytes32 indexed id_,
         uint256 collateralIndex,
         uint256 seizedAssets,
         uint256 repaidUnits,

--- a/src/libraries/IdLib.sol
+++ b/src/libraries/IdLib.sol
@@ -20,19 +20,12 @@ library IdLib {
     /// f3        RETURN          []                 mem[0:len] is returned
     bytes constant SSTORE2_PREFIX = hex"600b380380600b5f395ff3";
 
-    function toId(Obligation memory obligation, uint256 chainId, address midnight) internal pure returns (bytes20) {
-        bytes32 create2Hash = keccak256(
+    function toId(Obligation memory obligation, uint256 chainId, address midnight) internal pure returns (bytes32) {
+        return keccak256(
             abi.encodePacked(
                 uint8(0xff), midnight, chainId, keccak256(abi.encodePacked(SSTORE2_PREFIX, abi.encode(obligation)))
             )
         );
-        // forge-lint: disable-next-line(unsafe-typecast) unsafe casting made on purpose.
-        return bytes20(uint160(uint256(create2Hash)));
-    }
-
-    /// @dev Attempts to decode the data at address(id) into an obligation.
-    function toObligation(bytes20 id) internal view returns (Obligation memory) {
-        return abi.decode(address(id).code, (Obligation));
     }
 
     /// @dev Stores the data in the code of the contract at the given address.

--- a/src/periphery/TakeAmountsLib.sol
+++ b/src/periphery/TakeAmountsLib.sol
@@ -13,7 +13,7 @@ library TakeAmountsLib {
     // Forward: units = shares.mulDivUp/Down(totalUnits + 1, totalShares + 1) depending on buyerIsLender.
     // When buyerIsLender (forward rounds up): inverse rounds down.
     // When !buyerIsLender (forward rounds down): inverse rounds up.
-    function unitsToShares(Midnight midnight, bytes20 id, address taker, Offer memory offer, uint256 targetUnits)
+    function unitsToShares(Midnight midnight, bytes32 id, address taker, Offer memory offer, uint256 targetUnits)
         internal
         view
         returns (uint256)
@@ -29,7 +29,7 @@ library TakeAmountsLib {
     /// @dev Should not be used if buyerPrice > WAD, because not all buyerAssets are reachable then.
     function buyerAssetsToShares(
         Midnight midnight,
-        bytes20 id,
+        bytes32 id,
         address taker,
         Offer memory offer,
         uint256 targetBuyerAssets
@@ -45,7 +45,7 @@ library TakeAmountsLib {
     // Forward: sellerAssets = units.mulDivDown(sellerPrice, WAD).
     function sellerAssetsToShares(
         Midnight midnight,
-        bytes20 id,
+        bytes32 id,
         address taker,
         Offer memory offer,
         uint256 targetSellerAssets

--- a/src/periphery/TakeBundler.sol
+++ b/src/periphery/TakeBundler.sol
@@ -66,7 +66,7 @@ contract TakeBundler {
         Take[] calldata takes
     ) external {
         require(taker == msg.sender || midnight.isAuthorized(taker, msg.sender), "unauthorized");
-        bytes20 id = midnight.toId(takes[0].offer.obligation);
+        bytes32 id = midnight.toId(takes[0].offer.obligation);
 
         uint256 totalFilledUnits;
         for (uint256 i; i < takes.length && totalFilledUnits < targetUnits; i++) {
@@ -106,7 +106,7 @@ contract TakeBundler {
         Take[] calldata takes
     ) external {
         require(taker == msg.sender || midnight.isAuthorized(taker, msg.sender), "unauthorized");
-        bytes20 id = midnight.touchObligation(takes[0].offer.obligation); // to have the correct trading fees.
+        bytes32 id = midnight.touchObligation(takes[0].offer.obligation); // to have the correct trading fees.
 
         uint256 totalFilledBuyerAssets;
         for (uint256 i; i < takes.length && totalFilledBuyerAssets < targetBuyerAssets; i++) {
@@ -147,7 +147,7 @@ contract TakeBundler {
         Take[] calldata takes
     ) external {
         require(taker == msg.sender || midnight.isAuthorized(taker, msg.sender), "unauthorized");
-        bytes20 id = midnight.touchObligation(takes[0].offer.obligation); // to have the correct trading fees.
+        bytes32 id = midnight.touchObligation(takes[0].offer.obligation); // to have the correct trading fees.
 
         uint256 totalFilledSellerAssets;
         for (uint256 i; i < takes.length && totalFilledSellerAssets < targetSellerAssets; i++) {

--- a/test/AuthorizationTest.sol
+++ b/test/AuthorizationTest.sol
@@ -12,7 +12,7 @@ contract AuthorizationTest is BaseTest {
     using UtilsLib for uint256;
 
     Obligation internal obligation;
-    bytes20 internal id;
+    bytes32 internal id;
 
     function setUp() public override {
         super.setUp();

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -101,7 +101,7 @@ abstract contract BaseTest is Test {
     }
 
     function setupOtherUsers(Obligation memory obligation, uint256 shares) internal {
-        bytes20 _id = toId(obligation);
+        bytes32 _id = toId(obligation);
         uint256 totalUnits = midnight.totalUnits(_id);
         uint256 totalShares = midnight.totalShares(_id);
         uint256 units = shares.mulDivUp(totalUnits + 1, totalShares + 1);
@@ -162,7 +162,7 @@ abstract contract BaseTest is Test {
         Oracle(obligation.collaterals[0].oracle).setPrice(ORACLE_PRICE_SCALE);
     }
 
-    function toId(Obligation memory obligation) internal view returns (bytes20) {
+    function toId(Obligation memory obligation) internal view returns (bytes32) {
         return IdLib.toId(obligation, block.chainid, address(midnight));
     }
 

--- a/test/BundlerTest.sol
+++ b/test/BundlerTest.sol
@@ -15,7 +15,7 @@ contract BundlerTest is BaseTest {
     TakeBundler internal takeBundler;
 
     Obligation internal obligation;
-    bytes20 internal id;
+    bytes32 internal id;
     Offer[] internal offers;
 
     function setUp() public override {

--- a/test/IdLibTest.sol
+++ b/test/IdLibTest.sol
@@ -28,8 +28,8 @@ contract IdLibTest is Test {
 
         vm.assume(!(sameLoanToken && sameMaturity && sameCollaterals && sameRcfThreshold));
 
-        bytes20 id1 = IdLib.toId(obligation1, chainid, midnight);
-        bytes20 id2 = IdLib.toId(obligation2, chainid, midnight);
+        bytes32 id1 = IdLib.toId(obligation1, chainid, midnight);
+        bytes32 id2 = IdLib.toId(obligation2, chainid, midnight);
         assertNotEq(id1, id2);
     }
 
@@ -40,8 +40,8 @@ contract IdLibTest is Test {
         address midnight
     ) public pure {
         vm.assume(chainid1 != chainid2);
-        bytes20 id1 = IdLib.toId(obligation, chainid1, midnight);
-        bytes20 id2 = IdLib.toId(obligation, chainid2, midnight);
+        bytes32 id1 = IdLib.toId(obligation, chainid1, midnight);
+        bytes32 id2 = IdLib.toId(obligation, chainid2, midnight);
         assertNotEq(id1, id2);
     }
 
@@ -52,8 +52,8 @@ contract IdLibTest is Test {
         address midnightTwo
     ) public pure {
         vm.assume(midnightOne != midnightTwo);
-        bytes20 id1 = IdLib.toId(obligation, chainid, midnightOne);
-        bytes20 id2 = IdLib.toId(obligation, chainid, midnightTwo);
+        bytes32 id1 = IdLib.toId(obligation, chainid, midnightOne);
+        bytes32 id2 = IdLib.toId(obligation, chainid, midnightTwo);
         assertNotEq(id1, id2);
     }
 }

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -20,7 +20,7 @@ contract LiquidationTest is BaseTest {
     using UtilsLib for uint128;
 
     Obligation internal obligation;
-    bytes20 internal id;
+    bytes32 internal id;
 
     uint256 internal recordedRepaidUnits;
     bytes internal recordedData;

--- a/test/MaxAmountsTest.sol
+++ b/test/MaxAmountsTest.sol
@@ -14,7 +14,7 @@ contract MaxAmountsTest is BaseTest {
     using UtilsLib for uint256;
 
     Obligation internal obligation;
-    bytes20 internal id;
+    bytes32 internal id;
 
     function setUp() public override {
         super.setUp();

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -2,7 +2,6 @@
 // Copyright (c) 2025 Morpho Association
 pragma solidity ^0.8.0;
 
-import {IdLib} from "../src/libraries/IdLib.sol";
 import {Obligation, Collateral} from "../src/interfaces/IMidnight.sol";
 
 import {ERC20} from "./helpers/ERC20.sol";

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -20,7 +20,7 @@ contract OtherFunctionsTest is BaseTest {
     using UtilsLib for uint256;
 
     Obligation internal obligation;
-    bytes20 internal id;
+    bytes32 internal id;
 
     function setUp() public override {
         super.setUp();
@@ -191,7 +191,7 @@ contract OtherFunctionsTest is BaseTest {
         vm.assume(_obligation.collaterals.length > 0);
         _obligation = validObligation(_obligation);
 
-        bytes20 _id = midnight.touchObligation(_obligation);
+        bytes32 _id = midnight.touchObligation(_obligation);
         assertEq(midnight.obligationCreated(_id), true, "obligation created");
         uint16[7] memory fees = midnight.fees(_id);
         for (uint256 i = 0; i < 7; i++) {
@@ -203,8 +203,8 @@ contract OtherFunctionsTest is BaseTest {
         vm.assume(_obligation.collaterals.length > 0);
         _obligation = validObligation(_obligation);
 
-        bytes20 _id = midnight.touchObligation(_obligation);
-        Obligation memory obligationFromId = IdLib.toObligation(_id);
+        bytes32 _id = midnight.touchObligation(_obligation);
+        Obligation memory obligationFromId = midnight.toObligation(_id);
         assertEq(_obligation.loanToken, obligationFromId.loanToken, "loanToken");
         assertEq(_obligation.maturity, obligationFromId.maturity, "maturity");
         assertEq(_obligation.collaterals.length, obligationFromId.collaterals.length, "collaterals length");
@@ -219,12 +219,12 @@ contract OtherFunctionsTest is BaseTest {
     function testToId(Obligation memory _obligation) public view {
         _obligation = validObligation(_obligation);
 
-        bytes20 expected = toId(_obligation);
-        bytes20 actual = midnight.toId(_obligation);
+        bytes32 expected = toId(_obligation);
+        bytes32 actual = midnight.toId(_obligation);
         assertEq(actual, expected, "toId mismatch");
     }
 
-    function testToObligationRevertsIfNotCreated(bytes20 _id) public {
+    function testToObligationRevertsIfNotCreated(bytes32 _id) public {
         vm.expectRevert();
         midnight.toObligation(_id);
     }
@@ -233,8 +233,8 @@ contract OtherFunctionsTest is BaseTest {
         vm.assume(_obligation.collaterals.length > 0);
         _obligation = validObligation(_obligation);
 
-        bytes20 _id = midnight.touchObligation(_obligation);
-        address sstore2Address = address(_id);
+        bytes32 _id = midnight.touchObligation(_obligation);
+        address sstore2Address = address(uint160(uint256(_id)));
 
         assertGt(sstore2Address.code.length, 0, "code should exist");
         assertEq(uint8(sstore2Address.code[0]), 0x00, "first byte should be STOP opcode");
@@ -289,7 +289,7 @@ contract OtherFunctionsTest is BaseTest {
         deal(address(collateralToken1), address(this), collateral);
         midnight.supplyCollateral(obligationWithRevertingOracle, 0, collateral, borrower);
 
-        bytes20 _id = toId(obligationWithRevertingOracle);
+        bytes32 _id = toId(obligationWithRevertingOracle);
         assertEq(midnight.collateralOf(_id, borrower, 0), collateral, "collateral should be set");
 
         revertingOracle.stopOracle();
@@ -416,7 +416,7 @@ contract OtherFunctionsTest is BaseTest {
             midnight.supplyCollateral(_obligation, i, 1e18, borrower);
         }
 
-        bytes20 _id = toId(_obligation);
+        bytes32 _id = toId(_obligation);
         uint128 bitmap = midnight.activatedCollaterals(_id, borrower);
         assertEq(UtilsLib.countBits(bitmap), k, "countBits should equal number of supplied collaterals");
         assertEq(UtilsLib.msb(bitmap), k - 1, "msb should equal number of supplied collaterals - 1");
@@ -435,7 +435,7 @@ contract OtherFunctionsTest is BaseTest {
             midnight.supplyCollateral(_obligation, i, 1e18, borrower);
         }
 
-        bytes20 _id = toId(_obligation);
+        bytes32 _id = toId(_obligation);
         assertEq(UtilsLib.countBits(midnight.activatedCollaterals(_id, borrower)), numCollaterals, "all bits set");
 
         // Withdraw one collateral fully.

--- a/test/SettersTest.sol
+++ b/test/SettersTest.sol
@@ -59,7 +59,7 @@ contract SettersTest is BaseTest {
         Obligation memory obligation = Obligation({
             loanToken: loanToken, maturity: block.timestamp + 1 days, collaterals: collaterals, rcfThreshold: 0
         });
-        bytes20 id = toId(obligation);
+        bytes32 id = toId(obligation);
         midnight.touchObligation(obligation);
 
         midnight.setObligationTradingFee(id, 0, postMaturityFee);
@@ -81,7 +81,7 @@ contract SettersTest is BaseTest {
         assertEq(midnight.tradingFee(id, 1000 days), threeSixtyDaysFee, "one thousand days trading fee");
     }
 
-    function testSetTradingFeeInvalidIndex(bytes20 id) public {
+    function testSetTradingFeeInvalidIndex(bytes32 id) public {
         vm.expectRevert("invalid index");
         midnight.setObligationTradingFee(id, 7, 0);
     }
@@ -91,14 +91,14 @@ contract SettersTest is BaseTest {
         midnight.setDefaultTradingFee(loanToken, 7, 0);
     }
 
-    function testSetObligationTradingFeeValueTooHigh(bytes20 id, uint256 feeTooHigh, uint256 index) public {
+    function testSetObligationTradingFeeValueTooHigh(bytes32 id, uint256 feeTooHigh, uint256 index) public {
         index = bound(index, 0, 6);
         feeTooHigh = bound(feeTooHigh, midnight.maxTradingFee(index) + 1, 1e18);
         vm.expectRevert("value too high");
         midnight.setObligationTradingFee(id, index, feeTooHigh);
     }
 
-    function testSetTradingFeeNotMultipleOfFeeStep(bytes20 id, uint256 index, uint256 fee) public {
+    function testSetTradingFeeNotMultipleOfFeeStep(bytes32 id, uint256 index, uint256 fee) public {
         index = bound(index, 0, 6);
         fee = bound(fee, 1, midnight.maxTradingFee(index));
         vm.assume(fee % 1e12 != 0);
@@ -114,12 +114,12 @@ contract SettersTest is BaseTest {
         midnight.setDefaultTradingFee(loanToken, index, fee);
     }
 
-    function testSetObligationTradingFeeObligationNotCreated(bytes20 id) public {
+    function testSetObligationTradingFeeObligationNotCreated(bytes32 id) public {
         vm.expectRevert("obligation not created");
         midnight.setObligationTradingFee(id, 0, 0);
     }
 
-    function testSetTradingFeeOnlyFeeSetter(address rdm, bytes20 id) public {
+    function testSetTradingFeeOnlyFeeSetter(address rdm, bytes32 id) public {
         vm.assume(rdm != address(this));
         vm.prank(rdm);
         vm.expectRevert("only fee setter");
@@ -142,7 +142,7 @@ contract SettersTest is BaseTest {
 
     function testTradingFeeRevertsWhenNotCreated() public {
         vm.expectRevert("not created");
-        midnight.tradingFee(bytes20(0), 0);
+        midnight.tradingFee(bytes32(0), 0);
     }
 
     function testSetDefaultTradingFeeSuccess(
@@ -179,7 +179,7 @@ contract SettersTest is BaseTest {
         Obligation memory obligation = Obligation({
             loanToken: loanToken, maturity: block.timestamp + 1 days, collaterals: collaterals, rcfThreshold: 0
         });
-        bytes20 id = toId(obligation);
+        bytes32 id = toId(obligation);
         midnight.touchObligation(obligation);
 
         assertEq(midnight.tradingFee(id, 0), postMaturityFee, "0 days default fee");
@@ -230,7 +230,7 @@ contract SettersTest is BaseTest {
         });
         Obligation memory obligation =
             Obligation({loanToken: address(0), maturity: block.timestamp + 1 days, collaterals: cols, rcfThreshold: 0});
-        bytes20 id = toId(obligation);
+        bytes32 id = toId(obligation);
         midnight.touchObligation(obligation);
 
         midnight.setObligationTradingFee(id, 0, fee0);

--- a/test/TakeAmountsTest.sol
+++ b/test/TakeAmountsTest.sol
@@ -13,7 +13,7 @@ contract TakeAmountsTest is BaseTest {
     using UtilsLib for uint256;
 
     Obligation internal obligation;
-    bytes20 internal id;
+    bytes32 internal id;
     Offer internal offer;
 
     uint256 internal initialUnits;

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -16,7 +16,7 @@ contract TakeTest is BaseTest {
     using UtilsLib for uint256;
 
     Obligation internal obligation;
-    bytes20 internal id;
+    bytes32 internal id;
     Offer internal lenderOffer;
     Offer internal borrowerOffer;
     Offer internal otherLenderOffer;

--- a/test/TradingFeeTest.sol
+++ b/test/TradingFeeTest.sol
@@ -26,7 +26,7 @@ contract TradingFeeTest is BaseTest {
     using UtilsLib for uint256;
 
     Obligation internal obligation;
-    bytes20 internal id;
+    bytes32 internal id;
     Offer internal lenderOffer;
     Offer internal borrowerOffer;
     address internal feeRecipient = makeAddr("feeRecipient");


### PR DESCRIPTION
context in [this thread](https://morpholabs.slack.com/archives/C08A40KKN9W/p1771925393982049), inspired from @jhoenicke's idea [here](https://morpholabs.slack.com/archives/C0ACSA8TNMA/p1772564829296709?thread_ts=1772441125.820019&cid=C0ACSA8TNMA)

Why it works:
- assume that there cannot be any bytes32 collisions (but bytes20 collisions are still possible)
- now the `toId` function returns a bytes32, so because of the assumption above, it cannot be misused
- `toObligation` uses a bytes20 internally, but it checks that the obligation is created. So the passed id corresponds necessarily to the `toId` of an obligation, and because of the above assumption that obligation is unique