### PR TITLE
[Certora] Consume

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -14,6 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         conf:
+          - Consume
           - CreatedObligations
           - ExactMath
           - Liquidate

--- a/certora/confs/Consume.conf
+++ b/certora/confs/Consume.conf
@@ -1,27 +1,27 @@
 {
-	"files": [
-		"src/Midnight.sol"
-	],
-	"verify": "Midnight:certora/specs/Consume.spec",
-	"solc": "solc-0.8.31",
-	"solc_via_ir": true,
-	"solc_evm_version": "osaka",
-	"optimistic_loop": true,
-	"loop_iter": 2,
-	"optimistic_hashing": true,
-	"hashing_length_bound": 1024,
-	"rule_sanity": "basic",
-	"multi_assert_check": true,
-	"smt_timeout": 7200,
-	"prover_args": [
-		"-destructiveOptimizations",
-		"twostage",
-		"-s",
-		"[z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5}]",
-		"-splitParallel",
-		"true",
-		"-dontStopAtFirstSplitTimeout",
-		"true"
-	],
-	"msg": "Midnight Consumed"
+  "files": [
+	"src/Midnight.sol"
+  ],
+  "verify": "Midnight:certora/specs/Consume.spec",
+  "solc": "solc-0.8.31",
+  "solc_via_ir": true,
+  "solc_evm_version": "osaka",
+  "optimistic_loop": true,
+  "loop_iter": 2,
+  "optimistic_hashing": true,
+  "hashing_length_bound": 1024,
+  "rule_sanity": "basic",
+  "multi_assert_check": true,
+  "smt_timeout": 7200,
+ "prover_args": [
+    "-destructiveOptimizations",
+	"twostage",
+	"-s",
+	"[z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5}]",
+	"-splitParallel",
+	"true",
+	"-dontStopAtFirstSplitTimeout",
+	"true"
+  ],
+  "msg": "Midnight Consumed"
 }

--- a/certora/confs/Consume.conf
+++ b/certora/confs/Consume.conf
@@ -1,22 +1,27 @@
 {
-  "files": [
-    "src/Midnight.sol"
-  ],
-  "verify": "Midnight:certora/specs/Consume.spec",
-  "solc": "solc-0.8.31",
-  "solc_via_ir": true,
-  "solc_evm_version": "osaka",
-  "optimistic_loop": true,
-  "loop_iter": 2,
-  "optimistic_hashing": true,
-  "hashing_length_bound": 1024,
-  "rule_sanity": "basic",
-  "smt_timeout": 3600,
-  "prover_args": [
-    "-destructiveOptimizations twostage",
-    "-s [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},bitwuzla:def{randomSeed=1},bitwuzla:def{randomSeed=2},bitwuzla:def{randomSeed=3},bitwuzla:def{randomSeed=4},bitwuzla:def{randomSeed=5}]",
-    "-splitParallel true",
-    "-smt_initialSplitDepth 8"
-  ],
-  "msg": "Midnight Consume"
+	"files": [
+		"src/Midnight.sol"
+	],
+	"verify": "Midnight:certora/specs/Consume.spec",
+	"solc": "solc-0.8.31",
+	"solc_via_ir": true,
+	"solc_evm_version": "osaka",
+	"optimistic_loop": true,
+	"loop_iter": 2,
+	"optimistic_hashing": true,
+	"hashing_length_bound": 1024,
+	"rule_sanity": "basic",
+	"multi_assert_check": true,
+	"smt_timeout": 7200,
+	"prover_args": [
+		"-destructiveOptimizations",
+		"twostage",
+		"-s",
+		"[z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5}]",
+		"-splitParallel",
+		"true",
+		"-dontStopAtFirstSplitTimeout",
+		"true"
+	],
+	"msg": "Midnight Consumed"
 }

