### PR TITLE
fix: consume attack

### DIFF
--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -490,8 +490,11 @@ contract Midnight is IMidnight {
         return (seizedAssets, repaidUnits);
     }
 
+    /// @dev Pass type(uint256).max to cancel all offers in the group. Never reverts.
     function consume(bytes32 group, uint256 amount) external {
-        consumed[msg.sender][group] += amount;
+        require(amount >= consumed[msg.sender][group], "consumed");
+
+        consumed[msg.sender][group] = amount;
 
         emit EventsLib.Consume(msg.sender, group, amount);
     }

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -490,13 +490,13 @@ contract Midnight is IMidnight {
         return (seizedAssets, repaidUnits);
     }
 
-    /// @dev Pass type(uint256).max to cancel all offers in the group. Never reverts.
-    function consume(bytes32 group, uint256 amount) external {
+    /// @dev Passing type(uint256).max cancels all offers in the group (and never reverts).
+    function setConsumed(bytes32 group, uint256 amount) external {
         require(amount >= consumed[msg.sender][group], "consumed");
 
         consumed[msg.sender][group] = amount;
 
-        emit EventsLib.Consume(msg.sender, group, amount);
+        emit EventsLib.SetConsumed(msg.sender, group, amount);
     }
 
     /// @dev TODO: is it safe enough?

--- a/src/libraries/EventsLib.sol
+++ b/src/libraries/EventsLib.sol
@@ -63,7 +63,7 @@ library EventsLib {
         uint256 badDebt
     );
 
-    event Consume(address indexed user, bytes32 indexed group, uint256 amount);
+    event SetConsumed(address indexed user, bytes32 indexed group, uint256 amount);
     event ShuffleSession(address indexed user, bytes32 session);
     event FlashLoan(address indexed caller, address indexed token, uint256 assets);
 

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -187,6 +187,31 @@ contract OtherFunctionsTest is BaseTest {
         assertEq(midnight.consumed(user, group), amount, "consumed");
     }
 
+    function testConsumeIncreasing(address user, bytes32 group, uint256 amount0, uint256 amount1) public {
+        amount0 = bound(amount0, 0, type(uint256).max - 1);
+        amount1 = bound(amount1, amount0, type(uint256).max);
+
+        vm.prank(user);
+        midnight.consume(group, amount0);
+        assertEq(midnight.consumed(user, group), amount0, "consumed 0");
+
+        vm.prank(user);
+        midnight.consume(group, amount1);
+        assertEq(midnight.consumed(user, group), amount1, "consumed 1");
+    }
+
+    function testConsumeDecreasingReverts(address user, bytes32 group, uint256 amount0, uint256 amount1) public {
+        amount0 = bound(amount0, 1, type(uint256).max);
+        amount1 = bound(amount1, 0, amount0 - 1);
+
+        vm.prank(user);
+        midnight.consume(group, amount0);
+
+        vm.prank(user);
+        vm.expectRevert("consumed");
+        midnight.consume(group, amount1);
+    }
+
     function testTouchObligation(Obligation memory _obligation) public {
         vm.assume(_obligation.collaterals.length > 0);
         _obligation = validObligation(_obligation);

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -181,35 +181,35 @@ contract OtherFunctionsTest is BaseTest {
         assertEq(ERC20(collateralToken).balanceOf(receiver), withdraw, "balance of receiver");
     }
 
-    function testConsume(address user, bytes32 group, uint256 amount) public {
+    function testSetConsumed(address user, bytes32 group, uint256 amount) public {
         vm.prank(user);
-        midnight.consume(group, amount);
+        midnight.setConsumed(group, amount);
         assertEq(midnight.consumed(user, group), amount, "consumed");
     }
 
-    function testConsumeIncreasing(address user, bytes32 group, uint256 amount0, uint256 amount1) public {
+    function testSetConsumedIncreasing(address user, bytes32 group, uint256 amount0, uint256 amount1) public {
         amount0 = bound(amount0, 0, type(uint256).max - 1);
         amount1 = bound(amount1, amount0, type(uint256).max);
 
         vm.prank(user);
-        midnight.consume(group, amount0);
+        midnight.setConsumed(group, amount0);
         assertEq(midnight.consumed(user, group), amount0, "consumed 0");
 
         vm.prank(user);
-        midnight.consume(group, amount1);
+        midnight.setConsumed(group, amount1);
         assertEq(midnight.consumed(user, group), amount1, "consumed 1");
     }
 
-    function testConsumeDecreasingReverts(address user, bytes32 group, uint256 amount0, uint256 amount1) public {
+    function testSetConsumedDecreasingReverts(address user, bytes32 group, uint256 amount0, uint256 amount1) public {
         amount0 = bound(amount0, 1, type(uint256).max);
         amount1 = bound(amount1, 0, amount0 - 1);
 
         vm.prank(user);
-        midnight.consume(group, amount0);
+        midnight.setConsumed(group, amount0);
 
         vm.prank(user);
         vm.expectRevert("consumed");
-        midnight.consume(group, amount1);
+        midnight.setConsumed(group, amount1);
     }
 
     function testTouchObligation(Obligation memory _obligation) public {


### PR DESCRIPTION
if you are trying to put consumed to type(uint256).max, someone can front-run and take 1 of one of your offers to make you revert. one idea could be to target type(uint128).max, but i thought that it was simpler to do it this way. credits to @spennyp for the [finding](https://morpholabs.slack.com/archives/C08UY4ZS5PH/p1772582360067159)