### PR TITLE
separate callbacks

### DIFF
--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -10,7 +10,7 @@ import {SafeTransferLib} from "./libraries/SafeTransferLib.sol";
 import "./libraries/ConstantsLib.sol";
 import {IOracle} from "./interfaces/IOracle.sol";
 import {IMidnight, Obligation, Offer, CollateralParams, ObligationState, Position} from "./interfaces/IMidnight.sol";
-import {ICallbacks, IFlashLoanCallback} from "./interfaces/ICallbacks.sol";
+import {ITakeCallback, ILiquidateCallback, IRepayCallback, IFlashLoanCallback} from "./interfaces/ICallbacks.sol";
 import {IRatifier} from "./interfaces/IRatifier.sol";
 import {IEnterGate, ILiquidatorGate} from "./interfaces/IGate.sol";
 import {EventsLib} from "./libraries/EventsLib.sol";
@@ -384,7 +384,7 @@ contract Midnight is IMidnight {
         bool wasLocked = UtilsLib.tExchange(LIQUIDATION_LOCK_SLOT, id, seller, true);
         if (buyerCallback != address(0)) {
             require(
-                ICallbacks(buyerCallback).onBuy(id, offer.obligation, buyer, buyerAssets, units, buyerCallbackData)
+                ITakeCallback(buyerCallback).onBuy(id, offer.obligation, buyer, buyerAssets, units, buyerCallbackData)
                     == CALLBACK_SUCCESS,
                 InvalidBuyCallback()
             );
@@ -397,7 +397,8 @@ contract Midnight is IMidnight {
 
         if (sellerCallback != address(0)) {
             require(
-                ICallbacks(sellerCallback).onSell(id, offer.obligation, seller, sellerAssets, units, sellerCallbackData)
+                ITakeCallback(sellerCallback)
+                        .onSell(id, offer.obligation, seller, sellerAssets, units, sellerCallbackData)
                     == CALLBACK_SUCCESS,
                 InvalidSellCallback()
             );
@@ -440,7 +441,7 @@ contract Midnight is IMidnight {
         emit EventsLib.Repay(msg.sender, id, units, onBehalf);
 
         if (data.length > 0) {
-            ICallbacks(msg.sender).onRepay(id, obligation, units, onBehalf, data);
+            IRepayCallback(msg.sender).onRepay(id, obligation, units, onBehalf, data);
         }
 
         SafeTransferLib.safeTransferFrom(obligation.loanToken, msg.sender, address(this), units);
@@ -618,7 +619,7 @@ contract Midnight is IMidnight {
         SafeTransferLib.safeTransfer(obligation.collateralParams[collateralIndex].token, msg.sender, seizedAssets);
 
         if (data.length > 0) {
-            ICallbacks(msg.sender)
+            ILiquidateCallback(msg.sender)
                 .onLiquidate(id, obligation, collateralIndex, seizedAssets, repaidUnits, borrower, data);
         }
 

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -10,7 +10,13 @@ import {SafeTransferLib} from "./libraries/SafeTransferLib.sol";
 import "./libraries/ConstantsLib.sol";
 import {IOracle} from "./interfaces/IOracle.sol";
 import {IMidnight, Obligation, Offer, CollateralParams, ObligationState, Position} from "./interfaces/IMidnight.sol";
-import {ITakeCallback, ILiquidateCallback, IRepayCallback, IFlashLoanCallback} from "./interfaces/ICallbacks.sol";
+import {
+    IBuyCallback,
+    ISellCallback,
+    ILiquidateCallback,
+    IRepayCallback,
+    IFlashLoanCallback
+} from "./interfaces/ICallbacks.sol";
 import {IRatifier} from "./interfaces/IRatifier.sol";
 import {IEnterGate, ILiquidatorGate} from "./interfaces/IGate.sol";
 import {EventsLib} from "./libraries/EventsLib.sol";
@@ -384,7 +390,7 @@ contract Midnight is IMidnight {
         bool wasLocked = UtilsLib.tExchange(LIQUIDATION_LOCK_SLOT, id, seller, true);
         if (buyerCallback != address(0)) {
             require(
-                ITakeCallback(buyerCallback).onBuy(id, offer.obligation, buyer, buyerAssets, units, buyerCallbackData)
+                IBuyCallback(buyerCallback).onBuy(id, offer.obligation, buyer, buyerAssets, units, buyerCallbackData)
                     == CALLBACK_SUCCESS,
                 InvalidBuyCallback()
             );
@@ -397,7 +403,7 @@ contract Midnight is IMidnight {
 
         if (sellerCallback != address(0)) {
             require(
-                ITakeCallback(sellerCallback)
+                ISellCallback(sellerCallback)
                         .onSell(id, offer.obligation, seller, sellerAssets, units, sellerCallbackData)
                     == CALLBACK_SUCCESS,
                 InvalidSellCallback()

--- a/src/interfaces/ICallbacks.sol
+++ b/src/interfaces/ICallbacks.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.5.0;
 
 import {Obligation} from "./IMidnight.sol";
 
-interface ICallbacks {
+interface ITakeCallback {
     function onBuy(
         bytes32 id,
         Obligation memory obligation,
@@ -21,6 +21,9 @@ interface ICallbacks {
         uint256 units,
         bytes memory data
     ) external returns (bytes32);
+}
+
+interface ILiquidateCallback {
     function onLiquidate(
         bytes32 id,
         Obligation memory obligation,
@@ -30,6 +33,9 @@ interface ICallbacks {
         address borrower,
         bytes memory data
     ) external;
+}
+
+interface IRepayCallback {
     function onRepay(
         bytes32 obligationId,
         Obligation memory obligation,

--- a/src/interfaces/ICallbacks.sol
+++ b/src/interfaces/ICallbacks.sol
@@ -4,46 +4,23 @@ pragma solidity >=0.5.0;
 
 import {Obligation} from "./IMidnight.sol";
 
-interface ITakeCallback {
-    function onBuy(
-        bytes32 id,
-        Obligation memory obligation,
-        address buyer,
-        uint256 buyerAssets,
-        uint256 units,
-        bytes memory data
-    ) external returns (bytes32);
-    function onSell(
-        bytes32 id,
-        Obligation memory obligation,
-        address seller,
-        uint256 sellerAssets,
-        uint256 units,
-        bytes memory data
-    ) external returns (bytes32);
+// forgefmt: disable-start
+interface IBuyCallback {
+    function onBuy(bytes32 id, Obligation memory obligation, address buyer, uint256 buyerAssets, uint256 units, bytes memory data) external returns (bytes32);
+}
+
+interface ISellCallback {
+    function onSell(bytes32 id, Obligation memory obligation, address seller, uint256 sellerAssets, uint256 units, bytes memory data) external returns (bytes32);
 }
 
 interface ILiquidateCallback {
-    function onLiquidate(
-        bytes32 id,
-        Obligation memory obligation,
-        uint256 collateralIndex,
-        uint256 seizedAssets,
-        uint256 repaidUnits,
-        address borrower,
-        bytes memory data
-    ) external;
+    function onLiquidate(bytes32 id, Obligation memory obligation, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, bytes memory data) external;
 }
 
 interface IRepayCallback {
-    function onRepay(
-        bytes32 obligationId,
-        Obligation memory obligation,
-        uint256 units,
-        address onBehalf,
-        bytes memory data
-    ) external;
+    function onRepay(bytes32 obligationId, Obligation memory obligation, uint256 units, address onBehalf, bytes memory data) external;
 }
+// forgefmt: disable-end
 
 interface IFlashLoanCallback {
     function onFlashLoan(address token, uint256 amount, bytes memory data) external;

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 import {IMidnight, Obligation, CollateralParams} from "../src/interfaces/IMidnight.sol";
-import {ITakeCallback, ILiquidateCallback, IRepayCallback} from "../src/interfaces/ICallbacks.sol";
+import {IBuyCallback, ISellCallback, ILiquidateCallback, IRepayCallback} from "../src/interfaces/ICallbacks.sol";
 import {Midnight} from "../src/Midnight.sol";
 import {IdLib} from "../src/libraries/IdLib.sol";
 
@@ -654,8 +654,8 @@ contract OtherFunctionsTest is BaseTest {
 
     function testMidnightRevertsOnCallbacks(address msgSender, bytes calldata data) public {
         bytes4[4] memory selectors = [
-            ITakeCallback.onBuy.selector,
-            ITakeCallback.onSell.selector,
+            IBuyCallback.onBuy.selector,
+            ISellCallback.onSell.selector,
             ILiquidateCallback.onLiquidate.selector,
             IRepayCallback.onRepay.selector
         ];

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 import {IMidnight, Obligation, CollateralParams} from "../src/interfaces/IMidnight.sol";
-import {ICallbacks} from "../src/interfaces/ICallbacks.sol";
+import {ITakeCallback, ILiquidateCallback, IRepayCallback} from "../src/interfaces/ICallbacks.sol";
 import {Midnight} from "../src/Midnight.sol";
 import {IdLib} from "../src/libraries/IdLib.sol";
 
@@ -654,10 +654,10 @@ contract OtherFunctionsTest is BaseTest {
 
     function testMidnightRevertsOnCallbacks(address msgSender, bytes calldata data) public {
         bytes4[4] memory selectors = [
-            ICallbacks.onBuy.selector,
-            ICallbacks.onSell.selector,
-            ICallbacks.onLiquidate.selector,
-            ICallbacks.onRepay.selector
+            ITakeCallback.onBuy.selector,
+            ITakeCallback.onSell.selector,
+            ILiquidateCallback.onLiquidate.selector,
+            IRepayCallback.onRepay.selector
         ];
         for (uint256 i = 0; i < selectors.length; i++) {
             vm.prank(msgSender);

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -3,7 +3,13 @@
 pragma solidity ^0.8.0;
 
 import {IMidnight, Obligation, CollateralParams} from "../src/interfaces/IMidnight.sol";
-import {IBuyCallback, ISellCallback, ILiquidateCallback, IRepayCallback, IFlashLoanCallback} from "../src/interfaces/ICallbacks.sol";
+import {
+    IBuyCallback,
+    ISellCallback,
+    ILiquidateCallback,
+    IRepayCallback,
+    IFlashLoanCallback
+} from "../src/interfaces/ICallbacks.sol";
 import {Midnight} from "../src/Midnight.sol";
 import {IdLib} from "../src/libraries/IdLib.sol";
 

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 import {IMidnight, Obligation, CollateralParams} from "../src/interfaces/IMidnight.sol";
-import {IBuyCallback, ISellCallback, ILiquidateCallback, IRepayCallback} from "../src/interfaces/ICallbacks.sol";
+import {IBuyCallback, ISellCallback, ILiquidateCallback, IRepayCallback, IFlashLoanCallback} from "../src/interfaces/ICallbacks.sol";
 import {Midnight} from "../src/Midnight.sol";
 import {IdLib} from "../src/libraries/IdLib.sol";
 
@@ -653,11 +653,12 @@ contract OtherFunctionsTest is BaseTest {
     }
 
     function testMidnightRevertsOnCallbacks(address msgSender, bytes calldata data) public {
-        bytes4[4] memory selectors = [
+        bytes4[5] memory selectors = [
             IBuyCallback.onBuy.selector,
             ISellCallback.onSell.selector,
             ILiquidateCallback.onLiquidate.selector,
-            IRepayCallback.onRepay.selector
+            IRepayCallback.onRepay.selector,
+            IFlashLoanCallback.onFlashLoan.selector
         ];
         for (uint256 i = 0; i < selectors.length; i++) {
             vm.prank(msgSender);

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -9,7 +9,7 @@ import {Midnight} from "../src/Midnight.sol";
 import {WAD, CALLBACK_SUCCESS, MAX_CONTINUOUS_FEE} from "../src/libraries/ConstantsLib.sol";
 import {UtilsLib} from "../src/libraries/UtilsLib.sol";
 import {TickLib, MAX_TICK} from "../src/libraries/TickLib.sol";
-import {ITakeCallback} from "../src/interfaces/ICallbacks.sol";
+import {IBuyCallback, ISellCallback} from "../src/interfaces/ICallbacks.sol";
 import {IRatifier} from "../src/interfaces/IRatifier.sol";
 import {IdLib} from "../src/libraries/IdLib.sol";
 import {BaseTest} from "./BaseTest.sol";
@@ -1560,7 +1560,7 @@ contract TakeTest is BaseTest {
     }
 }
 
-contract InvalidBuyCallback is ITakeCallback {
+contract InvalidBuyCallback is IBuyCallback {
     function onBuy(bytes32, Obligation memory, address, uint256, uint256, bytes memory)
         external
         pure
@@ -1568,17 +1568,9 @@ contract InvalidBuyCallback is ITakeCallback {
     {
         return bytes32(0);
     }
-
-    function onSell(bytes32, Obligation memory, address, uint256, uint256, bytes memory)
-        external
-        pure
-        returns (bytes32)
-    {
-        return CALLBACK_SUCCESS;
-    }
 }
 
-contract BorrowCallback is ITakeCallback {
+contract BorrowCallback is ISellCallback {
     bytes public recordedData;
     bytes32 public recordedId;
 
@@ -1595,17 +1587,9 @@ contract BorrowCallback is ITakeCallback {
         Midnight(msg.sender).supplyCollateral(obligation, collateralIndex, amount, seller);
         return CALLBACK_SUCCESS;
     }
-
-    function onBuy(bytes32, Obligation memory, address, uint256, uint256, bytes memory)
-        external
-        pure
-        returns (bytes32)
-    {
-        return CALLBACK_SUCCESS;
-    }
 }
 
-contract ReentrantLiquidateBorrowCallback is ITakeCallback {
+contract ReentrantLiquidateBorrowCallback is ISellCallback {
     bool public liquidateSucceeded;
     bytes4 public liquidateErrorSelector;
 
@@ -1635,17 +1619,9 @@ contract ReentrantLiquidateBorrowCallback is ITakeCallback {
         oracle.setPrice(healthyPrice);
         return CALLBACK_SUCCESS;
     }
-
-    function onBuy(bytes32, Obligation memory, address, uint256, uint256, bytes memory)
-        external
-        pure
-        returns (bytes32)
-    {
-        return CALLBACK_SUCCESS;
-    }
 }
 
-contract NestedTakeReentrantLiquidateCallback is ITakeCallback {
+contract NestedTakeReentrantLiquidateCallback is ISellCallback {
     bool public reentered;
     bool public liquidateSucceeded;
     bytes4 public liquidateErrorSelector;
@@ -1712,17 +1688,9 @@ contract NestedTakeReentrantLiquidateCallback is ITakeCallback {
         }
         return CALLBACK_SUCCESS;
     }
-
-    function onBuy(bytes32, Obligation memory, address, uint256, uint256, bytes memory)
-        external
-        pure
-        returns (bytes32)
-    {
-        return CALLBACK_SUCCESS;
-    }
 }
 
-contract LendCallback is ITakeCallback {
+contract LendCallback is IBuyCallback {
     bytes public recordedData;
 
     bytes32 public recordedId;
@@ -1737,25 +1705,9 @@ contract LendCallback is ITakeCallback {
         ERC20(obligation.loanToken).approve(msg.sender, buyerAssets);
         return CALLBACK_SUCCESS;
     }
-
-    function onSell(bytes32, Obligation memory, address, uint256, uint256, bytes memory)
-        external
-        pure
-        returns (bytes32)
-    {
-        return CALLBACK_SUCCESS;
-    }
 }
 
-contract InvalidSellCallback is ITakeCallback {
-    function onBuy(bytes32, Obligation memory, address, uint256, uint256, bytes memory)
-        external
-        pure
-        returns (bytes32)
-    {
-        return CALLBACK_SUCCESS;
-    }
-
+contract InvalidSellCallback is ISellCallback {
     function onSell(bytes32, Obligation memory, address, uint256, uint256, bytes memory)
         external
         pure

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -9,7 +9,7 @@ import {Midnight} from "../src/Midnight.sol";
 import {WAD, CALLBACK_SUCCESS, MAX_CONTINUOUS_FEE} from "../src/libraries/ConstantsLib.sol";
 import {UtilsLib} from "../src/libraries/UtilsLib.sol";
 import {TickLib, MAX_TICK} from "../src/libraries/TickLib.sol";
-import {ICallbacks} from "../src/interfaces/ICallbacks.sol";
+import {ITakeCallback} from "../src/interfaces/ICallbacks.sol";
 import {IRatifier} from "../src/interfaces/IRatifier.sol";
 import {IdLib} from "../src/libraries/IdLib.sol";
 import {BaseTest} from "./BaseTest.sol";
@@ -1560,7 +1560,7 @@ contract TakeTest is BaseTest {
     }
 }
 
-contract InvalidBuyCallback is ICallbacks {
+contract InvalidBuyCallback is ITakeCallback {
     function onBuy(bytes32, Obligation memory, address, uint256, uint256, bytes memory)
         external
         pure
@@ -1576,13 +1576,9 @@ contract InvalidBuyCallback is ICallbacks {
     {
         return CALLBACK_SUCCESS;
     }
-
-    function onLiquidate(bytes32, Obligation memory, uint256, uint256, uint256, address, bytes memory) external {}
-
-    function onRepay(bytes32, Obligation memory, uint256, address, bytes memory) external {}
 }
 
-contract BorrowCallback is ICallbacks {
+contract BorrowCallback is ITakeCallback {
     bytes public recordedData;
     bytes32 public recordedId;
 
@@ -1607,13 +1603,9 @@ contract BorrowCallback is ICallbacks {
     {
         return CALLBACK_SUCCESS;
     }
-
-    function onLiquidate(bytes32, Obligation memory, uint256, uint256, uint256, address, bytes memory) external {}
-
-    function onRepay(bytes32, Obligation memory, uint256, address, bytes memory) external {}
 }
 
-contract ReentrantLiquidateBorrowCallback is ICallbacks {
+contract ReentrantLiquidateBorrowCallback is ITakeCallback {
     bool public liquidateSucceeded;
     bytes4 public liquidateErrorSelector;
 
@@ -1651,13 +1643,9 @@ contract ReentrantLiquidateBorrowCallback is ICallbacks {
     {
         return CALLBACK_SUCCESS;
     }
-
-    function onLiquidate(bytes32, Obligation memory, uint256, uint256, uint256, address, bytes memory) external {}
-
-    function onRepay(bytes32, Obligation memory, uint256, address, bytes memory) external {}
 }
 
-contract NestedTakeReentrantLiquidateCallback is ICallbacks {
+contract NestedTakeReentrantLiquidateCallback is ITakeCallback {
     bool public reentered;
     bool public liquidateSucceeded;
     bytes4 public liquidateErrorSelector;
@@ -1732,13 +1720,9 @@ contract NestedTakeReentrantLiquidateCallback is ICallbacks {
     {
         return CALLBACK_SUCCESS;
     }
-
-    function onLiquidate(bytes32, Obligation memory, uint256, uint256, uint256, address, bytes memory) external {}
-
-    function onRepay(bytes32, Obligation memory, uint256, address, bytes memory) external {}
 }
 
-contract LendCallback is ICallbacks {
+contract LendCallback is ITakeCallback {
     bytes public recordedData;
 
     bytes32 public recordedId;
@@ -1761,13 +1745,9 @@ contract LendCallback is ICallbacks {
     {
         return CALLBACK_SUCCESS;
     }
-
-    function onLiquidate(bytes32, Obligation memory, uint256, uint256, uint256, address, bytes memory) external {}
-
-    function onRepay(bytes32, Obligation memory, uint256, address, bytes memory) external {}
 }
 
-contract InvalidSellCallback is ICallbacks {
+contract InvalidSellCallback is ITakeCallback {
     function onBuy(bytes32, Obligation memory, address, uint256, uint256, bytes memory)
         external
         pure
@@ -1783,10 +1763,6 @@ contract InvalidSellCallback is ICallbacks {
     {
         return bytes32(0);
     }
-
-    function onLiquidate(bytes32, Obligation memory, uint256, uint256, uint256, address, bytes memory) external {}
-
-    function onRepay(bytes32, Obligation memory, uint256, address, bytes memory) external {}
 }
 
 contract RatifyCallback is IRatifier {


### PR DESCRIPTION
Contracts that want to implement the interface will need to declare the unused functions. Or not actually use this interface but then why have the interface. 

For instance the vault v2 adapter will have buy and sell callbacks but not liquidate and repay so it does

```solidity
    function onLiquidate(bytes32, Obligation memory, uint256, uint256, uint256, address, bytes memory) external pure {
        revert();
    }

    function onRepay(bytes32, Obligation memory, uint256, address, bytes memory) external pure {
        revert();
    }
```