### PR TITLE
Fix griefing issue with MAX_COLLATERAL_PER_BORROWER

### DIFF
--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -344,6 +344,7 @@ contract Midnight is IMidnight {
         SafeTransferLib.safeTransferFrom(obligation.loanToken, msg.sender, address(this), obligationUnits);
     }
 
+    /// @dev This function checks authorization to prevent activated collateral poisoning.
     function supplyCollateral(Obligation memory obligation, uint256 collateralIndex, uint256 assets, address onBehalf)
         external
     {

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -347,6 +347,7 @@ contract Midnight is IMidnight {
     function supplyCollateral(Obligation memory obligation, uint256 collateralIndex, uint256 assets, address onBehalf)
         external
     {
+        require(onBehalf == msg.sender || isAuthorized[onBehalf][msg.sender], "unauthorized");
         bytes20 id = touchObligation(obligation);
         address collateralToken = obligation.collaterals[collateralIndex].token;
 

--- a/test/AuthorizationTest.sol
+++ b/test/AuthorizationTest.sol
@@ -72,8 +72,11 @@ contract AuthorizationTest is BaseTest {
         address user = makeAddr("user");
         address collateralToken = obligation.collaterals[0].token;
 
-        deal(collateralToken, address(this), collateralAmount);
+        deal(collateralToken, user, collateralAmount);
+        vm.prank(user);
         ERC20(collateralToken).approve(address(midnight), collateralAmount);
+
+        vm.prank(user);
         midnight.supplyCollateral(obligation, 0, collateralAmount, user);
 
         // Attacker tries to withdraw user's collateral
@@ -112,13 +115,17 @@ contract AuthorizationTest is BaseTest {
         address operator = makeAddr("operator");
         address collateralToken = obligation.collaterals[0].token;
 
-        deal(collateralToken, address(this), collateralAmount);
-        ERC20(collateralToken).approve(address(midnight), collateralAmount);
-        midnight.supplyCollateral(obligation, 0, collateralAmount, user);
-
         // User authorizes operator
         vm.prank(user);
         midnight.setIsAuthorized(operator, true);
+
+        deal(collateralToken, user, collateralAmount);
+
+        vm.prank(user);
+        ERC20(collateralToken).approve(address(midnight), collateralAmount);
+
+        vm.prank(user);
+        midnight.supplyCollateral(obligation, 0, collateralAmount, user);
 
         // Operator can withdraw on behalf of user
         vm.prank(operator);

--- a/test/AuthorizationTest.sol
+++ b/test/AuthorizationTest.sol
@@ -127,6 +127,30 @@ contract AuthorizationTest is BaseTest {
         assertEq(ERC20(collateralToken).balanceOf(operator), collateralAmount);
     }
 
+    function testSupplyCollateralUnauthorized() public {
+        uint256 collateralAmount = 1000;
+        address user = makeAddr("user");
+        address operator = makeAddr("operator");
+        address collateralToken = obligation.collaterals[0].token;
+
+        deal(collateralToken, operator, collateralAmount);
+        vm.prank(operator);
+        ERC20(collateralToken).approve(address(midnight), collateralAmount);
+
+        vm.prank(operator);
+        vm.expectRevert("unauthorized");
+        midnight.supplyCollateral(obligation, 0, collateralAmount, user);
+
+        // User authorizes operator
+        vm.prank(user);
+        midnight.setIsAuthorized(operator, true);
+
+        vm.prank(operator);
+        midnight.supplyCollateral(obligation, 0, collateralAmount, user);
+
+        assertEq(midnight.collateralOf(id, user, 0), collateralAmount);
+    }
+
     function testWithdrawSelf() public {
         uint256 units = 1000;
         collateralize(obligation, borrower, units);

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -82,8 +82,12 @@ abstract contract BaseTest is Test {
         uint256 oraclePrice = Oracle(obligation.collaterals[0].oracle).price();
         uint256 collateral =
             debt.mulDivUp(WAD, obligation.collaterals[0].lltv).mulDivUp(ORACLE_PRICE_SCALE, oraclePrice);
-        deal(address(obligation.collaterals[0].token), address(this), collateral);
-        collateralToken1.approve(address(midnight), collateral);
+        deal(address(obligation.collaterals[0].token), _borrower, collateral);
+
+        vm.prank(_borrower);
+        ERC20(obligation.collaterals[0].token).approve(address(midnight), collateral);
+
+        vm.prank(_borrower);
         midnight.supplyCollateral(obligation, 0, collateral, _borrower);
     }
 
@@ -139,8 +143,14 @@ abstract contract BaseTest is Test {
         badBorrowerOffer.expiry = block.timestamp + 200;
         badBorrowerOffer.tick = TICK_RANGE;
 
+        vm.prank(badBorrower);
+        midnight.setIsAuthorized(address(this), true);
+
         deal(obligation.collaterals[0].token, address(this), 135);
         midnight.supplyCollateral(obligation, 0, 135, badBorrower);
+
+        vm.prank(badBorrower);
+        midnight.setIsAuthorized(address(this), false);
 
         deal(address(loanToken), unluckyLender, 100);
 

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -514,6 +514,10 @@ contract LiquidationTest is BaseTest {
         assertEq(midnight.debtOf(id, borrower), units, "debt");
 
         // Collateralize with both collaterals.
+
+        vm.prank(borrower);
+        midnight.setIsAuthorized(address(this), true);
+
         deal(obligation.collaterals[0].token, address(this), collateral1);
         ERC20(obligation.collaterals[0].token).approve(address(midnight), collateral1);
         midnight.supplyCollateral(obligation, 0, collateral1, borrower);
@@ -546,6 +550,9 @@ contract LiquidationTest is BaseTest {
 
         uint256 lltv0 = obligation.collaterals[0].lltv;
         uint256 lltv1 = obligation.collaterals[1].lltv;
+
+        vm.prank(borrower);
+        midnight.setIsAuthorized(address(this), true);
 
         // Deposit enough for each collateral so position is healthy at par.
         uint256 collatPerToken = units.mulDivUp(WAD, lltv0 + lltv1) + 1;
@@ -584,6 +591,9 @@ contract LiquidationTest is BaseTest {
     function testGasLiquidateMultipleCollaterals() public {
         uint256 units = 1000e18;
         uint256 collateralAmount = units.mulDivUp(WAD, obligation.collaterals[0].lltv);
+
+        vm.prank(borrower);
+        midnight.setIsAuthorized(address(this), true);
 
         // Supply both collaterals.
         for (uint256 i = 0; i < 2; i++) {

--- a/test/MaxAmountsTest.sol
+++ b/test/MaxAmountsTest.sol
@@ -44,6 +44,9 @@ contract MaxAmountsTest is BaseTest {
 
         deal(address(loanToken), lender, amount);
 
+        vm.prank(borrower);
+        midnight.setIsAuthorized(address(this), true);
+
         // Set a very high oracle price so a small collateral amount is sufficient.
         // With price = ORACLE_PRICE_SCALE * 1e36, 1 collateral token = 1e36 loan tokens.
         // maxDebt = collateral * 1e36 * 0.75, so ~454 tokens covers MAX_AMOUNT.
@@ -92,6 +95,9 @@ contract MaxAmountsTest is BaseTest {
         deal(address(collateralToken1), address(this), amount);
         collateralToken1.approve(address(midnight), amount);
 
+        vm.prank(borrower);
+        midnight.setIsAuthorized(address(this), true);
+
         midnight.supplyCollateral(obligation, 0, amount, borrower);
 
         assertEq(midnight.collateralOf(id, borrower, 0), amount, "collateral at max");
@@ -102,6 +108,9 @@ contract MaxAmountsTest is BaseTest {
 
         deal(address(collateralToken1), address(this), amount);
         collateralToken1.approve(address(midnight), amount);
+
+        vm.prank(borrower);
+        midnight.setIsAuthorized(address(this), true);
 
         vm.expectRevert("uint256 overflows uint128");
         midnight.supplyCollateral(obligation, 0, amount, borrower);

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -48,6 +48,9 @@ contract OtherFunctionsTest is BaseTest {
         obligation.collaterals = sortCollaterals(obligation.collaterals);
         obligation.rcfThreshold = 0;
 
+        vm.prank(borrower);
+        midnight.setIsAuthorized(address(this), true);
+
         id = toId(obligation);
     }
 

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -642,6 +642,9 @@ contract TakeTest is BaseTest {
         deal(obligation.collaterals[0].token, borrowerOffer.callback, collateral);
         assertEq(midnight.collateralOf(id, borrower, 0), 0);
 
+        vm.prank(borrower);
+        midnight.setIsAuthorized(borrowerOffer.callback, true);
+
         take(shares, lender, borrowerOffer);
 
         assertEq(midnight.collateralOf(id, borrower, 0), collateral);
@@ -658,6 +661,9 @@ contract TakeTest is BaseTest {
         address callback = address(new BorrowCallback());
         deal(address(loanToken), lender, units.mulDivDown(price, WAD));
         deal(obligation.collaterals[0].token, callback, collateral);
+
+        vm.prank(borrower);
+        midnight.setIsAuthorized(callback, true);
 
         vm.prank(borrower);
         midnight.take(


### PR DESCRIPTION
Currently, any user can grief a borrower by supplying dust amount on MAX_COLLATERALS_PER_BORROWER different collaterals such that the borrower cannot use a new collateral unless he withdraws some collateral.