### PR TITLE
[Certora] Check that non-zero credit is not accessed before update even in take

### DIFF
--- a/certora/specs/UpdateBeforeCredit.spec
+++ b/certora/specs/UpdateBeforeCredit.spec
@@ -16,6 +16,7 @@ methods {
 
     // Summarize _updatePosition so that its credit reads/writes do not fire the hooks below.
     function _updatePosition(Midnight.Obligation memory, bytes32 id, address user) internal => summaryUpdatePosition(id, user);
+    function hasCredit(bytes32 id, address user) internal returns (bool) => summaryHasCredit(id, user);
 }
 
 /// GHOSTS ///
@@ -37,6 +38,11 @@ function summaryUpdatePosition(bytes32 id, address user) {
     updated[id][user] = true;
 }
 
+/// Summary for hasCredit:  circumvent the load hook for credit checks.
+function summaryHasCredit(bytes32 id, address user) returns (bool) {
+    return currentContract.position[id][user].credit > 0;
+}
+
 /// HOOKS ///
 
 hook Sstore position[KEY bytes32 id][KEY address user].credit uint128 newVal (uint128 oldVal) {
@@ -46,7 +52,7 @@ hook Sstore position[KEY bytes32 id][KEY address user].credit uint128 newVal (ui
 }
 
 hook Sload uint128 val position[KEY bytes32 id][KEY address user].credit {
-    if (!updated[id][user]) {
+    if (!updated[id][user] && val != 0) {
         creditLoadedBeforeUpdate[id][user] = true;
     }
 }
@@ -68,8 +74,7 @@ rule creditNotStoredBeforeUpdate(env e, method f, calldataarg args, bytes32 id, 
 /// TODO check take with another approach.
 rule creditNotLoadedBeforeUpdate(env e, method f, calldataarg args, bytes32 id, address user)
 filtered {
-    f -> f.selector != sig:take(uint256, address, address, bytes, address, Midnight.Offer, Midnight.Signature, bytes32, bytes32[]).selector
-        && f.selector != sig:creditOf(bytes32, address).selector
+    f -> f.selector != sig:creditOf(bytes32, address).selector
         && f.selector != sig:updatePositionView(Midnight.Obligation, bytes32, address).selector
         && f.selector != sig:position(bytes32, address).selector
 } {

--- a/certora/specs/UpdateBeforeCredit.spec
+++ b/certora/specs/UpdateBeforeCredit.spec
@@ -72,12 +72,7 @@ rule creditNotStoredBeforeUpdate(env e, method f, calldataarg args, bytes32 id, 
 /// Check that credit is never loaded before _updatePosition is called.
 /// The SLOADs of _updatePosition are ignored (see summary above).
 /// TODO check take with another approach.
-rule creditNotLoadedBeforeUpdate(env e, method f, calldataarg args, bytes32 id, address user)
-filtered {
-    f -> f.selector != sig:creditOf(bytes32, address).selector
-        && f.selector != sig:updatePositionView(Midnight.Obligation, bytes32, address).selector
-        && f.selector != sig:position(bytes32, address).selector
-} {
+rule creditNotLoadedBeforeUpdate(env e, method f, calldataarg args, bytes32 id, address user) filtered { f -> f.selector != sig:creditOf(bytes32, address).selector && f.selector != sig:updatePositionView(Midnight.Obligation, bytes32, address).selector && f.selector != sig:position(bytes32, address).selector } {
     require !creditLoadedBeforeUpdate[id][user], "initialize the ghost variable";
 
     f(e, args);

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -272,8 +272,8 @@ contract Midnight is IMidnight {
         Position storage buyerPos = position[id][buyer];
         Position storage sellerPos = position[id][seller];
 
-        if (buyerPos.credit > 0 || units > buyerPos.debt) _updatePosition(offer.obligation, id, buyer);
-        if (sellerPos.credit > 0) _updatePosition(offer.obligation, id, seller);
+        if (hasCredit(id, buyer) || units > buyerPos.debt) _updatePosition(offer.obligation, id, buyer);
+        if (hasCredit(id, seller)) _updatePosition(offer.obligation, id, seller);
 
         uint256 buyerCreditIncrease = UtilsLib.zeroFloorSub(units, buyerPos.debt);
         uint256 sellerCreditDecrease = UtilsLib.min(units, sellerPos.credit);
@@ -671,6 +671,10 @@ contract Midnight is IMidnight {
         position[id][PASSIVE_FEE_RECIPIENT].credit += accruedFee;
 
         emit EventsLib.UpdatePosition(id, user, creditDecrease, pendingFeeDecrease, accruedFee);
+    }
+
+    function hasCredit(bytes32 id, address user) internal view returns (bool) {
+        return position[id][user].credit > 0;
     }
 
     /// OTHER VIEW FUNCTIONS ///


### PR DESCRIPTION
This fixes the updateBeforeCredit spec to include take again.