### PR TITLE
fix omit first line in Certora CI

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - id: list
-        run: echo "confs=$(ls certora/confs/*.conf | xargs -I{} basename {} .conf | jq -Rc '[inputs]')" >> "$GITHUB_OUTPUT"
+        run: echo "confs=$(ls certora/confs/*.conf | xargs -I{} basename {} .conf | jq -nRc '[inputs]')" >> "$GITHUB_OUTPUT"
 
   verify:
     needs: matrix


### PR DESCRIPTION
otherwise `jq` starts by reading the first line and consumes it from the input stream, so it would skip the first spec file