### PR TITLE
verif: faster created spec

### DIFF
--- a/certora/confs/CreatedObligations.conf
+++ b/certora/confs/CreatedObligations.conf
@@ -15,7 +15,7 @@
   "hashing_length_bound": 2048,
   "smt_timeout": 7200,
   "prover_args": [
-    "-destructiveOptimizations twostage",
+    "-destructiveOptimizations enable",
     "-s [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:def{randomSeed=8},z3:def{randomSeed=9},z3:def{randomSeed=10}]"
   ],
   "msg": "CreatedObligations"


### PR DESCRIPTION
https://docs.certora.com/en/latest/docs/user-guide/out-of-resources/timeout.html#:~:text=This%20option%20enables%20some%20aggressive%20simplifications%20that%20speed%20up%20the%20Prover%20in%20many%20cases%2C%20but%20breaks%20call%20trace%20generation%20in%20case%20a%20rule%20is%20violated