### PR TITLE
fix: take bundler pulling assets

### DIFF
--- a/src/periphery/TakeBundler.sol
+++ b/src/periphery/TakeBundler.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.34;
 
 import {Midnight} from "../Midnight.sol";
 import {Offer} from "../interfaces/IMidnight.sol";
+import {IERC20} from "../interfaces/IERC20.sol";
+import {SafeTransferLib} from "../libraries/SafeTransferLib.sol";
 import {UtilsLib} from "../libraries/UtilsLib.sol";
 import {TakeAmountsLib} from "./TakeAmountsLib.sol";
 
@@ -18,11 +20,26 @@ contract TakeBundler {
         bytes32[] proof;
     }
 
+    /// @dev Midnight's `take` fires maker-controlled callbacks after moving the loan token out of the bundler.
+    /// Without this guard, a malicious callback could reenter any entry point with `target=0` to trigger its sweep,
+    /// draining `bundleTakeUnits`'s residual balance (`maxBuyerAssets - totalBuyerAssets`) and shipping it to the
+    /// attacker via `msg.sender`. The shared transient lock blocks cross-function reentry too.
+    uint256 private transient _reentrancyLock;
+
+    modifier nonReentrant() {
+        require(_reentrancyLock == 0, "reentrancy");
+        _reentrancyLock = 1;
+        _;
+        _reentrancyLock = 0;
+    }
+
     /// @dev Iterates through orders, filling up to targetUnits units total.
     /// @dev Assumes offers are all buy or all sell and share the same obligation id.
     /// @dev The taker must have authorized this bundler and the msg.sender (if different from the taker) on Midnight.
     /// @dev The bundler skips every reason why `take` can revert (including ones that are not asynchrony related).
     /// @dev If taking an offer reverts, the bundler will completely skip this offer.
