### PR TITLE
[Certora] more robust consume spec

### DIFF
--- a/certora/specs/Consume.spec
+++ b/certora/specs/Consume.spec
@@ -81,7 +81,7 @@ rule takeConsumedAtMaxUnchanged(env e, uint256 obligationShares, address taker, 
     assert consumedBefore >= maxAmount => consumed(offer.maker, offer.group) == consumedBefore;
 }
 
-/// A fully-consumed offer always reverts when the take input is non-zero in the offer's consumption dimension.
+/// A fully-consumed offer in shares (rest. in units) only allows no-ops in shares (rest. in units).
 rule fullyConsumedOfferRevertsOnNonTrivialTake(env e, uint256 obligationShares, address taker, address takerCallback, bytes takerCallbackData, address receiver, Midnight.Offer offer, Midnight.Signature signature, bytes32 root, bytes32[] proof) {
     uint256 consumedBefore = consumed(offer.maker, offer.group);
     bytes32 id = toId(e, offer.obligation);

--- a/certora/specs/Consume.spec
+++ b/certora/specs/Consume.spec
@@ -86,11 +86,12 @@ rule fullyConsumedOfferRevertsOnNonTrivialTake(env e, uint256 obligationShares, 
     uint256 consumedBefore = consumed(offer.maker, offer.group);
     bytes32 id = toId(e, offer.obligation);
 
-    require obligationShares > 0, "take input is non-zero in the offers consumption dimension";
     require (offer.obligationUnits > 0 && consumedBefore >= offer.obligationUnits) || (offer.obligationShares > 0 && consumedBefore >= offer.obligationShares), "assume the offer is fully consumed";
-    require offer.obligationUnits > 0 => to_mathint(obligationShares) * (to_mathint(totalUnits(id)) + 1) >= to_mathint(totalShares(id)) + 1, "when consumption is units-based, ensure not rounded down to 0";
 
-    take@withrevert(e, obligationShares, taker, takerCallback, takerCallbackData, receiver, offer, signature, root, proof);
+    uint256 returnedUnits;
+    _, _, returnedUnits, _ = take(e, obligationShares, taker, takerCallback, takerCallbackData, receiver, offer, signature, root, proof);
 
-    assert lastReverted;
+    // If take does not revert, its input has to be zero in the offer's consumption dimension.
+    assert offer.obligationUnits > 0 => returnedUnits == 0;
+    assert offer.obligationShares > 0 => obligationShares == 0;
 }


### PR DESCRIPTION
Motivation is to not depend on the conversion from shares to units. Notably it fixes the issues that it breaks after #238, see [this run](https://prover.certora.com/output/66603/b3abc13c77f34201b9b33be1ad2c5d55?anonymousKey=d228c2943911ee17004620c5047df2af89762aff)