### PR TITLE
Remove problematic jq

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -34,9 +34,6 @@ jobs:
           distribution: temurin
           java-version: "21"
 
-      - name: Install Jq
-        uses: sergeysova/jq-action@a3f0d4ff59cc1dddf023fc0b325dd75b10deec58 # v2
-
       - name: Run Certora Config Linter
         run: |
           file="certora/confs/${{ matrix.conf }}.conf"


### PR DESCRIPTION
Which would allow to run the Certora CI again:
<img width="1445" height="252" alt="Screenshot 2026-04-21 at 17 43 53" src="https://github.com/user-attachments/assets/7fb977da-1afa-497d-93db-0b2b7b1dea3a" />
