### PR TITLE
[1-loss-index] save slot on no credit take

### DIFF
--- a/certora/specs/BalanceEffects.spec
+++ b/certora/specs/BalanceEffects.spec
@@ -71,8 +71,7 @@ rule repayEffects(env e, Midnight.Obligation obligation, uint256 obligationUnits
 /// withdraw decreases onBehalf's post-slash credit by exactly obligationUnits, and only changes position[id][onBehalf].credit.
 rule withdrawEffects(env e, Midnight.Obligation obligation, uint256 obligationUnits, address onBehalf, address receiver, bytes32 anyId, address anyUser) {
     bytes32 id = toId(e, obligation);
-    require userLossIndex(id, onBehalf) <= currentContract.obligationState[id].lossIndex, "see Midnight.spec";
-    require creditOf(id, onBehalf) > 0 => userLossIndex(id, onBehalf) != 0, "see Midnight.spec";
+    require userLossIndex(id, onBehalf) >= currentContract.obligationState[id].lossIndex || userLossIndex(id, onBehalf) == 0, "see Midnight.spec";
 
     uint256 creditPostSlash = creditAfterSlashing(id, onBehalf);
     uint256 otherCreditBefore = creditOf(anyId, anyUser);
@@ -91,10 +90,8 @@ rule withdrawEffects(env e, Midnight.Obligation obligation, uint256 obligationUn
 /// and only changes credit and debt of maker and taker at the obligation id.
 rule takeEffects(env e, uint256 obligationUnits, address taker, address takerCallback, bytes takerCallbackData, address receiver, Midnight.Offer offer, Midnight.Signature signature, bytes32 root, bytes32[] proof, bytes32 anyId, address anyUser) {
     bytes32 id = toId(e, offer.obligation);
-    require userLossIndex(id, offer.maker) <= currentContract.obligationState[id].lossIndex, "see Midnight.spec";
-    require creditOf(id, offer.maker) > 0 => userLossIndex(id, offer.maker) != 0, "see Midnight.spec";
-    require userLossIndex(id, taker) <= currentContract.obligationState[id].lossIndex, "see Midnight.spec";
-    require creditOf(id, taker) > 0 => userLossIndex(id, taker) != 0, "see Midnight.spec";
+    require userLossIndex(id, offer.maker) >= currentContract.obligationState[id].lossIndex || userLossIndex(id, offer.maker) == 0, "see Midnight.spec";
+    require userLossIndex(id, taker) >= currentContract.obligationState[id].lossIndex || userLossIndex(id, taker) == 0, "see Midnight.spec";
 
     mathint makerPostSlash = to_mathint(creditAfterSlashing(id, offer.maker)) - to_mathint(debtOf(id, offer.maker));
     mathint takerPostSlash = to_mathint(creditAfterSlashing(id, taker)) - to_mathint(debtOf(id, taker));

--- a/certora/specs/SlashBeforeBalance.spec
+++ b/certora/specs/SlashBeforeBalance.spec
@@ -45,7 +45,9 @@ hook Sstore position[KEY bytes32 id][KEY address user].credit uint128 newValue (
 /// RULES ///
 
 // View functions that read credit don't call slash (they can't mutate state).
-rule creditReadAfterSlash(method f, env e, calldataarg args) filtered { f -> f.selector != sig:creditOf(bytes32, address).selector && f.selector != sig:creditAfterSlashing(bytes32, address).selector } {
+// take is excluded because it reads credit as a guard to decide whether to call slash.
+// but take is still subject to creditWrittenAfterSlash
+rule creditReadAfterSlash(method f, env e, calldataarg args) filtered { f -> f.selector != sig:creditOf(bytes32, address).selector && f.selector != sig:creditAfterSlashing(bytes32, address).selector && f.selector != sig:take(uint256, address, address, bytes, address, Midnight.Offer, Midnight.Signature, bytes32, bytes32[]).selector } {
     require !creditReadWithoutSlash, "initialize the ghost variable";
     f(e, args);
     assert !creditReadWithoutSlash;

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -172,8 +172,6 @@ contract Midnight is IMidnight {
         require(UtilsLib.isLeaf(root, keccak256(abi.encode(offer)), proof), "invalid proof");
         require(offer.session == session[offer.maker], "invalid session");
         bytes32 id = touchObligation(offer.obligation);
-        slash(id, offer.maker);
-        slash(id, taker);
         ObligationState storage _obligationState = obligationState[id];
 
         (
@@ -221,10 +219,12 @@ contract Midnight is IMidnight {
         Position storage sellerPos = position[id][seller];
         uint256 oldBuyerDebt = buyerPos.debt;
         uint256 oldSellerDebt = sellerPos.debt;
-        uint256 buyerDebtReduction = UtilsLib.min(oldBuyerDebt, obligationUnits);
+        if (sellerPos.credit > 0) slash(id, seller);
+        uint256 buyerCreditIncrease = obligationUnits.zeroFloorSub(oldBuyerDebt);
+        if (buyerPos.credit > 0 || buyerCreditIncrease > 0) slash(id, buyer);
         uint256 sellerCreditReduction = UtilsLib.min(sellerPos.credit, obligationUnits);
-        buyerPos.debt -= UtilsLib.toUint128(buyerDebtReduction);
-        buyerPos.credit += UtilsLib.toUint128(obligationUnits - buyerDebtReduction);
+        buyerPos.debt -= UtilsLib.toUint128(obligationUnits - buyerCreditIncrease);
+        buyerPos.credit += UtilsLib.toUint128(buyerCreditIncrease);
         sellerPos.credit -= UtilsLib.toUint128(sellerCreditReduction);
         sellerPos.debt += UtilsLib.toUint128(obligationUnits - sellerCreditReduction);
         _obligationState.totalUnits = UtilsLib.toUint128(


### PR DESCRIPTION
invariant for this is `user credit > 0 -> user index >= global index`