--- a/certora/confs/Consume.conf
+++ b/certora/confs/Consume.conf
@@ -1,27 +1,22 @@
 {
   "files": [
-	"src/Midnight.sol"
+    "certora/helpers/Utils.sol",
+    "src/Midnight.sol"
+  ],
+  "parametric_contracts": [
+    "Midnight"
   ],
   "verify": "Midnight:certora/specs/Consume.spec",
   "solc": "solc-0.8.31",
   "solc_via_ir": true,
-  "solc_evm_version": "osaka",
   "optimistic_loop": true,
   "loop_iter": 2,
   "optimistic_hashing": true,
-  "hashing_length_bound": 1024,
-  "rule_sanity": "basic",
-  "multi_assert_check": true,
+  "hashing_length_bound": 2048,
   "smt_timeout": 7200,
- "prover_args": [
-    "-destructiveOptimizations",
-	"twostage",
-	"-s",
-	"[z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5}]",
-	"-splitParallel",
-	"true",
-	"-dontStopAtFirstSplitTimeout",
-	"true"
+  "prover_args": [
+    "-destructiveOptimizations twostage",
+    "-s [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:def{randomSeed=8},z3:def{randomSeed=9},z3:def{randomSeed=10}]"
   ],
-  "msg": "Midnight Consumed"
+  "msg": "Midnight Consume"
 }

--- a/certora/confs/Consume.conf
+++ b/certora/confs/Consume.conf
@@ -9,16 +9,14 @@
   "optimistic_loop": true,
   "loop_iter": 2,
   "optimistic_hashing": true,
-  "hashing_length_bound": 2048,
+  "hashing_length_bound": 1024,
+  "rule_sanity": "basic",
+  "smt_timeout": 3600,
   "prover_args": [
-    "-depth 5",
-    "-mediumTimeout 20",
-    "-timeout 3600",
-    "-splitParallel",
-    "true",
-    "-dontStopAtFirstSplitTimeout",
-    "true"
+    "-destructiveOptimizations twostage",
+    "-s [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},bitwuzla:def{randomSeed=1},bitwuzla:def{randomSeed=2},bitwuzla:def{randomSeed=3},bitwuzla:def{randomSeed=4},bitwuzla:def{randomSeed=5}]",
+    "-splitParallel true",
+    "-smt_initialSplitDepth 8"
   ],
-  "smt_timeout": 7200,
-  "msg": "ConsumeNonDecreasing"
+  "msg": "Midnight Consume"
 }

--- a/certora/confs/Consume.conf
+++ b/certora/confs/Consume.conf
@@ -1,0 +1,24 @@
+{
+  "files": [
+    "src/Midnight.sol"
+  ],
+  "verify": "Midnight:certora/specs/Consume.spec",
+  "solc": "solc-0.8.31",
+  "solc_via_ir": true,
+  "solc_evm_version": "osaka",
+  "optimistic_loop": true,
+  "loop_iter": 2,
+  "optimistic_hashing": true,
+  "hashing_length_bound": 2048,
+  "prover_args": [
+    "-depth 5",
+    "-mediumTimeout 20",
+    "-timeout 3600",
+    "-splitParallel",
+    "true",
+    "-dontStopAtFirstSplitTimeout",
+    "true"
+  ],
+  "smt_timeout": 7200,
+  "msg": "ConsumeNonDecreasing"
+}

