### PR TITLE
Reintroduce the clz opcode.

### DIFF
--- a/src/libraries/UtilsLib.sol
+++ b/src/libraries/UtilsLib.sol
@@ -68,13 +68,9 @@ library UtilsLib {
         }
     }
 
-    function msb(uint256 bitmap) internal pure returns (uint256) {
-        // Temporary workaround for the Certora pipeline.
-        // TODO: restore the clz-based implementation once the pipeline issue is fixed.
-        for (uint256 i = 256; i > 0; i--) {
-            uint256 bit = i - 1;
-            if ((bitmap & (1 << bit)) != 0) return bit;
+    function msb(uint256 bitmap) internal pure returns (uint256 res) {
+        assembly {
+            res := sub(255, clz(bitmap))
         }
-        return 0;
     }
 }


### PR DESCRIPTION
This reverts the previous hack to workaround the problematic clz opcode.

Since Prover 8.8.1 the opcode is supported, so lets see if the verification succeeds here.

This was the previous commit: 46b38b8294e5b663db213d3dc904a27d9f8983f1