+    /// @dev For sell offers the bundler pulls `maxBuyerAssets` from msg.sender, whom must have previously approved the
+    /// bundler to spend their loan assets.
     function bundleTakeUnits(
         Midnight midnight,
         uint256 targetUnits,
@@ -33,8 +50,14 @@ contract TakeBundler {
         uint256 maxBuyerAssets,
         uint256 minSellerAssets,
         uint256 maxSellerAssets
-    ) external {
+    ) external nonReentrant {
         require(taker == msg.sender || midnight.isAuthorized(taker, msg.sender), "unauthorized");
+
+        address loanToken = takes[0].offer.obligation.loanToken;
+        if (!takes[0].offer.buy) {
+            SafeTransferLib.safeTransferFrom(loanToken, msg.sender, address(this), maxBuyerAssets);
+            _approve(loanToken, address(midnight), maxBuyerAssets);
+        }
 
         uint256 totalFilledUnits;
         uint256 totalBuyerAssets;
@@ -64,6 +87,8 @@ contract TakeBundler {
         require(totalBuyerAssets <= maxBuyerAssets, "buyer assets above max");
         require(totalSellerAssets >= minSellerAssets, "seller assets below min");
         require(totalSellerAssets <= maxSellerAssets, "seller assets above max");
+
+        _sweepAndRevoke(midnight, loanToken);
     }
 
     /// @dev Same as bundleTakeUnits but targets buyer assets.
@@ -71,6 +96,8 @@ contract TakeBundler {
     /// @dev buyerAssetsToUnits is evaluated before midnight.take, so reverts there (e.g. underflow when offerPrice <
     /// tradingFee) are not caught by the try/catch and will abort the bundle.
     /// @dev Requires a non-empty takes array.
+    /// @dev For sell offers the bundler pulls `targetBuyerAssets` from msg.sender, whom must have previously approved
+    /// the bundler to spend their loan assets.
     function bundleTakeBuyerAssets(
         Midnight midnight,
         uint256 targetBuyerAssets,
@@ -79,9 +106,15 @@ contract TakeBundler {
         Take[] calldata takes,
         uint256 minUnits,
         uint256 maxUnits
-    ) external {
+    ) external nonReentrant {
         require(taker == msg.sender || midnight.isAuthorized(taker, msg.sender), "unauthorized");
         bytes32 id = midnight.touchObligation(takes[0].offer.obligation); // to have the correct trading fees.
+
+        address loanToken = takes[0].offer.obligation.loanToken;
+        if (!takes[0].offer.buy) {
+            SafeTransferLib.safeTransferFrom(loanToken, msg.sender, address(this), targetBuyerAssets);
+            _approve(loanToken, address(midnight), targetBuyerAssets);
+        }
 
         uint256 totalFilledBuyerAssets;
         uint256 totalUnits;
@@ -112,9 +145,13 @@ contract TakeBundler {
         require(totalFilledBuyerAssets == targetBuyerAssets, "insufficient liquidity");
         require(totalUnits >= minUnits, "units below min");
         require(totalUnits <= maxUnits, "units above max");
+
+        _sweepAndRevoke(midnight, loanToken);
     }
 
     /// @dev Same as bundleTakeUnits but targets seller assets.
+    /// @dev Only supports buy offers because for sell offers the bundler does not know how many buyer assets it
+    /// needs to pull from msg.sender.
     /// @dev sellerAssetsToUnits is evaluated before midnight.take, so reverts there (e.g. underflow when offerPrice <
     /// tradingFee) are not caught by the try/catch and will abort the bundle.
     /// @dev Requires a non-empty takes array.
@@ -126,8 +163,9 @@ contract TakeBundler {
         Take[] calldata takes,
         uint256 minUnits,
         uint256 maxUnits
-    ) external {
+    ) external nonReentrant {
         require(taker == msg.sender || midnight.isAuthorized(taker, msg.sender), "unauthorized");
+        require(takes[0].offer.buy, "sell offers unsupported");
         bytes32 id = midnight.touchObligation(takes[0].offer.obligation); // to have the correct trading fees.
 
         uint256 totalFilledSellerAssets;
@@ -159,5 +197,18 @@ contract TakeBundler {
         require(totalFilledSellerAssets == targetSellerAssets, "insufficient liquidity");
         require(totalUnits >= minUnits, "units below min");
         require(totalUnits <= maxUnits, "units above max");
+    }
+
+    /// @dev Revokes Midnight's allowance and returns any residual loan-token balance to `msg.sender`.
+    function _sweepAndRevoke(Midnight midnight, address loanToken) private {
+        _approve(loanToken, address(midnight), 0);
+        uint256 residual = IERC20(loanToken).balanceOf(address(this));
+        if (residual > 0) SafeTransferLib.safeTransfer(loanToken, msg.sender, residual);
+    }
+
+    /// @dev Simplified version of OZ safeApprove.
+    function _approve(address token, address spender, uint256 value) private {
+        (bool success, bytes memory returndata) = token.call(abi.encodeCall(IERC20.approve, (spender, value)));
+        require(success && (returndata.length == 0 || abi.decode(returndata, (bool))), "approve failed");
     }
 }

--- a/test/BundlerTest.sol
+++ b/test/BundlerTest.sol
@@ -92,6 +92,67 @@ contract BundlerTest is BaseTest {
         takeBundler.bundleTakeUnits(
             midnight, 100, borrower, address(0), takes, 0, type(uint256).max, 0, type(uint256).max
         );
+
+        vm.prank(address(0xdead));
+        vm.expectRevert("unauthorized");
+        takeBundler.bundleTakeBuyerAssets(midnight, 100, borrower, address(0), takes, 0, type(uint256).max);
+
+        vm.prank(address(0xdead));
+        vm.expectRevert("unauthorized");
+        takeBundler.bundleTakeSellerAssets(midnight, 100, borrower, address(0), takes, 0, type(uint256).max);
+    }
+
+    /// @dev Two sequential sell-offer calls must both succeed and both end with zero Midnight allowance. The revoke
+    /// is critical because `midnight` is a caller-supplied parameter — leaving a standing approval would let an
+    /// attacker pass their own contract as `midnight` to trap a max allowance.
+    function testAllowanceRevokedOnEveryCall() public {
+        _zeroObligationTradingFees();
+        _convertOffersToSell(100, 100);
+        collateralize(obligation, borrower, 100);
+
+        TakeBundler.Take[] memory takes = new TakeBundler.Take[](1);
+        takes[0] = TakeBundler.Take({
+            offer: offers[0], units: 100, sig: sig([offers[0]]), root: root([offers[0]]), proof: proof([offers[0]])
+        });
+
+        assertEq(loanToken.allowance(address(takeBundler), address(midnight)), 0, "precondition");
+
+        _primeLenderAsBuyerTaker(1);
+        vm.prank(lender);
+        takeBundler.bundleTakeBuyerAssets(midnight, 1, lender, address(0), takes, 0, type(uint256).max);
+        assertEq(loanToken.allowance(address(takeBundler), address(midnight)), 0, "revoked after first");
+
+        _primeLenderAsBuyerTaker(1);
+        vm.prank(lender);
+        takeBundler.bundleTakeBuyerAssets(midnight, 1, lender, address(0), takes, 0, type(uint256).max);
+        assertEq(loanToken.allowance(address(takeBundler), address(midnight)), 0, "revoked after second");
+    }
+
+    /// @dev Fees are snapshotted on the obligation at first touch, so the obligation-level values must be rewritten
+    /// rather than the defaults.
+    function _zeroObligationTradingFees() internal {
+        for (uint256 i; i <= 6; i++) {
+            midnight.setObligationTradingFee(id, i, 0);
+        }
+    }
+
+    function _convertOffersToSell(uint256 offerUnits0, uint256 offerUnits1) internal {
+        offers[0].buy = false;
+        offers[0].maker = borrower;
+        offers[0].receiverIfMakerIsSeller = borrower;
+        offers[0].maxUnits = offerUnits0;
+        offers[1].buy = false;
+        offers[1].maker = borrower;
+        offers[1].receiverIfMakerIsSeller = borrower;
+        offers[1].maxUnits = offerUnits1;
+    }
+
+    function _primeLenderAsBuyerTaker(uint256 amount) internal {
+        deal(address(loanToken), lender, amount);
+        vm.prank(lender);
+        loanToken.approve(address(takeBundler), amount);
+        vm.prank(lender);
+        midnight.setIsAuthorized(lender, address(takeBundler), true);
     }
 
     function testBundleTakeUnits(uint256 offerUnits0, uint256 offerUnits1, uint256 units) public {
@@ -138,6 +199,112 @@ contract BundlerTest is BaseTest {
                 midnight, units, borrower, borrower, takes, 0, type(uint256).max, 0, type(uint256).max
             );
         }
+    }
+
+    function testBundleTakeUnitsSellOffers(uint256 offerUnits0, uint256 offerUnits1, uint256 targetUnits) public {
+        _zeroObligationTradingFees();
+
+        targetUnits = bound(targetUnits, 1, uint256(type(uint128).max) / 2);
+        _convertOffersToSell(offerUnits0, offerUnits1);
+
+        uint256 price = TickLib.tickToPrice(MAX_TICK);
+        uint256 fromOffer0 = UtilsLib.min(targetUnits, offerUnits0);
+        uint256 fromOffer1 = targetUnits - fromOffer0;
+        uint256 expectedBuyerAssets = fromOffer0.mulDivUp(price, WAD) + fromOffer1.mulDivUp(price, WAD);
+
+        // Extra slack on the pull so the sweep has something to refund.
+        uint256 slack = 12345;
+        uint256 maxBuyerAssets = expectedBuyerAssets + slack;
+        _primeLenderAsBuyerTaker(maxBuyerAssets);
+        collateralize(obligation, borrower, targetUnits + 1);
+        _authorizeBundler();
+
+        TakeBundler.Take[] memory takes = new TakeBundler.Take[](2);
+        takes[0] = TakeBundler.Take({
+            offer: offers[0],
+            units: offerUnits0,
+            sig: sig([offers[0]]),
+            root: root([offers[0]]),
+            proof: proof([offers[0]])
+        });
+        takes[1] = TakeBundler.Take({
+            offer: offers[1],
+            units: offerUnits1,
+            sig: sig([offers[1]]),
+            root: root([offers[1]]),
+            proof: proof([offers[1]])
+        });
+
+        uint256 lenderBalanceBefore = loanToken.balanceOf(lender);
+
+        if (offerUnits1 >= targetUnits - fromOffer0) {
+            vm.prank(lender);
+            takeBundler.bundleTakeUnits(
+                midnight, targetUnits, lender, address(0), takes, 0, maxBuyerAssets, 0, type(uint256).max
+            );
+
+            uint256 consumed0 = midnight.consumed(offers[0].maker, offers[0].group);
+            uint256 consumed1 = midnight.consumed(offers[1].maker, offers[1].group);
+            assertEq(consumed0, fromOffer0, "consumed offer 0");
+            assertEq(consumed0 + consumed1, midnight.debtOf(id, borrower), "total consumed");
+            assertEq(midnight.debtOf(id, borrower), targetUnits, "debt");
+            assertEq(
+                lenderBalanceBefore - loanToken.balanceOf(lender),
+                expectedBuyerAssets,
+                "lender paid buyer assets (slack refunded)"
+            );
+            assertEq(loanToken.balanceOf(address(takeBundler)), 0, "bundler drained");
+        } else {
+            vm.prank(lender);
+            vm.expectRevert("insufficient liquidity");
+            takeBundler.bundleTakeUnits(
+                midnight, targetUnits, lender, address(0), takes, 0, maxBuyerAssets, 0, type(uint256).max
+            );
+        }
+    }
+
+    function testBundlerSweepsLeftoverDonations() public {
+        _zeroObligationTradingFees();
+
+        uint256 donation = 777e18;
+        uint256 target = 10;
+        offers[0].maxUnits = 100;
+        offers[1].maxUnits = 100;
+        collateralize(obligation, borrower, target * 2 + 10);
+        _authorizeBundler();
+
+        TakeBundler.Take[] memory takes = new TakeBundler.Take[](1);
+        takes[0] = TakeBundler.Take({
+            offer: offers[0], units: 100, sig: sig([offers[0]]), root: root([offers[0]]), proof: proof([offers[0]])
+        });
+
+        // Buy-offer path: sweep drains bundler to taker.
+        deal(address(loanToken), address(takeBundler), donation);
+        uint256 borrowerBefore = loanToken.balanceOf(borrower);
+        vm.prank(borrower);
+        takeBundler.bundleTakeUnits(
+            midnight, target, borrower, borrower, takes, 0, type(uint256).max, 0, type(uint256).max
+        );
+        assertEq(loanToken.balanceOf(address(takeBundler)), 0, "bundler drained");
+        assertGe(loanToken.balanceOf(borrower) - borrowerBefore, donation, "donation swept");
+
+        // Sell-offer path: pull + sweep must drain both residual and donation to lender.
+        _convertOffersToSell(100, 100);
+        TakeBundler.Take[] memory sellTakes = new TakeBundler.Take[](1);
+        sellTakes[0] = TakeBundler.Take({
+            offer: offers[0], units: 100, sig: sig([offers[0]]), root: root([offers[0]]), proof: proof([offers[0]])
+        });
+        uint256 slack = 7;
+        uint256 maxBuyerAssets = target + slack;
+        _primeLenderAsBuyerTaker(maxBuyerAssets);
+        deal(address(loanToken), address(takeBundler), donation);
+        uint256 lenderBefore = loanToken.balanceOf(lender);
+        vm.prank(lender);
+        takeBundler.bundleTakeUnits(
+            midnight, target, lender, address(0), sellTakes, 0, maxBuyerAssets, 0, type(uint256).max
+        );
+        assertEq(loanToken.balanceOf(address(takeBundler)), 0, "bundler drained (sell)");
+        assertEq(loanToken.balanceOf(lender), lenderBefore + donation - target, "donation + slack swept");
     }
 
     function testBundleTakeBuyerAssets(uint256 offerUnits0, uint256 offerUnits1, uint256 targetBuyerAssets) public {
@@ -370,5 +537,65 @@ contract BundlerTest is BaseTest {
         takeBundler.bundleTakeUnits(
             midnight, targetUnits, borrower, borrower, takes, minBuyerAssets, type(uint256).max, 0, type(uint256).max
         );
+    }
+
+    function testBundleTakeBuyerAssetsSellOffers(uint256 offerUnits0, uint256 offerUnits1, uint256 targetBuyerAssets)
+        public
+    {
+        _zeroObligationTradingFees();
+
+        targetBuyerAssets = bound(targetBuyerAssets, 1, uint256(type(uint128).max) / 2);
+        _convertOffersToSell(offerUnits0, offerUnits1);
+
+        uint256 price = TickLib.tickToPrice(MAX_TICK);
+        uint256 units = targetBuyerAssets.mulDivDown(WAD, price);
+        uint256 fromOffer0 = UtilsLib.min(units, offerUnits0);
+
+        collateralize(obligation, borrower, units + 1);
+        _primeLenderAsBuyerTaker(targetBuyerAssets);
+        _authorizeBundler();
+
+        TakeBundler.Take[] memory takes = new TakeBundler.Take[](2);
+        takes[0] = TakeBundler.Take({
+            offer: offers[0],
+            units: offerUnits0,
+            sig: sig([offers[0]]),
+            root: root([offers[0]]),
+            proof: proof([offers[0]])
+        });
+        takes[1] = TakeBundler.Take({
+            offer: offers[1],
+            units: offerUnits1,
+            sig: sig([offers[1]]),
+            root: root([offers[1]]),
+            proof: proof([offers[1]])
+        });
+
+        uint256 lenderBalanceBefore = loanToken.balanceOf(lender);
+        uint256 borrowerBalanceBefore = loanToken.balanceOf(borrower);
+
+        if (offerUnits1 >= units - fromOffer0) {
+            vm.prank(lender);
+            takeBundler.bundleTakeBuyerAssets(
+                midnight, targetBuyerAssets, lender, address(0), takes, 0, type(uint256).max
+            );
+
+            uint256 consumed0 = midnight.consumed(offers[0].maker, offers[0].group);
+            uint256 consumed1 = midnight.consumed(offers[1].maker, offers[1].group);
+            assertEq(consumed0, fromOffer0, "consumed offer 0");
+            assertEq(consumed0 + consumed1, midnight.debtOf(id, borrower), "total consumed");
+            assertEq(lenderBalanceBefore - loanToken.balanceOf(lender), targetBuyerAssets, "lender paid");
+            assertEq(loanToken.balanceOf(address(takeBundler)), 0, "bundler drained");
+            // Maker is seller with receiverIfMakerIsSeller == borrower; the trading fee stays on Midnight.
+            uint256 borrowerGain = loanToken.balanceOf(borrower) - borrowerBalanceBefore;
+            assertGt(borrowerGain, 0, "borrower received proceeds");
+            assertLe(borrowerGain, targetBuyerAssets, "proceeds bounded");
+        } else {
+            vm.prank(lender);
+            vm.expectRevert("insufficient liquidity");
+            takeBundler.bundleTakeBuyerAssets(
+                midnight, targetBuyerAssets, lender, address(0), takes, 0, type(uint256).max
+            );
+        }
     }
 }


### PR DESCRIPTION
## Problem

Sell-offer takes reverted. `Midnight.take` resolves `payer = msg.sender` (the bundler) for sell offers with no buyer callback, but the bundler held no loan tokens. Every `safeTransferFrom` failed inside the take loop, was swallowed by try/catch, and the call reverted with `"insufficient liquidity"`. The take-lend flow was fully broken.

## Fix

On sell offers, pull the loan token from `msg.sender` up front, approve Midnight for the exact pull amount, run the bundle, then revoke the allowance and sweep any residual back to `msg.sender` on exit.

- **Pull from `msg.sender`** (not `taker`) — matches Midnight's convention.
- **Exact approve amount** — bounded exposure, not `type(uint256).max`.
- **Always revoke on exit** — `midnight` is a caller-supplied parameter, so a standing approval would let an attacker pass their own contract as `midnight` and trap a max allowance. The revoke enforces `allowance == 0` before and after every call.
- **`bundleTakeSellerAssets` restricted to buy offers** (`require(takes[0].offer.buy)`) — sell offers need the buyer-side amount up-front which the seller-asset target doesn't provide.
- **`_approve` helper** — low-level call for USDT-style tokens (no return value). No OZ retry path needed because `_sweepAndRevoke` zeros the allowance on exit, so approvals always start from a zero baseline. Probs replace this. 
- **Reentrancy guard**: a malicious maker can set `offer.callback` and, during the callback Midnight fires after pulling tokens from the bundler, reenter any entry point with `target=0` to drain `bundleTakeUnits`'s unconsumed slack. Added for now. 

> Targeting `mvp/limits` as this is what we are deploying for alpha. 
> Deployed to 0x487e6263188eFD547F6eFD9491AD902b5173ee72 on Base