### PR TITLE
feat: passive fee recipient

### DIFF
--- a/certora/confs/Midnight.conf
+++ b/certora/confs/Midnight.conf
@@ -1,5 +1,6 @@
 {
   "files": [
+    "certora/helpers/Utils.sol",
     "src/Midnight.sol"
   ],
   "verify": "Midnight:certora/specs/Midnight.spec",

--- a/certora/confs/OnlyAuthorizedCanDecreaseShares.conf
+++ b/certora/confs/OnlyAuthorizedCanDecreaseShares.conf
@@ -1,5 +1,6 @@
 {
   "files": [
+    "certora/helpers/Utils.sol",
     "src/Midnight.sol"
   ],
   "verify": "Midnight:certora/specs/OnlyAuthorizedCanDecreaseShares.spec",

--- a/certora/helpers/Utils.sol
+++ b/certora/helpers/Utils.sol
@@ -4,9 +4,14 @@ pragma solidity ^0.8.0;
 
 import {Obligation} from "../../src/interfaces/IMidnight.sol";
 import {IdLib} from "../../src/libraries/IdLib.sol";
+import {PASSIVE_FEE_RECIPIENT} from "../../src/libraries/ConstantsLib.sol";
 
 contract Utils {
     function hashObligation(Obligation memory obligation) external pure returns (bytes32) {
         return keccak256(abi.encode(obligation));
+    }
+
+    function passiveFeeRecipient() external pure returns (address) {
+        return PASSIVE_FEE_RECIPIENT;
     }
 }

--- a/certora/specs/Midnight.spec
+++ b/certora/specs/Midnight.spec
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using Utils as Utils;
+
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;
 
@@ -10,6 +12,7 @@ methods {
     function sharesOf(bytes32 id, address owner) external returns (uint256) envfree;
     function debtOf(bytes32 id, address user) external returns (uint256) envfree;
     function remainingContinuousFee(bytes32 id, address user) external returns (uint128) envfree;
+    function Utils.passiveFeeRecipient() external returns (address) envfree;
 
     function _.price() external => NONDET;
     function IdLib.toId(Midnight.Obligation memory, uint256, address) internal returns (bytes32) => NONDET;
@@ -42,6 +45,8 @@ function summaryMulDiv(uint256 x, uint256 y, uint256 d) returns uint256 {
     uint256 res;
     return res;
 }
+
+definition isPassiveFeeRecipient(address user) returns bool = user == Utils.passiveFeeRecipient();
 
 rule takeInputOutputConsistency(env e, uint256 obligationSharesInput, address taker, address receiver, Midnight.Offer offer, Midnight.Signature signature, bytes32 root, bytes32[] proof, address takerCallbackAddress, bytes takerCallbackData) {
     uint256 buyerAssetsOutput;
@@ -105,7 +110,7 @@ rule liquidateInputOutputConsistency(env e, Midnight.Obligation obligation, uint
 /// INVARIANTS ///
 
 strong invariant notBorrowerAndLender(bytes32 id, address user)
-    sharesOf(id, user) == 0 || debtOf(id, user) == 0;
+    !isPassiveFeeRecipient(user) => sharesOf(id, user) == 0 || debtOf(id, user) == 0;
 
 strong invariant noRemainingContinuousFeeWithoutDebt(bytes32 id, address user)
     debtOf(id, user) == 0 => remainingContinuousFee(id, user) == 0;

--- a/certora/specs/OnlyAuthorizedCanDecreaseShares.spec
+++ b/certora/specs/OnlyAuthorizedCanDecreaseShares.spec
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+using Utils as Utils;
+
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;
 
+    function feeRecipient() external returns (address) envfree;
     function sharesOf(bytes32 id, address user) external returns (uint256) envfree;
     function isAuthorized(address authorizer, address authorized) external returns (bool) envfree;
+    function Utils.passiveFeeRecipient() external returns (address) envfree;
 
     function _.price() external => NONDET;
 }
@@ -13,6 +17,10 @@ methods {
 /// Assumes no reentrancy: callbacks (onBuy, onSell) and token transfers are not modeled as re-entering Midnight, so re-entrant share decreases are not covered.
 rule onlyAuthorizedCanDecreaseSharesExceptTake(env e, method f, bytes32 id, address user) {
     uint256 sharesBefore = sharesOf(id, user);
+    bool passiveFeeWithdraw =
+        user == Utils.passiveFeeRecipient()
+        && e.msg.sender == feeRecipient()
+        && f.selector == sig:withdraw(Midnight.Obligation, uint256, uint256, address, address).selector;
 
     require user != e.msg.sender;
     require !isAuthorized(user, e.msg.sender);
@@ -20,7 +28,9 @@ rule onlyAuthorizedCanDecreaseSharesExceptTake(env e, method f, bytes32 id, addr
     calldataarg args;
     f(e, args);
 
-    assert sharesOf(id, user) >= sharesBefore || f.selector == sig:take(uint256, address, address, bytes, address, Midnight.Offer, Midnight.Signature, bytes32, bytes32[]).selector;
+    assert sharesOf(id, user) >= sharesBefore
+        || f.selector == sig:take(uint256, address, address, bytes, address, Midnight.Offer, Midnight.Signature, bytes32, bytes32[]).selector
+        || passiveFeeWithdraw;
 }
 
 /// In take, the caller must be authorized by the taker and only the seller's shares can decrease.

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -17,7 +17,8 @@ import {
     LIQUIDATION_CURSOR_LOW,
     LIQUIDATION_CURSOR_HIGH,
     EIP712_DOMAIN_TYPEHASH,
-    ROOT_TYPEHASH
+    ROOT_TYPEHASH,
+    PASSIVE_FEE_RECIPIENT
 } from "./libraries/ConstantsLib.sol";
 import {IOracle} from "./interfaces/IOracle.sol";
 import {
@@ -348,7 +349,11 @@ contract Midnight is IMidnight {
         address onBehalf,
         address receiver
     ) external returns (uint256, uint256) {
-        require(onBehalf == msg.sender || isAuthorized[onBehalf][msg.sender], "unauthorized");
+        require(
+            onBehalf == msg.sender || isAuthorized[onBehalf][msg.sender]
+                || (onBehalf == PASSIVE_FEE_RECIPIENT && msg.sender == feeRecipient),
+            "unauthorized"
+        );
         require(UtilsLib.atMostOneNonZero(obligationUnits, shares), "inconsistent input");
         bytes32 id = touchObligation(obligation);
         ObligationState storage _obligationState = obligationState[id];
@@ -718,7 +723,7 @@ contract Midnight is IMidnight {
                 _state.debt += feeUnits;
                 _obligationState.totalUnits += feeUnits;
                 if (feeShares > 0) {
-                    sharesOf[id][feeRecipient] += feeShares;
+                    sharesOf[id][PASSIVE_FEE_RECIPIENT] += feeShares;
                     _obligationState.totalShares += UtilsLib.toUint128(feeShares);
                 }
             }

--- a/src/libraries/ConstantsLib.sol
+++ b/src/libraries/ConstantsLib.sol
@@ -13,3 +13,4 @@ uint256 constant MAX_COLLATERALS = 128;
 uint256 constant MAX_COLLATERALS_PER_BORROWER = 10;
 uint256 constant LIQUIDATION_CURSOR_LOW = 0.25e18;
 uint256 constant LIQUIDATION_CURSOR_HIGH = 0.5e18;
+address constant PASSIVE_FEE_RECIPIENT = address(uint160(uint256(keccak256("passive fee recipient"))));

--- a/test/ContinuousFeeTest.sol
+++ b/test/ContinuousFeeTest.sol
@@ -462,6 +462,42 @@ contract ContinuousFeeTest is BaseTest {
         assertEq(midnight.continuousFee(id), fee, "obligation fee updated");
     }
 
+    function testFeeSharesRetrievableAfterRecipientChange(uint256 debt, uint256 feeRate, uint256 ttm, uint256 elapsed)
+        public
+    {
+        debt = bound(debt, 1e18, MAX_DEBT);
+        feeRate = bound(feeRate, 1, MAX_CONTINUOUS_FEE);
+        ttm = bound(ttm, 2, 360 days);
+        elapsed = bound(elapsed, 1, ttm - 1);
+
+        setupBorrower(debt, feeRate, ttm);
+        uint256 remaining = midnight.remainingContinuousFee(id, borrower);
+        vm.assume(remaining > 0);
+
+        // Accrue fees
+        vm.warp(block.timestamp + elapsed);
+        midnight.repay(obligation, 0, borrower);
+        uint256 feeShares = midnight.sharesOf(id, PASSIVE_FEE_RECIPIENT);
+        vm.assume(feeShares > 0);
+
+        // Repay all debt so withdrawable is filled
+        uint256 totalDebt = midnight.debtOf(id, borrower);
+        deal(address(loanToken), address(this), totalDebt);
+        midnight.repay(obligation, totalDebt, borrower);
+
+        // Change fee recipient
+        address newRecipient = makeAddr("newFeeRecipient");
+        midnight.setFeeRecipient(newRecipient);
+
+        // New recipient can withdraw the fee shares
+        vm.prank(newRecipient);
+        (uint256 units,) = midnight.withdraw(obligation, 0, feeShares, PASSIVE_FEE_RECIPIENT, newRecipient);
+
+        assertGt(units, 0, "new recipient got assets");
+        assertEq(midnight.sharesOf(id, PASSIVE_FEE_RECIPIENT), 0, "passive shares drained");
+        assertEq(loanToken.balanceOf(newRecipient), units, "assets received");
+    }
+
     function testRateChangeDoesNotAffectExistingBorrower(
         uint256 debt,
         uint256 rate1,

--- a/test/ContinuousFeeTest.sol
+++ b/test/ContinuousFeeTest.sol
@@ -2,7 +2,7 @@
 // Copyright (c) 2025 Morpho Association
 pragma solidity ^0.8.0;
 
-import {WAD, ORACLE_PRICE_SCALE, MAX_CONTINUOUS_FEE} from "../src/libraries/ConstantsLib.sol";
+import {WAD, ORACLE_PRICE_SCALE, MAX_CONTINUOUS_FEE, PASSIVE_FEE_RECIPIENT} from "../src/libraries/ConstantsLib.sol";
 import {UtilsLib} from "../src/libraries/UtilsLib.sol";
 import {TICK_RANGE} from "../src/libraries/TickLib.sol";
 import {Obligation, Offer, Collateral} from "../src/interfaces/IMidnight.sol";
@@ -326,7 +326,7 @@ contract ContinuousFeeTest is BaseTest {
         uint256 feeUnits = remaining.mulDivDown(elapsed, ttm);
         if (feeUnits > 0) {
             uint256 expectedShares = feeUnits.mulDivDown(totalSharesBefore + 1, totalUnitsBefore + 1);
-            assertEq(midnight.sharesOf(id, feeRecipient), expectedShares, "fee recipient shares");
+            assertEq(midnight.sharesOf(id, PASSIVE_FEE_RECIPIENT), expectedShares, "fee recipient shares");
         }
     }
 


### PR DESCRIPTION
pro:
- simple code change
 
 cons
- recipient must wait until maturity to collect
- invariant debt=0|shares=0 true in practice but harder to prove