### PR TITLE
Update events

### DIFF
--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -304,7 +304,10 @@ contract Midnight is IMidnight {
             receiver,
             offer.group,
             newConsumed,
-            _obligationState.totalUnits,
+            buyerPos.credit,
+            sellerPos.credit,
+            buyerCreditIncrease,
+            sellerCreditDecrease,
             buyerPos.pendingFee,
             sellerPos.pendingFee
         );

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -349,7 +349,7 @@ contract Midnight is IMidnight {
         _obligationState.withdrawable -= units;
         _obligationState.totalUnits -= UtilsLib.toUint128(units);
 
-        emit EventsLib.Withdraw(msg.sender, id, units, onBehalf, receiver, _position.pendingFee);
+        emit EventsLib.Withdraw(msg.sender, id, units, onBehalf, receiver, _position.credit, _position.pendingFee);
 
         SafeTransferLib.safeTransfer(obligation.loanToken, receiver, units);
     }

--- a/src/libraries/EventsLib.sol
+++ b/src/libraries/EventsLib.sol
@@ -31,7 +31,10 @@ library EventsLib {
         address sellerReceiver,
         bytes32 group,
         uint256 consumed,
-        uint256 totalUnits,
+        uint256 buyerCredit,
+        uint256 sellerCredit,
+        uint256 buyerCreditIncrease,
+        uint256 sellerCreditDecrease,
         uint256 buyerPendingFee,
         uint256 sellerPendingFee
     );

--- a/src/libraries/EventsLib.sol
+++ b/src/libraries/EventsLib.sol
@@ -44,6 +44,7 @@ library EventsLib {
         uint256 units,
         address indexed onBehalf,
         address indexed receiver,
+        uint256 credit,
         uint256 pendingFee
     );
     event Repay(address indexed caller, bytes32 indexed id_, uint256 units, address indexed onBehalf);


### PR DESCRIPTION
Should solve #543 

- credit cannot be retrieved through events by adding updates because the formula of `updatePosition` is too complex so new credit values should be logged when its state value is updated (in take, withdraw and updatePosition)
- debt can easily be retrieved by adding debt increase/decrease in take, repay and liquidate. Note that this breaks consistency between credit and debt (because the former logs its new value while the latter logs its diff with the previous value). We could make it consistent by logging `newDebt` everywhere but not sure about the benefit. Same thing for `totalUnits`