### PR TITLE
bundler: supply/withdraw collateral batch

### DIFF
--- a/src/periphery/TakeBundler.sol
+++ b/src/periphery/TakeBundler.sol
@@ -238,6 +238,7 @@ contract TakeBundler is ITakeBundler {
         require(totalUnits <= maxUnits, UnitsAboveMax());
     }
 
+    /// @dev USDT won't break because the allowance is reset to 0 after supplyCollateral.
     function _safeApprove(address token, address spender, uint256 value) internal {
         (bool success, bytes memory returndata) = token.call(abi.encodeCall(IERC20.approve, (spender, value)));
         if (!success) {

--- a/src/periphery/TakeBundler.sol
+++ b/src/periphery/TakeBundler.sol
@@ -2,9 +2,11 @@
 // Copyright (c) 2025 Morpho Association
 pragma solidity 0.8.34;
 
-import {IMidnight} from "../interfaces/IMidnight.sol";
-import {ITakeBundler, Take} from "./interfaces/ITakeBundler.sol";
+import {IMidnight, Obligation} from "../interfaces/IMidnight.sol";
+import {IERC20} from "../interfaces/IERC20.sol";
+import {ITakeBundler, Take, CollateralTransfer} from "./interfaces/ITakeBundler.sol";
 import {UtilsLib} from "../libraries/UtilsLib.sol";
+import {SafeTransferLib} from "../libraries/SafeTransferLib.sol";
 import {TakeAmountsLib} from "./TakeAmountsLib.sol";
 
 contract TakeBundler is ITakeBundler {
@@ -20,7 +22,9 @@ contract TakeBundler is ITakeBundler {
         address taker,
         Take[] calldata takes,
         uint256 minBuyerAssets,
-        uint256 maxBuyerAssets
+        uint256 maxBuyerAssets,
+        CollateralTransfer[] calldata collateralWithdrawals,
+        address collateralReceiver
     ) external {
         require(taker == msg.sender || IMidnight(midnight).isAuthorized(taker, msg.sender), Unauthorized());
 
@@ -50,6 +54,18 @@ contract TakeBundler is ITakeBundler {
         require(totalFilledUnits == targetUnits, InsufficientLiquidity());
         require(totalBuyerAssets >= minBuyerAssets, BuyerAssetsBelowMin());
         require(totalBuyerAssets <= maxBuyerAssets, BuyerAssetsAboveMax());
+
+        Obligation memory obligation = takes[0].offer.obligation;
+        for (uint256 i; i < collateralWithdrawals.length; i++) {
+            IMidnight(midnight)
+                .withdrawCollateral(
+                    obligation,
+                    collateralWithdrawals[i].collateralIndex,
+                    collateralWithdrawals[i].assets,
+                    taker,
+                    collateralReceiver
+                );
+        }
     }
 
     /// @dev See buyUnitsTarget.
@@ -60,9 +76,21 @@ contract TakeBundler is ITakeBundler {
         address receiverIfTakerIsSeller,
         Take[] calldata takes,
         uint256 minSellerAssets,
-        uint256 maxSellerAssets
+        uint256 maxSellerAssets,
+        CollateralTransfer[] calldata collateralSupplies
     ) external {
         require(taker == msg.sender || IMidnight(midnight).isAuthorized(taker, msg.sender), Unauthorized());
+
+        Obligation memory obligation = takes[0].offer.obligation;
+        for (uint256 i; i < collateralSupplies.length; i++) {
+            address token = obligation.collateralParams[collateralSupplies[i].collateralIndex].token;
+            SafeTransferLib.safeTransferFrom(token, msg.sender, address(this), collateralSupplies[i].assets);
+            _safeApprove(token, midnight, collateralSupplies[i].assets);
+            IMidnight(midnight)
+                .supplyCollateral(
+                    obligation, collateralSupplies[i].collateralIndex, collateralSupplies[i].assets, taker
+                );
+        }
 
         uint256 totalFilledUnits;
         uint256 totalSellerAssets;
@@ -99,7 +127,9 @@ contract TakeBundler is ITakeBundler {
         address taker,
         Take[] calldata takes,
         uint256 minUnits,
-        uint256 maxUnits
+        uint256 maxUnits,
+        CollateralTransfer[] calldata collateralWithdrawals,
+        address collateralReceiver
     ) external {
         require(taker == msg.sender || IMidnight(midnight).isAuthorized(taker, msg.sender), Unauthorized());
         // touchObligation to have the correct trading fees.
@@ -136,6 +166,18 @@ contract TakeBundler is ITakeBundler {
         require(totalFilledBuyerAssets == targetBuyerAssets, InsufficientLiquidity());
         require(totalUnits >= minUnits, UnitsBelowMin());
         require(totalUnits <= maxUnits, UnitsAboveMax());
+
+        Obligation memory obligation = takes[0].offer.obligation;
+        for (uint256 i; i < collateralWithdrawals.length; i++) {
+            IMidnight(midnight)
+                .withdrawCollateral(
+                    obligation,
+                    collateralWithdrawals[i].collateralIndex,
+                    collateralWithdrawals[i].assets,
+                    taker,
+                    collateralReceiver
+                );
+        }
     }
 
     /// @dev See buyUnitsTarget.
@@ -146,9 +188,22 @@ contract TakeBundler is ITakeBundler {
         address receiverIfTakerIsSeller,
         Take[] calldata takes,
         uint256 minUnits,
-        uint256 maxUnits
+        uint256 maxUnits,
+        CollateralTransfer[] calldata collateralSupplies
     ) external {
         require(taker == msg.sender || IMidnight(midnight).isAuthorized(taker, msg.sender), Unauthorized());
+
+        Obligation memory obligation = takes[0].offer.obligation;
+        for (uint256 i; i < collateralSupplies.length; i++) {
+            address token = obligation.collateralParams[collateralSupplies[i].collateralIndex].token;
+            SafeTransferLib.safeTransferFrom(token, msg.sender, address(this), collateralSupplies[i].assets);
+            _safeApprove(token, midnight, collateralSupplies[i].assets);
+            IMidnight(midnight)
+                .supplyCollateral(
+                    obligation, collateralSupplies[i].collateralIndex, collateralSupplies[i].assets, taker
+                );
+        }
+
         // touchObligation to have the correct trading fees.
         bytes32 id = IMidnight(midnight).touchObligation(takes[0].offer.obligation);
 
@@ -183,5 +238,15 @@ contract TakeBundler is ITakeBundler {
         require(totalFilledSellerAssets == targetSellerAssets, InsufficientLiquidity());
         require(totalUnits >= minUnits, UnitsBelowMin());
         require(totalUnits <= maxUnits, UnitsAboveMax());
+    }
+
+    function _safeApprove(address token, address spender, uint256 value) internal {
+        (bool success, bytes memory returndata) = token.call(abi.encodeCall(IERC20.approve, (spender, value)));
+        if (!success) {
+            assembly ("memory-safe") {
+                revert(add(returndata, 0x20), mload(returndata))
+            }
+        }
+        require(returndata.length == 0 || abi.decode(returndata, (bool)));
     }
 }

--- a/src/periphery/TakeBundler.sol
+++ b/src/periphery/TakeBundler.sol
@@ -84,7 +84,7 @@ contract TakeBundler is ITakeBundler {
         Obligation memory obligation = takes[0].offer.obligation;
         for (uint256 i; i < collateralSupplies.length; i++) {
             address token = obligation.collateralParams[collateralSupplies[i].collateralIndex].token;
-            SafeTransferLib.safeTransferFrom(token, msg.sender, address(this), collateralSupplies[i].assets);
+            SafeTransferLib.safeTransferFrom(token, taker, address(this), collateralSupplies[i].assets);
             _safeApprove(token, midnight, collateralSupplies[i].assets);
             IMidnight(midnight)
                 .supplyCollateral(
@@ -196,7 +196,7 @@ contract TakeBundler is ITakeBundler {
         Obligation memory obligation = takes[0].offer.obligation;
         for (uint256 i; i < collateralSupplies.length; i++) {
             address token = obligation.collateralParams[collateralSupplies[i].collateralIndex].token;
-            SafeTransferLib.safeTransferFrom(token, msg.sender, address(this), collateralSupplies[i].assets);
+            SafeTransferLib.safeTransferFrom(token, taker, address(this), collateralSupplies[i].assets);
             _safeApprove(token, midnight, collateralSupplies[i].assets);
             IMidnight(midnight)
                 .supplyCollateral(

--- a/src/periphery/TakeBundler.sol
+++ b/src/periphery/TakeBundler.sol
@@ -69,6 +69,7 @@ contract TakeBundler is ITakeBundler {
     }
 
     /// @dev See buyUnitsTarget.
+    /// @dev The msg.sender should have approved the bundler to transfer enough collateral.
     function sellUnitsTarget(
         address midnight,
         uint256 targetUnits,
@@ -84,7 +85,7 @@ contract TakeBundler is ITakeBundler {
         Obligation memory obligation = takes[0].offer.obligation;
         for (uint256 i; i < collateralSupplies.length; i++) {
             address token = obligation.collateralParams[collateralSupplies[i].collateralIndex].token;
-            SafeTransferLib.safeTransferFrom(token, taker, address(this), collateralSupplies[i].assets);
+            SafeTransferLib.safeTransferFrom(token, msg.sender, address(this), collateralSupplies[i].assets);
             _safeApprove(token, midnight, collateralSupplies[i].assets);
             IMidnight(midnight)
                 .supplyCollateral(
@@ -181,6 +182,7 @@ contract TakeBundler is ITakeBundler {
     }
 
     /// @dev See buyUnitsTarget.
+    /// @dev The msg.sender should have approved the bundler to transfer enough collateral.
     function sellSellerAssetsTarget(
         address midnight,
         uint256 targetSellerAssets,
@@ -196,7 +198,7 @@ contract TakeBundler is ITakeBundler {
         Obligation memory obligation = takes[0].offer.obligation;
         for (uint256 i; i < collateralSupplies.length; i++) {
             address token = obligation.collateralParams[collateralSupplies[i].collateralIndex].token;
-            SafeTransferLib.safeTransferFrom(token, taker, address(this), collateralSupplies[i].assets);
+            SafeTransferLib.safeTransferFrom(token, msg.sender, address(this), collateralSupplies[i].assets);
             _safeApprove(token, midnight, collateralSupplies[i].assets);
             IMidnight(midnight)
                 .supplyCollateral(

--- a/src/periphery/interfaces/ITakeBundler.sol
+++ b/src/periphery/interfaces/ITakeBundler.sol
@@ -12,6 +12,11 @@ struct Take {
     bytes32[] proof;
 }
 
+struct CollateralTransfer {
+    uint256 collateralIndex;
+    uint256 assets;
+}
+
 interface ITakeBundler {
     /// ERRORS ///
     error BuyerAssetsAboveMax();
@@ -26,9 +31,9 @@ interface ITakeBundler {
 
     // forgefmt: disable-start
     /// FUNCTIONS ///
-    function buyUnitsTarget(address midnight, uint256 targetUnits, address taker, Take[] calldata takes, uint256 minBuyerAssets, uint256 maxBuyerAssets) external;
-    function sellUnitsTarget(address midnight, uint256 targetUnits, address taker, address receiverIfTakerIsSeller, Take[] calldata takes, uint256 minSellerAssets, uint256 maxSellerAssets) external;
-    function buyBuyerAssetsTarget(address midnight, uint256 targetBuyerAssets, address taker, Take[] calldata takes, uint256 minUnits, uint256 maxUnits) external;
-    function sellSellerAssetsTarget(address midnight, uint256 targetSellerAssets, address taker, address receiverIfTakerIsSeller, Take[] calldata takes, uint256 minUnits, uint256 maxUnits) external;
+    function buyUnitsTarget(address midnight, uint256 targetUnits, address taker, Take[] calldata takes, uint256 minBuyerAssets, uint256 maxBuyerAssets, CollateralTransfer[] calldata collateralWithdrawals, address collateralReceiver) external;
+    function sellUnitsTarget(address midnight, uint256 targetUnits, address taker, address receiverIfTakerIsSeller, Take[] calldata takes, uint256 minSellerAssets, uint256 maxSellerAssets, CollateralTransfer[] calldata collateralSupplies) external;
+    function buyBuyerAssetsTarget(address midnight, uint256 targetBuyerAssets, address taker, Take[] calldata takes, uint256 minUnits, uint256 maxUnits, CollateralTransfer[] calldata collateralWithdrawals, address collateralReceiver) external;
+    function sellSellerAssetsTarget(address midnight, uint256 targetSellerAssets, address taker, address receiverIfTakerIsSeller, Take[] calldata takes, uint256 minUnits, uint256 maxUnits, CollateralTransfer[] calldata collateralSupplies) external;
     // forgefmt: disable-end
 }

--- a/test/BundlerTest.sol
+++ b/test/BundlerTest.sol
@@ -303,24 +303,43 @@ contract BundlerTest is BaseTest {
 
     // Collateral transfers.
 
-    function testBuyUnitsTargetWithCollateralWithdrawal() public {
+    function _collateralAmount(uint256 collateralIndex, uint256 debt) internal view returns (uint256) {
+        uint256 oraclePrice = Oracle(obligation.collateralParams[collateralIndex].oracle).price();
+        return debt.mulDivUp(WAD, obligation.collateralParams[collateralIndex].lltv).mulDivUp(
+            ORACLE_PRICE_SCALE, oraclePrice
+        );
+    }
+
+    function _supplyBorrowerCollateral(uint256 numCollaterals, uint256 units)
+        internal
+        returns (uint256[] memory amounts)
+    {
+        amounts = new uint256[](numCollaterals);
+        for (uint256 i; i < numCollaterals; i++) {
+            amounts[i] = _collateralAmount(i, units / numCollaterals + 1);
+            deal(obligation.collateralParams[i].token, borrower, amounts[i]);
+            vm.startPrank(borrower);
+            ERC20(obligation.collateralParams[i].token).approve(address(midnight), amounts[i]);
+            midnight.supplyCollateral(obligation, i, amounts[i], borrower);
+            vm.stopPrank();
+        }
+    }
+
+    function testBuyUnitsTargetWithCollateralWithdrawals(uint256 numCollaterals) public {
+        numCollaterals = bound(numCollaterals, 0, 2);
         uint256 units = 100e18;
 
         offers[0].buy = false;
         offers[0].receiverIfMakerIsSeller = lender;
         offers[0].maxUnits = units;
 
-        // Reset trading fees to avoid overflow.
         for (uint256 i; i <= 6; i++) {
             midnight.setObligationTradingFee(id, i, 0);
         }
         deal(address(loanToken), lender, 0);
 
-        // Lender is the seller, so lender needs collateral.
         collateralize(obligation, lender, units);
-
-        // Borrower (buyer) also has collateral that they want to withdraw after buying.
-        collateralize(obligation, borrower, units);
+        uint256[] memory amounts = _supplyBorrowerCollateral(numCollaterals, units);
 
         Take[] memory takes = new Take[](1);
         takes[0] = Take({
@@ -333,74 +352,38 @@ contract BundlerTest is BaseTest {
 
         _authorizeBundler();
 
-        uint256 collateralBefore = midnight.collateral(id, borrower, 0);
-        uint256 withdrawAmount = collateralBefore / 2;
         address receiver = makeAddr("collateralReceiver");
-
-        CollateralTransfer[] memory withdrawals = new CollateralTransfer[](1);
-        withdrawals[0] = CollateralTransfer({collateralIndex: 0, assets: withdrawAmount});
+        CollateralTransfer[] memory withdrawals = new CollateralTransfer[](numCollaterals);
+        for (uint256 i; i < numCollaterals; i++) {
+            withdrawals[i] = CollateralTransfer({collateralIndex: i, assets: amounts[i] / 4});
+        }
 
         vm.prank(borrower);
         takeBundler.buyUnitsTarget(
             address(midnight), units, borrower, takes, 0, type(uint256).max, withdrawals, receiver
         );
 
-        assertEq(midnight.collateral(id, borrower, 0), collateralBefore - withdrawAmount, "collateral after withdrawal");
-        assertEq(ERC20(obligation.collateralParams[0].token).balanceOf(receiver), withdrawAmount, "receiver balance");
+        for (uint256 i; i < numCollaterals; i++) {
+            assertEq(midnight.collateral(id, borrower, i), amounts[i] - amounts[i] / 4);
+            assertEq(ERC20(obligation.collateralParams[i].token).balanceOf(receiver), amounts[i] / 4);
+        }
     }
 
-    function testSellUnitsTargetWithCollateralSupply() public {
-        uint256 units = 100e18;
-
-        offers[0].maxUnits = units;
-
-        _authorizeBundler();
-
-        // Compute how much collateral the borrower needs for the debt.
-        address token = obligation.collateralParams[0].token;
-        uint256 oraclePrice = Oracle(obligation.collateralParams[0].oracle).price();
-        uint256 supplyAmount =
-            units.mulDivUp(WAD, obligation.collateralParams[0].lltv).mulDivUp(ORACLE_PRICE_SCALE, oraclePrice);
-
-        // Give collateral to borrower and approve the bundler to pull it.
-        deal(token, borrower, supplyAmount);
-        vm.prank(borrower);
-        ERC20(token).approve(address(takeBundler), supplyAmount);
-
-        CollateralTransfer[] memory supplies = new CollateralTransfer[](1);
-        supplies[0] = CollateralTransfer({collateralIndex: 0, assets: supplyAmount});
-
-        Take[] memory takes = new Take[](1);
-        takes[0] = Take({
-            offer: offers[0],
-            units: units,
-            ratifierData: ratifierData([offers[0]]),
-            root: root([offers[0]]),
-            proof: proof([offers[0]])
-        });
-
-        vm.prank(borrower);
-        takeBundler.sellUnitsTarget(address(midnight), units, borrower, borrower, takes, 0, type(uint256).max, supplies);
-
-        assertEq(midnight.collateral(id, borrower, 0), supplyAmount, "collateral supplied");
-        assertEq(midnight.debtOf(id, borrower), units, "debt");
-    }
-
-    function testBuyBuyerAssetsTargetWithCollateralWithdrawal() public {
+    function testBuyBuyerAssetsTargetWithCollateralWithdrawals(uint256 numCollaterals) public {
+        numCollaterals = bound(numCollaterals, 0, 2);
         uint256 units = 100e18;
 
         offers[0].buy = false;
         offers[0].receiverIfMakerIsSeller = lender;
         offers[0].maxUnits = units;
 
-        // Reset trading fees to avoid overflow.
         for (uint256 i; i <= 6; i++) {
             midnight.setObligationTradingFee(id, i, 0);
         }
         deal(address(loanToken), lender, 0);
 
         collateralize(obligation, lender, units);
-        collateralize(obligation, borrower, units);
+        uint256[] memory amounts = _supplyBorrowerCollateral(numCollaterals, units);
 
         uint256 price = TickLib.tickToPrice(MAX_TICK);
         uint256 targetBuyerAssets = units.mulDivUp(price, WAD);
@@ -416,23 +399,60 @@ contract BundlerTest is BaseTest {
 
         _authorizeBundler();
 
-        uint256 collateralBefore = midnight.collateral(id, borrower, 0);
-        uint256 withdrawAmount = collateralBefore / 2;
         address receiver = makeAddr("collateralReceiver");
-
-        CollateralTransfer[] memory withdrawals = new CollateralTransfer[](1);
-        withdrawals[0] = CollateralTransfer({collateralIndex: 0, assets: withdrawAmount});
+        CollateralTransfer[] memory withdrawals = new CollateralTransfer[](numCollaterals);
+        for (uint256 i; i < numCollaterals; i++) {
+            withdrawals[i] = CollateralTransfer({collateralIndex: i, assets: amounts[i] / 4});
+        }
 
         vm.prank(borrower);
         takeBundler.buyBuyerAssetsTarget(
             address(midnight), targetBuyerAssets, borrower, takes, 0, type(uint256).max, withdrawals, receiver
         );
 
-        assertEq(midnight.collateral(id, borrower, 0), collateralBefore - withdrawAmount, "collateral after withdrawal");
-        assertEq(ERC20(obligation.collateralParams[0].token).balanceOf(receiver), withdrawAmount, "receiver balance");
+        for (uint256 i; i < numCollaterals; i++) {
+            assertEq(midnight.collateral(id, borrower, i), amounts[i] - amounts[i] / 4);
+            assertEq(ERC20(obligation.collateralParams[i].token).balanceOf(receiver), amounts[i] / 4);
+        }
     }
 
-    function testSellSellerAssetsTargetWithCollateralSupply() public {
+    function testSellUnitsTargetWithCollateralSupplies(uint256 numCollaterals) public {
+        numCollaterals = bound(numCollaterals, 1, 2);
+        uint256 units = 100e18;
+
+        offers[0].maxUnits = units;
+
+        _authorizeBundler();
+
+        CollateralTransfer[] memory supplies = new CollateralTransfer[](numCollaterals);
+        for (uint256 i; i < numCollaterals; i++) {
+            uint256 amount = _collateralAmount(i, units / numCollaterals + 1);
+            deal(obligation.collateralParams[i].token, borrower, amount);
+            vm.prank(borrower);
+            ERC20(obligation.collateralParams[i].token).approve(address(takeBundler), amount);
+            supplies[i] = CollateralTransfer({collateralIndex: i, assets: amount});
+        }
+
+        Take[] memory takes = new Take[](1);
+        takes[0] = Take({
+            offer: offers[0],
+            units: units,
+            ratifierData: ratifierData([offers[0]]),
+            root: root([offers[0]]),
+            proof: proof([offers[0]])
+        });
+
+        vm.prank(borrower);
+        takeBundler.sellUnitsTarget(address(midnight), units, borrower, borrower, takes, 0, type(uint256).max, supplies);
+
+        for (uint256 i; i < numCollaterals; i++) {
+            assertEq(midnight.collateral(id, borrower, i), supplies[i].assets);
+        }
+        assertEq(midnight.debtOf(id, borrower), units);
+    }
+
+    function testSellSellerAssetsTargetWithCollateralSupplies(uint256 numCollaterals) public {
+        numCollaterals = bound(numCollaterals, 1, 2);
         uint256 units = 100e18;
 
         offers[0].maxUnits = units;
@@ -445,18 +465,14 @@ contract BundlerTest is BaseTest {
 
         _authorizeBundler();
 
-        address token = obligation.collateralParams[0].token;
-        uint256 oraclePrice = Oracle(obligation.collateralParams[0].oracle).price();
-        // Extra headroom for rounding.
-        uint256 supplyAmount =
-            (units + 1).mulDivUp(WAD, obligation.collateralParams[0].lltv).mulDivUp(ORACLE_PRICE_SCALE, oraclePrice);
-
-        deal(token, borrower, supplyAmount);
-        vm.prank(borrower);
-        ERC20(token).approve(address(takeBundler), supplyAmount);
-
-        CollateralTransfer[] memory supplies = new CollateralTransfer[](1);
-        supplies[0] = CollateralTransfer({collateralIndex: 0, assets: supplyAmount});
+        CollateralTransfer[] memory supplies = new CollateralTransfer[](numCollaterals);
+        for (uint256 i; i < numCollaterals; i++) {
+            uint256 amount = _collateralAmount(i, units / numCollaterals + 1);
+            deal(obligation.collateralParams[i].token, borrower, amount);
+            vm.prank(borrower);
+            ERC20(obligation.collateralParams[i].token).approve(address(takeBundler), amount);
+            supplies[i] = CollateralTransfer({collateralIndex: i, assets: amount});
+        }
 
         Take[] memory takes = new Take[](1);
         takes[0] = Take({
@@ -472,53 +488,10 @@ contract BundlerTest is BaseTest {
             address(midnight), targetSellerAssets, borrower, borrower, takes, 0, type(uint256).max, supplies
         );
 
-        assertEq(midnight.collateral(id, borrower, 0), supplyAmount, "collateral supplied");
-        assertEq(loanToken.balanceOf(borrower), targetSellerAssets, "borrower received seller assets");
-    }
-
-    function testSellUnitsTargetWithMultipleCollateralSupplies() public {
-        uint256 units = 100e18;
-
-        offers[0].maxUnits = units;
-
-        _authorizeBundler();
-
-        // Supply across both collateral tokens.
-        uint256 oraclePrice0 = Oracle(obligation.collateralParams[0].oracle).price();
-        uint256 oraclePrice1 = Oracle(obligation.collateralParams[1].oracle).price();
-        // Supply half the needed collateral in each token.
-        uint256 halfUnits = units / 2;
-        uint256 supplyAmount0 = (halfUnits + 1).mulDivUp(WAD, obligation.collateralParams[0].lltv)
-            .mulDivUp(ORACLE_PRICE_SCALE, oraclePrice0);
-        uint256 supplyAmount1 = (halfUnits + 1).mulDivUp(WAD, obligation.collateralParams[1].lltv)
-            .mulDivUp(ORACLE_PRICE_SCALE, oraclePrice1);
-
-        deal(obligation.collateralParams[0].token, borrower, supplyAmount0);
-        deal(obligation.collateralParams[1].token, borrower, supplyAmount1);
-        vm.startPrank(borrower);
-        ERC20(obligation.collateralParams[0].token).approve(address(takeBundler), supplyAmount0);
-        ERC20(obligation.collateralParams[1].token).approve(address(takeBundler), supplyAmount1);
-        vm.stopPrank();
-
-        CollateralTransfer[] memory supplies = new CollateralTransfer[](2);
-        supplies[0] = CollateralTransfer({collateralIndex: 0, assets: supplyAmount0});
-        supplies[1] = CollateralTransfer({collateralIndex: 1, assets: supplyAmount1});
-
-        Take[] memory takes = new Take[](1);
-        takes[0] = Take({
-            offer: offers[0],
-            units: units,
-            ratifierData: ratifierData([offers[0]]),
-            root: root([offers[0]]),
-            proof: proof([offers[0]])
-        });
-
-        vm.prank(borrower);
-        takeBundler.sellUnitsTarget(address(midnight), units, borrower, borrower, takes, 0, type(uint256).max, supplies);
-
-        assertEq(midnight.collateral(id, borrower, 0), supplyAmount0, "collateral 0 supplied");
-        assertEq(midnight.collateral(id, borrower, 1), supplyAmount1, "collateral 1 supplied");
-        assertEq(midnight.debtOf(id, borrower), units, "debt");
+        for (uint256 i; i < numCollaterals; i++) {
+            assertEq(midnight.collateral(id, borrower, i), supplies[i].assets);
+        }
+        assertEq(loanToken.balanceOf(borrower), targetSellerAssets);
     }
 
     // Average prices.

--- a/test/BundlerTest.sol
+++ b/test/BundlerTest.sol
@@ -441,7 +441,7 @@ contract BundlerTest is BaseTest {
         });
 
         vm.prank(borrower);
-        takeBundler.sellUnitsTarget(address(midnight), units, borrower, borrower, takes, type(uint256).max, supplies);
+        takeBundler.sellUnitsTarget(address(midnight), units, borrower, borrower, takes, 0, supplies);
 
         for (uint256 i; i < numCollaterals; i++) {
             assertEq(midnight.collateral(id, borrower, i), supplies[i].assets);
@@ -589,10 +589,11 @@ contract BundlerTest is BaseTest {
         uint256 tick1,
         uint256 minSellerAssets
     ) public {
-        tick0 = bound(tick0, 0, MAX_TICK);
-        tick1 = bound(tick1, 0, MAX_TICK);
         // Ensure sellerPrice > 0 so the min bound actually triggers.
         uint256 fee = midnight.tradingFee(id, obligation.maturity - block.timestamp);
+        uint256 minTick = TickLib.priceToTick(fee + 1);
+        tick0 = bound(tick0, minTick, MAX_TICK);
+        tick1 = bound(tick1, minTick, MAX_TICK);
         uint256 minSellerPrice = UtilsLib.min(TickLib.tickToPrice(tick0) - fee, TickLib.tickToPrice(tick1) - fee);
         targetUnits = bound(targetUnits, WAD / minSellerPrice + 1, uint256(type(uint128).max) * 3 / 4);
 

--- a/test/BundlerTest.sol
+++ b/test/BundlerTest.sol
@@ -5,9 +5,11 @@ pragma solidity ^0.8.0;
 import {Obligation, Offer, CollateralParams} from "../src/interfaces/IMidnight.sol";
 import {UtilsLib} from "../src/libraries/UtilsLib.sol";
 import {TickLib, MAX_TICK} from "../src/libraries/TickLib.sol";
-import {WAD} from "../src/libraries/ConstantsLib.sol";
+import {WAD, ORACLE_PRICE_SCALE} from "../src/libraries/ConstantsLib.sol";
+import {ERC20} from "./erc20s/ERC20.sol";
+import {Oracle} from "./helpers/Oracle.sol";
 import {TakeBundler} from "../src/periphery/TakeBundler.sol";
-import {ITakeBundler, Take} from "../src/periphery/interfaces/ITakeBundler.sol";
+import {ITakeBundler, Take, CollateralTransfer} from "../src/periphery/interfaces/ITakeBundler.sol";
 import {BaseTest} from "./BaseTest.sol";
 
 contract BundlerTest is BaseTest {
@@ -99,7 +101,9 @@ contract BundlerTest is BaseTest {
 
         vm.prank(address(0xdead));
         vm.expectRevert(ITakeBundler.Unauthorized.selector);
-        takeBundler.buyUnitsTarget(address(midnight), 100, borrower, takes, 0, type(uint256).max);
+        takeBundler.buyUnitsTarget(
+            address(midnight), 100, borrower, takes, 0, type(uint256).max, new CollateralTransfer[](0), address(0)
+        );
     }
 
     function testSellUnitsTarget(uint256 offerUnits0, uint256 offerUnits1, uint256 units) public {
@@ -130,7 +134,9 @@ contract BundlerTest is BaseTest {
 
         if (offerUnits1 >= units - fromOffer0) {
             vm.prank(borrower);
-            takeBundler.sellUnitsTarget(address(midnight), units, borrower, borrower, takes, 0, type(uint256).max);
+            takeBundler.sellUnitsTarget(
+                address(midnight), units, borrower, borrower, takes, 0, type(uint256).max, new CollateralTransfer[](0)
+            );
 
             uint256 consumed0 = midnight.consumed(offers[0].maker, offers[0].group);
             uint256 consumed1 = midnight.consumed(offers[1].maker, offers[1].group);
@@ -140,7 +146,9 @@ contract BundlerTest is BaseTest {
         } else {
             vm.prank(borrower);
             vm.expectRevert(ITakeBundler.InsufficientLiquidity.selector);
-            takeBundler.sellUnitsTarget(address(midnight), units, borrower, borrower, takes, 0, type(uint256).max);
+            takeBundler.sellUnitsTarget(
+                address(midnight), units, borrower, borrower, takes, 0, type(uint256).max, new CollateralTransfer[](0)
+            );
         }
     }
 
@@ -188,7 +196,14 @@ contract BundlerTest is BaseTest {
         if (offerUnits1 >= units - fromOffer0) {
             vm.prank(borrower);
             takeBundler.buyBuyerAssetsTarget(
-                address(midnight), targetBuyerAssets, borrower, takes, 0, type(uint256).max
+                address(midnight),
+                targetBuyerAssets,
+                borrower,
+                takes,
+                0,
+                type(uint256).max,
+                new CollateralTransfer[](0),
+                address(0)
             );
 
             uint256 consumed0 = midnight.consumed(offers[0].maker, offers[0].group);
@@ -202,7 +217,14 @@ contract BundlerTest is BaseTest {
             vm.prank(borrower);
             vm.expectRevert(ITakeBundler.InsufficientLiquidity.selector);
             takeBundler.buyBuyerAssetsTarget(
-                address(midnight), targetBuyerAssets, borrower, takes, 0, type(uint256).max
+                address(midnight),
+                targetBuyerAssets,
+                borrower,
+                takes,
+                0,
+                type(uint256).max,
+                new CollateralTransfer[](0),
+                address(0)
             );
         }
     }
@@ -248,7 +270,14 @@ contract BundlerTest is BaseTest {
         if (offerUnits1 >= neededFromOffer1) {
             vm.prank(borrower);
             takeBundler.sellSellerAssetsTarget(
-                address(midnight), targetSellerAssets, borrower, borrower, takes, 0, type(uint256).max
+                address(midnight),
+                targetSellerAssets,
+                borrower,
+                borrower,
+                takes,
+                0,
+                type(uint256).max,
+                new CollateralTransfer[](0)
             );
 
             uint256 consumed0 = midnight.consumed(offers[0].maker, offers[0].group);
@@ -260,9 +289,236 @@ contract BundlerTest is BaseTest {
             vm.prank(borrower);
             vm.expectRevert(ITakeBundler.InsufficientLiquidity.selector);
             takeBundler.sellSellerAssetsTarget(
-                address(midnight), targetSellerAssets, borrower, borrower, takes, 0, type(uint256).max
+                address(midnight),
+                targetSellerAssets,
+                borrower,
+                borrower,
+                takes,
+                0,
+                type(uint256).max,
+                new CollateralTransfer[](0)
             );
         }
+    }
+
+    // Collateral transfers.
+
+    function testBuyUnitsTargetWithCollateralWithdrawal() public {
+        uint256 units = 100e18;
+
+        offers[0].buy = false;
+        offers[0].receiverIfMakerIsSeller = lender;
+        offers[0].maxUnits = units;
+
+        // Reset trading fees to avoid overflow.
+        for (uint256 i; i <= 6; i++) {
+            midnight.setObligationTradingFee(id, i, 0);
+        }
+        deal(address(loanToken), lender, 0);
+
+        // Lender is the seller, so lender needs collateral.
+        collateralize(obligation, lender, units);
+
+        // Borrower (buyer) also has collateral that they want to withdraw after buying.
+        collateralize(obligation, borrower, units);
+
+        Take[] memory takes = new Take[](1);
+        takes[0] = Take({
+            offer: offers[0],
+            units: units,
+            ratifierData: ratifierData([offers[0]]),
+            root: root([offers[0]]),
+            proof: proof([offers[0]])
+        });
+
+        _authorizeBundler();
+
+        uint256 collateralBefore = midnight.collateral(id, borrower, 0);
+        uint256 withdrawAmount = collateralBefore / 2;
+        address receiver = makeAddr("collateralReceiver");
+
+        CollateralTransfer[] memory withdrawals = new CollateralTransfer[](1);
+        withdrawals[0] = CollateralTransfer({collateralIndex: 0, assets: withdrawAmount});
+
+        vm.prank(borrower);
+        takeBundler.buyUnitsTarget(
+            address(midnight), units, borrower, takes, 0, type(uint256).max, withdrawals, receiver
+        );
+
+        assertEq(midnight.collateral(id, borrower, 0), collateralBefore - withdrawAmount, "collateral after withdrawal");
+        assertEq(ERC20(obligation.collateralParams[0].token).balanceOf(receiver), withdrawAmount, "receiver balance");
+    }
+
+    function testSellUnitsTargetWithCollateralSupply() public {
+        uint256 units = 100e18;
+
+        offers[0].maxUnits = units;
+
+        _authorizeBundler();
+
+        // Compute how much collateral the borrower needs for the debt.
+        address token = obligation.collateralParams[0].token;
+        uint256 oraclePrice = Oracle(obligation.collateralParams[0].oracle).price();
+        uint256 supplyAmount =
+            units.mulDivUp(WAD, obligation.collateralParams[0].lltv).mulDivUp(ORACLE_PRICE_SCALE, oraclePrice);
+
+        // Give collateral to borrower and approve the bundler to pull it.
+        deal(token, borrower, supplyAmount);
+        vm.prank(borrower);
+        ERC20(token).approve(address(takeBundler), supplyAmount);
+
+        CollateralTransfer[] memory supplies = new CollateralTransfer[](1);
+        supplies[0] = CollateralTransfer({collateralIndex: 0, assets: supplyAmount});
+
+        Take[] memory takes = new Take[](1);
+        takes[0] = Take({
+            offer: offers[0],
+            units: units,
+            ratifierData: ratifierData([offers[0]]),
+            root: root([offers[0]]),
+            proof: proof([offers[0]])
+        });
+
+        vm.prank(borrower);
+        takeBundler.sellUnitsTarget(address(midnight), units, borrower, borrower, takes, 0, type(uint256).max, supplies);
+
+        assertEq(midnight.collateral(id, borrower, 0), supplyAmount, "collateral supplied");
+        assertEq(midnight.debtOf(id, borrower), units, "debt");
+    }
+
+    function testBuyBuyerAssetsTargetWithCollateralWithdrawal() public {
+        uint256 units = 100e18;
+
+        offers[0].buy = false;
+        offers[0].receiverIfMakerIsSeller = lender;
+        offers[0].maxUnits = units;
+
+        // Reset trading fees to avoid overflow.
+        for (uint256 i; i <= 6; i++) {
+            midnight.setObligationTradingFee(id, i, 0);
+        }
+        deal(address(loanToken), lender, 0);
+
+        collateralize(obligation, lender, units);
+        collateralize(obligation, borrower, units);
+
+        uint256 price = TickLib.tickToPrice(MAX_TICK);
+        uint256 targetBuyerAssets = units.mulDivUp(price, WAD);
+
+        Take[] memory takes = new Take[](1);
+        takes[0] = Take({
+            offer: offers[0],
+            units: units,
+            ratifierData: ratifierData([offers[0]]),
+            root: root([offers[0]]),
+            proof: proof([offers[0]])
+        });
+
+        _authorizeBundler();
+
+        uint256 collateralBefore = midnight.collateral(id, borrower, 0);
+        uint256 withdrawAmount = collateralBefore / 2;
+        address receiver = makeAddr("collateralReceiver");
+
+        CollateralTransfer[] memory withdrawals = new CollateralTransfer[](1);
+        withdrawals[0] = CollateralTransfer({collateralIndex: 0, assets: withdrawAmount});
+
+        vm.prank(borrower);
+        takeBundler.buyBuyerAssetsTarget(
+            address(midnight), targetBuyerAssets, borrower, takes, 0, type(uint256).max, withdrawals, receiver
+        );
+
+        assertEq(midnight.collateral(id, borrower, 0), collateralBefore - withdrawAmount, "collateral after withdrawal");
+        assertEq(ERC20(obligation.collateralParams[0].token).balanceOf(receiver), withdrawAmount, "receiver balance");
+    }
+
+    function testSellSellerAssetsTargetWithCollateralSupply() public {
+        uint256 units = 100e18;
+
+        offers[0].maxUnits = units;
+
+        uint256 price = TickLib.tickToPrice(MAX_TICK);
+        midnight.touchObligation(obligation);
+        uint256 _tradingFee = midnight.tradingFee(id, obligation.maturity - block.timestamp);
+        uint256 sellerPrice = price - _tradingFee;
+        uint256 targetSellerAssets = units.mulDivDown(sellerPrice, WAD);
+
+        _authorizeBundler();
+
+        address token = obligation.collateralParams[0].token;
+        uint256 oraclePrice = Oracle(obligation.collateralParams[0].oracle).price();
+        // Extra headroom for rounding.
+        uint256 supplyAmount =
+            (units + 1).mulDivUp(WAD, obligation.collateralParams[0].lltv).mulDivUp(ORACLE_PRICE_SCALE, oraclePrice);
+
+        deal(token, borrower, supplyAmount);
+        vm.prank(borrower);
+        ERC20(token).approve(address(takeBundler), supplyAmount);
+
+        CollateralTransfer[] memory supplies = new CollateralTransfer[](1);
+        supplies[0] = CollateralTransfer({collateralIndex: 0, assets: supplyAmount});
+
+        Take[] memory takes = new Take[](1);
+        takes[0] = Take({
+            offer: offers[0],
+            units: units,
+            ratifierData: ratifierData([offers[0]]),
+            root: root([offers[0]]),
+            proof: proof([offers[0]])
+        });
+
+        vm.prank(borrower);
+        takeBundler.sellSellerAssetsTarget(
+            address(midnight), targetSellerAssets, borrower, borrower, takes, 0, type(uint256).max, supplies
+        );
+
+        assertEq(midnight.collateral(id, borrower, 0), supplyAmount, "collateral supplied");
+        assertEq(loanToken.balanceOf(borrower), targetSellerAssets, "borrower received seller assets");
+    }
+
+    function testSellUnitsTargetWithMultipleCollateralSupplies() public {
+        uint256 units = 100e18;
+
+        offers[0].maxUnits = units;
+
+        _authorizeBundler();
+
+        // Supply across both collateral tokens.
+        uint256 oraclePrice0 = Oracle(obligation.collateralParams[0].oracle).price();
+        uint256 oraclePrice1 = Oracle(obligation.collateralParams[1].oracle).price();
+        // Supply half the needed collateral in each token.
+        uint256 halfUnits = units / 2;
+        uint256 supplyAmount0 = (halfUnits + 1).mulDivUp(WAD, obligation.collateralParams[0].lltv)
+            .mulDivUp(ORACLE_PRICE_SCALE, oraclePrice0);
+        uint256 supplyAmount1 = (halfUnits + 1).mulDivUp(WAD, obligation.collateralParams[1].lltv)
+            .mulDivUp(ORACLE_PRICE_SCALE, oraclePrice1);
+
+        deal(obligation.collateralParams[0].token, borrower, supplyAmount0);
+        deal(obligation.collateralParams[1].token, borrower, supplyAmount1);
+        vm.startPrank(borrower);
+        ERC20(obligation.collateralParams[0].token).approve(address(takeBundler), supplyAmount0);
+        ERC20(obligation.collateralParams[1].token).approve(address(takeBundler), supplyAmount1);
+        vm.stopPrank();
+
+        CollateralTransfer[] memory supplies = new CollateralTransfer[](2);
+        supplies[0] = CollateralTransfer({collateralIndex: 0, assets: supplyAmount0});
+        supplies[1] = CollateralTransfer({collateralIndex: 1, assets: supplyAmount1});
+
+        Take[] memory takes = new Take[](1);
+        takes[0] = Take({
+            offer: offers[0],
+            units: units,
+            ratifierData: ratifierData([offers[0]]),
+            root: root([offers[0]]),
+            proof: proof([offers[0]])
+        });
+
+        vm.prank(borrower);
+        takeBundler.sellUnitsTarget(address(midnight), units, borrower, borrower, takes, 0, type(uint256).max, supplies);
+
+        assertEq(midnight.collateral(id, borrower, 0), supplyAmount0, "collateral 0 supplied");
+        assertEq(midnight.collateral(id, borrower, 1), supplyAmount1, "collateral 1 supplied");
+        assertEq(midnight.debtOf(id, borrower), units, "debt");
     }
 
     // Average prices.
@@ -335,7 +591,9 @@ contract BundlerTest is BaseTest {
 
         vm.prank(borrower);
         vm.expectRevert(ITakeBundler.BuyerAssetsAboveMax.selector);
-        takeBundler.buyUnitsTarget(address(midnight), targetUnits, borrower, takes, 0, maxBuyerAssets);
+        takeBundler.buyUnitsTarget(
+            address(midnight), targetUnits, borrower, takes, 0, maxBuyerAssets, new CollateralTransfer[](0), address(0)
+        );
     }
 
     function testAveragePriceTooLow(
@@ -388,6 +646,15 @@ contract BundlerTest is BaseTest {
 
         vm.prank(borrower);
         vm.expectRevert(ITakeBundler.BuyerAssetsBelowMin.selector);
-        takeBundler.buyUnitsTarget(address(midnight), targetUnits, borrower, takes, minBuyerAssets, type(uint256).max);
+        takeBundler.buyUnitsTarget(
+            address(midnight),
+            targetUnits,
+            borrower,
+            takes,
+            minBuyerAssets,
+            type(uint256).max,
+            new CollateralTransfer[](0),
+            address(0)
+        );
     }
 }

--- a/test/BundlerTest.sol
+++ b/test/BundlerTest.sol
@@ -305,9 +305,9 @@ contract BundlerTest is BaseTest {
 
     function _collateralAmount(uint256 collateralIndex, uint256 debt) internal view returns (uint256) {
         uint256 oraclePrice = Oracle(obligation.collateralParams[collateralIndex].oracle).price();
-        return debt.mulDivUp(WAD, obligation.collateralParams[collateralIndex].lltv).mulDivUp(
-            ORACLE_PRICE_SCALE, oraclePrice
-        );
+        return
+            debt.mulDivUp(WAD, obligation.collateralParams[collateralIndex].lltv)
+                .mulDivUp(ORACLE_PRICE_SCALE, oraclePrice);
     }
 
     function _supplyBorrowerCollateral(uint256 numCollaterals, uint256 units)


### PR DESCRIPTION
- withdraw collat on buy, supply collat on sell
- we could approve max on the first interaction with a token, but the code is more complex
- we could factorize the safe approve in a lib (but not in SafeTransferLib, because it's not used in midnight)

https://morpholabs.slack.com/archives/C08A40KKN9W/p1776693468452509