--- a/certora/specs/Consume.spec
+++ b/certora/specs/Consume.spec
@@ -13,7 +13,6 @@ methods {
 
 ///  Only `setConsumed` and `take` can modify the consumed mapping.
 rule onlySetConsumedAndTakeChangeConsumed(env e, method f, calldataarg args, address user, bytes32 group) filtered { f -> f.selector != sig:setConsumed(bytes32, uint256, address).selector && f.selector != sig:take(uint256, address, address, bytes, address, Midnight.Offer, Midnight.Signature, bytes32, bytes32[]).selector } {
-
     uint256 consumedBefore = consumed(user, group);
 
     f(e, args);

--- a/certora/specs/Consume.spec
+++ b/certora/specs/Consume.spec
@@ -6,12 +6,11 @@ methods {
     function consumed(address user, bytes32 group) external returns (uint256) envfree;
     function totalUnits(bytes32 id) external returns (uint256) envfree;
     function totalShares(bytes32 id) external returns (uint256) envfree;
-    function toId(Midnight.Obligation obligation) external returns (bytes32);
 
     function _.price() external => NONDET;
 }
 
-///  Only `setConsumed` and `take` can modify the consumed mapping.
+///  Only `setConsumed` and `take` can modify the `consumed` mapping.
 rule onlySetConsumedAndTakeChangeConsumed(env e, method f, calldataarg args, address user, bytes32 group) filtered { f -> f.selector != sig:setConsumed(bytes32, uint256, address).selector && f.selector != sig:take(uint256, address, address, bytes, address, Midnight.Offer, Midnight.Signature, bytes32, bytes32[]).selector } {
     uint256 consumedBefore = consumed(user, group);
 
@@ -20,7 +19,7 @@ rule onlySetConsumedAndTakeChangeConsumed(env e, method f, calldataarg args, add
     assert consumed(user, group) == consumedBefore;
 }
 
-/// Calling `setConsumed` only affects msg.sender's consumed value for the given group.
+/// Calling `setConsumed` only affects onBehalf's consumed value for the given group.
 /// No other (user, group) pair is modified.
 rule setConsumedOnlyAffectsOnBehalf(env e, bytes32 group, uint256 amount, address onBehalf, address otherUser, bytes32 otherGroup) {
     uint256 otherConsumedBefore = consumed(otherUser, otherGroup);
@@ -74,7 +73,7 @@ rule takeConsumedAtMaxUnchanged(env e, uint256 obligationShares, address taker, 
 }
 
 /// A fully-consumed offer always reverts when the take input is non-zero in the offer's consumption dimension.
-rule fullyConsumedOfferRevertsOnNonTrivialTake(env e, uint256 obligationShares, address taker, address takerCallback, bytes takerCallbackData, address receiverIfTakerIsSeller, Midnight.Offer offer, Midnight.Signature signature, bytes32 root, bytes32[] proof) {
+rule fullyConsumedOfferRevertsOnNonTrivialTake(env e, uint256 obligationShares, address taker, address takerCallback, bytes takerCallbackData, address receiver, Midnight.Offer offer, Midnight.Signature signature, bytes32 root, bytes32[] proof) {
     uint256 consumedBefore = consumed(offer.maker, offer.group);
 
     bytes32 id = toId(e, offer.obligation);
@@ -86,7 +85,7 @@ rule fullyConsumedOfferRevertsOnNonTrivialTake(env e, uint256 obligationShares, 
     // When consumption is units-based, prevent rounding down to 0
     require offer.obligationUnits > 0 => to_mathint(obligationShares) * (to_mathint(_totalUnits) + 1) >= to_mathint(_totalShares) + 1;
 
-    take@withrevert(e, obligationShares, taker, takerCallback, takerCallbackData, receiverIfTakerIsSeller, offer, signature, root, proof);
+    take@withrevert(e, obligationShares, taker, takerCallback, takerCallbackData, receiver, offer, signature, root, proof);
 
     assert lastReverted;
 }

--- a/certora/specs/Consume.spec
+++ b/certora/specs/Consume.spec
@@ -4,6 +4,9 @@ methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;
 
     function consumed(address user, bytes32 group) external returns (uint256) envfree;
+    function totalUnits(bytes32 id) external returns (uint256) envfree;
+    function totalShares(bytes32 id) external returns (uint256) envfree;
+    function toId(Midnight.Obligation obligation) external returns (bytes32);
 
     function _.price() external => NONDET;
 
@@ -17,7 +20,7 @@ function summaryMulDiv(uint256 x, uint256 y, uint256 d) returns uint256 {
     return res;
 }
 
-// Only `consume` and `take` can modify the consumed mapping.
+///  Only `consume` and `take` can modify the consumed mapping.
 rule onlyConsumeAndTakeChangeConsumed(env e, method f, calldataarg args, address user, bytes32 group) filtered { f -> f.selector != sig:consume(bytes32, uint256).selector && f.selector != sig:take(uint256, address, address, bytes, address, Midnight.Offer, Midnight.Signature, bytes32, bytes32[]).selector } {
     uint256 consumedBefore = consumed(user, group);
 
@@ -26,8 +29,8 @@ rule onlyConsumeAndTakeChangeConsumed(env e, method f, calldataarg args, address
     assert consumed(user, group) == consumedBefore;
 }
 
-// Calling `consume` only affects msg.sender's consumed value for the given group.
-// No other (user, group) pair is modified.
+/// Calling `consume` only affects msg.sender's consumed value for the given group.
+/// No other (user, group) pair is modified.
 rule consumeOnlyAffectsSender(env e, bytes32 group, uint256 amount, address otherUser, bytes32 otherGroup) {
     uint256 otherConsumedBefore = consumed(otherUser, otherGroup);
 
@@ -37,7 +40,7 @@ rule consumeOnlyAffectsSender(env e, bytes32 group, uint256 amount, address othe
     assert (otherUser != e.msg.sender || otherGroup != group) => consumed(otherUser, otherGroup) == otherConsumedBefore;
 }
 
-/// @title Calling `take` only affects the maker's consumed value for the offer's group.
+/// Calling `take` only affects the maker's consumed value for the offer's group.
 /// No other (user, group) pair is modified.
 rule takeOnlyAffectsMakerConsumed(env e, uint256 obligationShares, address taker, address takerCallback, bytes takerCallbackData, address receiver, Midnight.Offer offer, Midnight.Signature signature, bytes32 root, bytes32[] proof, address user, bytes32 group) {
     uint256 consumedBefore = consumed(user, group);
@@ -48,13 +51,51 @@ rule takeOnlyAffectsMakerConsumed(env e, uint256 obligationShares, address taker
     assert (user != offer.maker || group != offer.group) => consumed(user, group) == consumedBefore;
 }
 
-/// @title The consumed mapping is non-decreasing: no function can decrease consumed[user][group].
+/// The consumed mapping is non-decreasing: no function can decrease consumed[user][group].
 rule consumeNonDecreasing(env e, method f, calldataarg args, address user, bytes32 group) {
     uint256 consumedBefore = consumed(user, group);
 
     f(e, args);
 
-    uint256 consumedAfter = consumed(user, group);
+    assert consumed(user, group) >= consumedBefore;
+}
 
-    assert consumedAfter >= consumedBefore;
+/// After a successful `take`, consumed[offer.maker][offer.group] does not exceed the offer's max amount
+/// (offer.obligationUnits if units-based, offer.obligationShares if shares-based).
+rule takeConsumedBoundedByMax(env e, uint256 obligationShares, address taker, address takerCallback, bytes takerCallbackData, address receiver, Midnight.Offer offer, Midnight.Signature signature, bytes32 root, bytes32[] proof) {
+    take(e, obligationShares, taker, takerCallback, takerCallbackData, receiver, offer, signature, root, proof);
+
+    uint256 maxAmount = offer.obligationUnits > 0 ? offer.obligationUnits : offer.obligationShares;
+    assert consumed(offer.maker, offer.group) <= maxAmount;
+}
+
+/// If consumed[offer.maker][offer.group] is already at or above the offer's max amount before a `take`,
+/// it does not change (the take either reverts or is a no-op).
+rule takeConsumedAtMaxUnchanged(env e, uint256 obligationShares, address taker, address takerCallback, bytes takerCallbackData, address receiver, Midnight.Offer offer, Midnight.Signature signature, bytes32 root, bytes32[] proof) {
+    uint256 consumedBefore = consumed(offer.maker, offer.group);
+    uint256 maxAmount = offer.obligationUnits > 0 ? offer.obligationUnits : offer.obligationShares;
+
+    require consumedBefore >= maxAmount;
+
+    take@withrevert(e, obligationShares, taker, takerCallback, takerCallbackData, receiver, offer, signature, root, proof);
+
+    assert consumed(offer.maker, offer.group) == consumedBefore;
+}
+
+/// A fully-consumed offer always reverts when the take input is non-zero in the offer's consumption dimension.
+rule fullyConsumedOfferRevertsOnNonTrivialTake(env e, uint256 obligationShares, address taker, address takerCallback, bytes takerCallbackData, address receiverIfTakerIsSeller, Midnight.Offer offer, Midnight.Signature signature, bytes32 root, bytes32[] proof) {
+    uint256 consumedBefore = consumed(offer.maker, offer.group);
+
+    bytes32 id = toId(e, offer.obligation);
+    uint256 _totalUnits = totalUnits(id);
+    uint256 _totalShares = totalShares(id);
+
+    require (offer.obligationUnits > 0 && consumedBefore >= offer.obligationUnits && obligationShares > 0) || (offer.obligationShares > 0 && consumedBefore >= offer.obligationShares && obligationShares > 0);
+
+    // When consumption is units-based, prevent rounding down to 0
+    require offer.obligationUnits > 0 => to_mathint(obligationShares) * (to_mathint(_totalUnits) + 1) >= to_mathint(_totalShares) + 1;
+
+    take@withrevert(e, obligationShares, taker, takerCallback, takerCallbackData, receiverIfTakerIsSeller, offer, signature, root, proof);
+
+    assert lastReverted;
 }

--- a/certora/specs/Consume.spec
+++ b/certora/specs/Consume.spec
@@ -9,18 +9,9 @@ methods {
     function toId(Midnight.Obligation obligation) external returns (bytes32);
 
     function _.price() external => NONDET;
-
-    function UtilsLib.mulDivDown(uint256 x, uint256 y, uint256 d) internal returns (uint256) => summaryMulDiv(x, y, d);
-    function UtilsLib.mulDivUp(uint256 x, uint256 y, uint256 d) internal returns (uint256) => summaryMulDiv(x, y, d);
 }
 
-function summaryMulDiv(uint256 x, uint256 y, uint256 d) returns uint256 {
-    if (x == 0 || y == 0) return 0;
-    uint256 res;
-    return res;
-}
-
-///  Only `consume` and `take` can modify the consumed mapping.
+///  Only `setConsumed` and `take` can modify the consumed mapping.
 rule onlySetConsumedAndTakeChangeConsumed(env e, method f, calldataarg args, address user, bytes32 group) filtered { f -> f.selector != sig:setConsumed(bytes32, uint256, address).selector && f.selector != sig:take(uint256, address, address, bytes, address, Midnight.Offer, Midnight.Signature, bytes32, bytes32[]).selector } {
 
     uint256 consumedBefore = consumed(user, group);
@@ -32,13 +23,13 @@ rule onlySetConsumedAndTakeChangeConsumed(env e, method f, calldataarg args, add
 
 /// Calling `setConsumed` only affects msg.sender's consumed value for the given group.
 /// No other (user, group) pair is modified.
-rule setConsumedOnlyAffectsSender(env e, bytes32 group, uint256 amount, address onBehalf, address otherUser, bytes32 otherGroup) {
+rule setConsumedOnlyAffectsOnBehalf(env e, bytes32 group, uint256 amount, address onBehalf, address otherUser, bytes32 otherGroup) {
     uint256 otherConsumedBefore = consumed(otherUser, otherGroup);
 
     setConsumed(e, group, amount, onBehalf);
 
-    // Any pair that is not exactly (msg.sender, group) remains unchanged.
-    assert (otherUser != e.msg.sender || otherGroup != group) => consumed(otherUser, otherGroup) == otherConsumedBefore;
+    // Any pair that is not (onBehalf, group) remains unchanged.
+    assert (otherUser != onBehalf || otherGroup != group) => consumed(otherUser, otherGroup) == otherConsumedBefore;
 }
 
 /// Calling `take` only affects the maker's consumed value for the offer's group.
@@ -71,14 +62,14 @@ rule takeConsumedBoundedByMax(env e, uint256 obligationShares, address taker, ad
 }
 
 /// If consumed[offer.maker][offer.group] is already at or above the offer's max amount before a `take`,
-/// it does not change (the take either reverts or is a no-op).
+/// it remains unchanged.
 rule takeConsumedAtMaxUnchanged(env e, uint256 obligationShares, address taker, address takerCallback, bytes takerCallbackData, address receiver, Midnight.Offer offer, Midnight.Signature signature, bytes32 root, bytes32[] proof) {
     uint256 consumedBefore = consumed(offer.maker, offer.group);
     uint256 maxAmount = offer.obligationUnits > 0 ? offer.obligationUnits : offer.obligationShares;
 
     require consumedBefore >= maxAmount;
 
-    take@withrevert(e, obligationShares, taker, takerCallback, takerCallbackData, receiver, offer, signature, root, proof);
+    take(e, obligationShares, taker, takerCallback, takerCallbackData, receiver, offer, signature, root, proof);
 
     assert consumed(offer.maker, offer.group) == consumedBefore;
 }

--- a/certora/specs/Consume.spec
+++ b/certora/specs/Consume.spec
@@ -63,7 +63,7 @@ rule takeConsumedBoundedByMax(env e, uint256 obligationShares, address taker, ad
 
 /// After a successful `take`, the change in consumed equals the amount taken: returnedUnits for units-based
 /// offers, obligationShares for shares-based.
-rule takeConsumedExactDelta(env e, uint256 obligationShares, address taker, address takerCallback, bytes takerCallbackData, address receiver, Midnight.Offer offer, Midnight.Signature signature, bytes32 root, bytes32[] proof) {
+rule takeConsumedDelta(env e, uint256 obligationShares, address taker, address takerCallback, bytes takerCallbackData, address receiver, Midnight.Offer offer, Midnight.Signature signature, bytes32 root, bytes32[] proof) {
     uint256 consumedBefore = consumed(offer.maker, offer.group);
 
     uint256 returnedUnits;

--- a/certora/specs/Consume.spec
+++ b/certora/specs/Consume.spec
@@ -52,9 +52,6 @@ rule consumeNonDecreasing(env e, method f, calldataarg args, address user, bytes
 /// After a successful `take`, consumed[offer.maker][offer.group] does not exceed the offer's max amount
 /// (offer.obligationUnits if units-based, offer.obligationShares if shares-based).
 rule takeConsumedBoundedByMax(env e, uint256 obligationShares, address taker, address takerCallback, bytes takerCallbackData, address receiver, Midnight.Offer offer, Midnight.Signature signature, bytes32 root, bytes32[] proof) {
-    uint256 consumedBefore = consumed(offer.maker, offer.group);
-
-    uint256 returnedUnits;
     take(e, obligationShares, taker, takerCallback, takerCallbackData, receiver, offer, signature, root, proof);
 
     uint256 maxAmount = offer.obligationUnits > 0 ? offer.obligationUnits : offer.obligationShares;

--- a/certora/specs/Consume.spec
+++ b/certora/specs/Consume.spec
@@ -52,10 +52,24 @@ rule consumeNonDecreasing(env e, method f, calldataarg args, address user, bytes
 /// After a successful `take`, consumed[offer.maker][offer.group] does not exceed the offer's max amount
 /// (offer.obligationUnits if units-based, offer.obligationShares if shares-based).
 rule takeConsumedBoundedByMax(env e, uint256 obligationShares, address taker, address takerCallback, bytes takerCallbackData, address receiver, Midnight.Offer offer, Midnight.Signature signature, bytes32 root, bytes32[] proof) {
+    uint256 consumedBefore = consumed(offer.maker, offer.group);
+
+    uint256 returnedUnits;
     take(e, obligationShares, taker, takerCallback, takerCallbackData, receiver, offer, signature, root, proof);
 
     uint256 maxAmount = offer.obligationUnits > 0 ? offer.obligationUnits : offer.obligationShares;
     assert consumed(offer.maker, offer.group) <= maxAmount;
+}
+
+/// After a successful `take`, the change in consumed equals the amount taken: returnedUnits for units-based offers, obligationShares for shares-based.
+rule takeConsumedExactDelta(env e, uint256 obligationShares, address taker, address takerCallback, bytes takerCallbackData, address receiver, Midnight.Offer offer, Midnight.Signature signature, bytes32 root, bytes32[] proof) {
+    uint256 consumedBefore = consumed(offer.maker, offer.group);
+
+    uint256 returnedUnits;
+    (_, _, returnedUnits, _) = take(e, obligationShares, taker, takerCallback, takerCallbackData, receiver, offer, signature, root, proof);
+
+    uint256 expectedDelta = offer.obligationUnits > 0 ? returnedUnits : obligationShares;
+    assert consumed(offer.maker, offer.group) == consumedBefore + expectedDelta;
 }
 
 /// If consumed[offer.maker][offer.group] is already at or above the offer's max amount before a `take`,

--- a/certora/specs/Consume.spec
+++ b/certora/specs/Consume.spec
@@ -2,12 +2,11 @@
 
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;
+    function _.price() external => NONDET;
 
     function consumed(address user, bytes32 group) external returns (uint256) envfree;
     function totalUnits(bytes32 id) external returns (uint256) envfree;
     function totalShares(bytes32 id) external returns (uint256) envfree;
-
-    function _.price() external => NONDET;
 }
 
 ///  Only `setConsumed` and `take` can modify the `consumed` mapping.
@@ -65,25 +64,19 @@ rule takeConsumedAtMaxUnchanged(env e, uint256 obligationShares, address taker, 
     uint256 consumedBefore = consumed(offer.maker, offer.group);
     uint256 maxAmount = offer.obligationUnits > 0 ? offer.obligationUnits : offer.obligationShares;
 
-    require consumedBefore >= maxAmount;
-
     take(e, obligationShares, taker, takerCallback, takerCallbackData, receiver, offer, signature, root, proof);
 
-    assert consumed(offer.maker, offer.group) == consumedBefore;
+    assert consumedBefore >= maxAmount => consumed(offer.maker, offer.group) == consumedBefore;
 }
 
 /// A fully-consumed offer always reverts when the take input is non-zero in the offer's consumption dimension.
 rule fullyConsumedOfferRevertsOnNonTrivialTake(env e, uint256 obligationShares, address taker, address takerCallback, bytes takerCallbackData, address receiver, Midnight.Offer offer, Midnight.Signature signature, bytes32 root, bytes32[] proof) {
     uint256 consumedBefore = consumed(offer.maker, offer.group);
-
     bytes32 id = toId(e, offer.obligation);
-    uint256 _totalUnits = totalUnits(id);
-    uint256 _totalShares = totalShares(id);
 
-    require (offer.obligationUnits > 0 && consumedBefore >= offer.obligationUnits && obligationShares > 0) || (offer.obligationShares > 0 && consumedBefore >= offer.obligationShares && obligationShares > 0);
-
-    // When consumption is units-based, prevent rounding down to 0
-    require offer.obligationUnits > 0 => to_mathint(obligationShares) * (to_mathint(_totalUnits) + 1) >= to_mathint(_totalShares) + 1;
+    require obligationShares > 0, "take input is non-zero in the offers consumption dimension";
+    require (offer.obligationUnits > 0 && consumedBefore >= offer.obligationUnits) || (offer.obligationShares > 0 && consumedBefore >= offer.obligationShares), "assume the offer is fully consumed";
+    require offer.obligationUnits > 0 => to_mathint(obligationShares) * (to_mathint(totalUnits(id)) + 1) >= to_mathint(totalShares(id)) + 1, "when consumption is units-based, ensure not rounded down to 0";
 
     take@withrevert(e, obligationShares, taker, takerCallback, takerCallbackData, receiver, offer, signature, root, proof);
 

--- a/certora/specs/Consume.spec
+++ b/certora/specs/Consume.spec
@@ -67,7 +67,7 @@ rule takeConsumedExactDelta(env e, uint256 obligationShares, address taker, addr
     uint256 consumedBefore = consumed(offer.maker, offer.group);
 
     uint256 returnedUnits;
-    (_, _, returnedUnits, _) = take(e, obligationShares, taker, takerCallback, takerCallbackData, receiver, offer, signature, root, proof);
+    _, _, returnedUnits, _ = take(e, obligationShares, taker, takerCallback, takerCallbackData, receiver, offer, signature, root, proof);
 
     uint256 expectedDelta = offer.obligationUnits > 0 ? returnedUnits : obligationShares;
     assert consumed(offer.maker, offer.group) == consumedBefore + expectedDelta;

--- a/certora/specs/Consume.spec
+++ b/certora/specs/Consume.spec
@@ -21,7 +21,8 @@ function summaryMulDiv(uint256 x, uint256 y, uint256 d) returns uint256 {
 }
 
 ///  Only `consume` and `take` can modify the consumed mapping.
-rule onlyConsumeAndTakeChangeConsumed(env e, method f, calldataarg args, address user, bytes32 group) filtered { f -> f.selector != sig:consume(bytes32, uint256).selector && f.selector != sig:take(uint256, address, address, bytes, address, Midnight.Offer, Midnight.Signature, bytes32, bytes32[]).selector } {
+rule onlySetConsumedAndTakeChangeConsumed(env e, method f, calldataarg args, address user, bytes32 group) filtered { f -> f.selector != sig:setConsumed(bytes32, uint256).selector && f.selector != sig:take(uint256, address, address, bytes, address, Midnight.Offer, Midnight.Signature, bytes32, bytes32[]).selector } {
+
     uint256 consumedBefore = consumed(user, group);
 
     f(e, args);
@@ -29,14 +30,14 @@ rule onlyConsumeAndTakeChangeConsumed(env e, method f, calldataarg args, address
     assert consumed(user, group) == consumedBefore;
 }
 
-/// Calling `consume` only affects msg.sender's consumed value for the given group.
+/// Calling `setConsumed` only affects msg.sender's consumed value for the given group.
 /// No other (user, group) pair is modified.
-rule consumeOnlyAffectsSender(env e, bytes32 group, uint256 amount, address otherUser, bytes32 otherGroup) {
+rule setConsumedOnlyAffectsSender(env e, bytes32 group, uint256 amount, address otherUser, bytes32 otherGroup) {
     uint256 otherConsumedBefore = consumed(otherUser, otherGroup);
 
-    consume(e, group, amount);
+    setConsumed(e, group, amount);
 
-    // Any pair that is not exactly (msg.sender, group) must be unchanged.
+    // Any pair that is not exactly (msg.sender, group) remains unchanged.
     assert (otherUser != e.msg.sender || otherGroup != group) => consumed(otherUser, otherGroup) == otherConsumedBefore;
 }
 

--- a/certora/specs/Consume.spec
+++ b/certora/specs/Consume.spec
@@ -5,8 +5,8 @@ methods {
 
     function consumed(address user, bytes32 group) external returns (uint256) envfree;
 
-    // assume price does not revert and does not modify storage.
     function _.price() external => NONDET;
+
     function UtilsLib.mulDivDown(uint256 x, uint256 y, uint256 d) internal returns (uint256) => summaryMulDiv(x, y, d);
     function UtilsLib.mulDivUp(uint256 x, uint256 y, uint256 d) internal returns (uint256) => summaryMulDiv(x, y, d);
 }

--- a/certora/specs/Consume.spec
+++ b/certora/specs/Consume.spec
@@ -61,7 +61,8 @@ rule takeConsumedBoundedByMax(env e, uint256 obligationShares, address taker, ad
     assert consumed(offer.maker, offer.group) <= maxAmount;
 }
 
-/// After a successful `take`, the change in consumed equals the amount taken: returnedUnits for units-based offers, obligationShares for shares-based.
+/// After a successful `take`, the change in consumed equals the amount taken: returnedUnits for units-based
+/// offers, obligationShares for shares-based.
 rule takeConsumedExactDelta(env e, uint256 obligationShares, address taker, address takerCallback, bytes takerCallbackData, address receiver, Midnight.Offer offer, Midnight.Signature signature, bytes32 root, bytes32[] proof) {
     uint256 consumedBefore = consumed(offer.maker, offer.group);
 

--- a/certora/specs/Consume.spec
+++ b/certora/specs/Consume.spec
@@ -21,7 +21,7 @@ function summaryMulDiv(uint256 x, uint256 y, uint256 d) returns uint256 {
 }
 
 ///  Only `consume` and `take` can modify the consumed mapping.
-rule onlySetConsumedAndTakeChangeConsumed(env e, method f, calldataarg args, address user, bytes32 group) filtered { f -> f.selector != sig:setConsumed(bytes32, uint256).selector && f.selector != sig:take(uint256, address, address, bytes, address, Midnight.Offer, Midnight.Signature, bytes32, bytes32[]).selector } {
+rule onlySetConsumedAndTakeChangeConsumed(env e, method f, calldataarg args, address user, bytes32 group) filtered { f -> f.selector != sig:setConsumed(bytes32, uint256, address).selector && f.selector != sig:take(uint256, address, address, bytes, address, Midnight.Offer, Midnight.Signature, bytes32, bytes32[]).selector } {
 
     uint256 consumedBefore = consumed(user, group);
 
@@ -32,10 +32,10 @@ rule onlySetConsumedAndTakeChangeConsumed(env e, method f, calldataarg args, add
 
 /// Calling `setConsumed` only affects msg.sender's consumed value for the given group.
 /// No other (user, group) pair is modified.
-rule setConsumedOnlyAffectsSender(env e, bytes32 group, uint256 amount, address otherUser, bytes32 otherGroup) {
+rule setConsumedOnlyAffectsSender(env e, bytes32 group, uint256 amount, address onBehalf, address otherUser, bytes32 otherGroup) {
     uint256 otherConsumedBefore = consumed(otherUser, otherGroup);
 
-    setConsumed(e, group, amount);
+    setConsumed(e, group, amount, onBehalf);
 
     // Any pair that is not exactly (msg.sender, group) remains unchanged.
     assert (otherUser != e.msg.sender || otherGroup != group) => consumed(otherUser, otherGroup) == otherConsumedBefore;

--- a/certora/specs/Consume.spec
+++ b/certora/specs/Consume.spec
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+methods {
+    function multicall(bytes[]) external => HAVOC_ALL DELETE;
+
+    function consumed(address user, bytes32 group) external returns (uint256) envfree;
+
+    // assume price does not revert and does not modify storage.
+    function _.price() external => NONDET;
+    function UtilsLib.mulDivDown(uint256 x, uint256 y, uint256 d) internal returns (uint256) => summaryMulDiv(x, y, d);
+    function UtilsLib.mulDivUp(uint256 x, uint256 y, uint256 d) internal returns (uint256) => summaryMulDiv(x, y, d);
+}
+
+function summaryMulDiv(uint256 x, uint256 y, uint256 d) returns uint256 {
+    if (x == 0 || y == 0) return 0;
+    uint256 res;
+    return res;
+}
+
+// Only `consume` and `take` can modify the consumed mapping.
+rule onlyConsumeAndTakeChangeConsumed(env e, method f, calldataarg args, address user, bytes32 group) filtered { f -> f.selector != sig:consume(bytes32, uint256).selector && f.selector != sig:take(uint256, address, address, bytes, address, Midnight.Offer, Midnight.Signature, bytes32, bytes32[]).selector } {
+    uint256 consumedBefore = consumed(user, group);
+
+    f(e, args);
+
+    assert consumed(user, group) == consumedBefore;
+}
+
+// Calling `consume` only affects msg.sender's consumed value for the given group.
+// No other (user, group) pair is modified.
+rule consumeOnlyAffectsSender(env e, bytes32 group, uint256 amount, address otherUser, bytes32 otherGroup) {
+    uint256 otherConsumedBefore = consumed(otherUser, otherGroup);
+
+    consume(e, group, amount);
+
+    // Any pair that is not exactly (msg.sender, group) must be unchanged.
+    assert (otherUser != e.msg.sender || otherGroup != group) => consumed(otherUser, otherGroup) == otherConsumedBefore;
+}
+
+/// @title Calling `take` only affects the maker's consumed value for the offer's group.
+/// No other (user, group) pair is modified.
+rule takeOnlyAffectsMakerConsumed(env e, uint256 obligationShares, address taker, address takerCallback, bytes takerCallbackData, address receiver, Midnight.Offer offer, Midnight.Signature signature, bytes32 root, bytes32[] proof, address user, bytes32 group) {
+    uint256 consumedBefore = consumed(user, group);
+
+    take(e, obligationShares, taker, takerCallback, takerCallbackData, receiver, offer, signature, root, proof);
+
+    // Any pair that is not exactly (offer.maker, offer.group) must be unchanged.
+    assert (user != offer.maker || group != offer.group) => consumed(user, group) == consumedBefore;
+}
+
+/// @title The consumed mapping is non-decreasing: no function can decrease consumed[user][group].
+rule consumeNonDecreasing(env e, method f, calldataarg args, address user, bytes32 group) {
+    uint256 consumedBefore = consumed(user, group);
+
+    f(e, args);
+
+    uint256 consumedAfter = consumed(user, group);
+
+    assert consumedAfter >= consumedBefore;
+}


### PR DESCRIPTION
- [x] only `setCconsumed` and `take` can modify consumed
- [x] calling `setConsumed` only affects onBehalf's consumed
- [x] calling `take` only affects maker's consumed
- [x] consumed is non-decreasing
- [x] after a successful take, consumed does not exceed offer's max amount
- [x] after a successful take, consume is changed exactly as expected
- [x] if the maker's consumed is already >= offer's max amount, then it remains unchanged
- [x] a fully consumed offer always reverts when take input is non-zero in the offer's consumption (thanks to @lilCertora)
