### PR TITLE
Revert liquidate when liquidatedCollatPrice = 0

### DIFF
--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -406,6 +406,7 @@ contract Midnight is IMidnight {
         }
 
         if (repaidUnits > 0 || seizedAssets > 0) {
+            require(liquidatedCollatPrice > 0, "collateral not active or zero oracle price");
             uint256 _maxLif = obligation.collaterals[collateralIndex].maxLif;
             uint256 lif = originalDebt > maxDebt
                 ? _maxLif

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -378,6 +378,7 @@ contract Midnight is IMidnight {
         uint256 originalDebt = debtOf(id, borrower);
         uint256 badDebt = originalDebt;
         uint256 bitmap = _position.activatedCollaterals;
+        require((bitmap & (1 << collateralIndex)) != 0, "collateral not activated");
         while (bitmap != 0) {
             uint256 i = UtilsLib.msb(bitmap);
             Collateral memory _collateral = obligation.collaterals[i];
@@ -406,7 +407,6 @@ contract Midnight is IMidnight {
         }
 
         if (repaidUnits > 0 || seizedAssets > 0) {
-            require(liquidatedCollatPrice > 0, "collateral not active or zero oracle price");
             uint256 _maxLif = obligation.collaterals[collateralIndex].maxLif;
             uint256 lif = originalDebt > maxDebt
                 ? _maxLif


### PR DESCRIPTION
currently, when liquidatedCollatPrice = 0, the two paths diverge in `liquidate()`:
- repaidUnits > 0 path: mulDivDown(ORACLE_PRICE_SCALE, 0) ->  division by zero -> reverts
- seizedAssets > 0 path: mulDivUp(0, ORACLE_PRICE_SCALE) -> repaidUnits = 0 -> does not revert. liquidator can seize the collaterals for free. 

This asymmetry is exposed in the LiquidationsBoundedByLIF [spec](https://github.com/morpho-org/midnight/pull/497/changes#r2952746770). 

This PR adds an additional require, which makes the two cases symmetric and also simplifies the spec. 