### PR TITLE
bundler: remove average price check

### DIFF
--- a/src/periphery/TakeBundler.sol
+++ b/src/periphery/TakeBundler.sol
@@ -21,14 +21,12 @@ contract TakeBundler is ITakeBundler {
         uint256 targetUnits,
         address taker,
         Take[] calldata takes,
-        uint256 maxBuyerAssets,
         CollateralTransfer[] calldata collateralWithdrawals,
         address collateralReceiver
     ) external {
         require(taker == msg.sender || IMidnight(midnight).isAuthorized(taker, msg.sender), Unauthorized());
 
         uint256 totalFilledUnits;
-        uint256 totalBuyerAssets;
         for (uint256 i; i < takes.length && totalFilledUnits < targetUnits; i++) {
             require(!takes[i].offer.buy, InconsistentSide());
             try IMidnight(midnight)
@@ -43,15 +41,13 @@ contract TakeBundler is ITakeBundler {
                     takes[i].root,
                     takes[i].proof
                 ) returns (
-                uint256 filledBuyerAssets, uint256, uint256 filledUnits
+                uint256, uint256, uint256 filledUnits
             ) {
                 totalFilledUnits += filledUnits;
-                totalBuyerAssets += filledBuyerAssets;
             } catch {}
         }
 
         require(totalFilledUnits == targetUnits, InsufficientLiquidity());
-        require(totalBuyerAssets <= maxBuyerAssets, BuyerAssetsAboveMax());
 
         Obligation memory obligation = takes[0].offer.obligation;
         for (uint256 i; i < collateralWithdrawals.length; i++) {
@@ -74,7 +70,6 @@ contract TakeBundler is ITakeBundler {
         address taker,
         address receiverIfTakerIsSeller,
         Take[] calldata takes,
-        uint256 minSellerAssets,
         CollateralTransfer[] calldata collateralSupplies
     ) external {
         require(taker == msg.sender || IMidnight(midnight).isAuthorized(taker, msg.sender), Unauthorized());
@@ -91,7 +86,6 @@ contract TakeBundler is ITakeBundler {
         }
 
         uint256 totalFilledUnits;
-        uint256 totalSellerAssets;
         for (uint256 i; i < takes.length && totalFilledUnits < targetUnits; i++) {
             require(takes[i].offer.buy, InconsistentSide());
             try IMidnight(midnight)
@@ -106,15 +100,13 @@ contract TakeBundler is ITakeBundler {
                     takes[i].root,
                     takes[i].proof
                 ) returns (
-                uint256, uint256 filledSellerAssets, uint256 filledUnits
+                uint256, uint256, uint256 filledUnits
             ) {
                 totalFilledUnits += filledUnits;
-                totalSellerAssets += filledSellerAssets;
             } catch {}
         }
 
         require(totalFilledUnits == targetUnits, InsufficientLiquidity());
-        require(totalSellerAssets >= minSellerAssets, SellerAssetsBelowMin());
     }
 
     /// @dev See buyUnitsTarget.
@@ -123,8 +115,6 @@ contract TakeBundler is ITakeBundler {
         uint256 targetBuyerAssets,
         address taker,
         Take[] calldata takes,
-        uint256 minUnits,
-        uint256 maxUnits,
         CollateralTransfer[] calldata collateralWithdrawals,
         address collateralReceiver
     ) external {
@@ -133,7 +123,6 @@ contract TakeBundler is ITakeBundler {
         bytes32 id = IMidnight(midnight).touchObligation(takes[0].offer.obligation);
 
         uint256 totalFilledBuyerAssets;
-        uint256 totalUnits;
         for (uint256 i; i < takes.length && totalFilledBuyerAssets < targetBuyerAssets; i++) {
             require(!takes[i].offer.buy, InconsistentSide());
             try IMidnight(midnight)
@@ -153,16 +142,13 @@ contract TakeBundler is ITakeBundler {
                     takes[i].root,
                     takes[i].proof
                 ) returns (
-                uint256 filledBuyerAssets, uint256, uint256 filledUnits
+                uint256 filledBuyerAssets, uint256, uint256
             ) {
                 totalFilledBuyerAssets += filledBuyerAssets;
-                totalUnits += filledUnits;
             } catch {}
         }
 
         require(totalFilledBuyerAssets == targetBuyerAssets, InsufficientLiquidity());
-        require(totalUnits >= minUnits, UnitsBelowMin());
-        require(totalUnits <= maxUnits, UnitsAboveMax());
 
         Obligation memory obligation = takes[0].offer.obligation;
         for (uint256 i; i < collateralWithdrawals.length; i++) {
@@ -185,8 +171,6 @@ contract TakeBundler is ITakeBundler {
         address taker,
         address receiverIfTakerIsSeller,
         Take[] calldata takes,
-        uint256 minUnits,
-        uint256 maxUnits,
         CollateralTransfer[] calldata collateralSupplies
     ) external {
         require(taker == msg.sender || IMidnight(midnight).isAuthorized(taker, msg.sender), Unauthorized());
@@ -206,7 +190,6 @@ contract TakeBundler is ITakeBundler {
         bytes32 id = IMidnight(midnight).touchObligation(takes[0].offer.obligation);
 
         uint256 totalFilledSellerAssets;
-        uint256 totalUnits;
         for (uint256 i; i < takes.length && totalFilledSellerAssets < targetSellerAssets; i++) {
             require(takes[i].offer.buy, InconsistentSide());
             try IMidnight(midnight)
@@ -226,16 +209,13 @@ contract TakeBundler is ITakeBundler {
                     takes[i].root,
                     takes[i].proof
                 ) returns (
-                uint256, uint256 filledSellerAssets, uint256 filledUnits
+                uint256, uint256 filledSellerAssets, uint256
             ) {
                 totalFilledSellerAssets += filledSellerAssets;
-                totalUnits += filledUnits;
             } catch {}
         }
 
         require(totalFilledSellerAssets == targetSellerAssets, InsufficientLiquidity());
-        require(totalUnits >= minUnits, UnitsBelowMin());
-        require(totalUnits <= maxUnits, UnitsAboveMax());
     }
 
     /// @dev USDT won't break because the allowance is reset to 0 after supplyCollateral.

--- a/src/periphery/interfaces/ITakeBundler.sol
+++ b/src/periphery/interfaces/ITakeBundler.sol
@@ -19,19 +19,15 @@ struct CollateralTransfer {
 
 interface ITakeBundler {
     /// ERRORS ///
-    error BuyerAssetsAboveMax();
     error InconsistentSide();
     error InsufficientLiquidity();
-    error SellerAssetsBelowMin();
     error Unauthorized();
-    error UnitsAboveMax();
-    error UnitsBelowMin();
 
     // forgefmt: disable-start
     /// FUNCTIONS ///
-    function buyUnitsTarget(address midnight, uint256 targetUnits, address taker, Take[] calldata takes, uint256 maxBuyerAssets, CollateralTransfer[] calldata collateralWithdrawals, address collateralReceiver) external;
-    function sellUnitsTarget(address midnight, uint256 targetUnits, address taker, address receiverIfTakerIsSeller, Take[] calldata takes, uint256 minSellerAssets, CollateralTransfer[] calldata collateralSupplies) external;
-    function buyBuyerAssetsTarget(address midnight, uint256 targetBuyerAssets, address taker, Take[] calldata takes, uint256 minUnits, uint256 maxUnits, CollateralTransfer[] calldata collateralWithdrawals, address collateralReceiver) external;
-    function sellSellerAssetsTarget(address midnight, uint256 targetSellerAssets, address taker, address receiverIfTakerIsSeller, Take[] calldata takes, uint256 minUnits, uint256 maxUnits, CollateralTransfer[] calldata collateralSupplies) external;
+    function buyUnitsTarget(address midnight, uint256 targetUnits, address taker, Take[] calldata takes, CollateralTransfer[] calldata collateralWithdrawals, address collateralReceiver) external;
+    function sellUnitsTarget(address midnight, uint256 targetUnits, address taker, address receiverIfTakerIsSeller, Take[] calldata takes, CollateralTransfer[] calldata collateralSupplies) external;
+    function buyBuyerAssetsTarget(address midnight, uint256 targetBuyerAssets, address taker, Take[] calldata takes, CollateralTransfer[] calldata collateralWithdrawals, address collateralReceiver) external;
+    function sellSellerAssetsTarget(address midnight, uint256 targetSellerAssets, address taker, address receiverIfTakerIsSeller, Take[] calldata takes, CollateralTransfer[] calldata collateralSupplies) external;
     // forgefmt: disable-end
 }

--- a/test/BundlerTest.sol
+++ b/test/BundlerTest.sol
@@ -102,7 +102,7 @@ contract BundlerTest is BaseTest {
         vm.prank(address(0xdead));
         vm.expectRevert(ITakeBundler.Unauthorized.selector);
         takeBundler.buyUnitsTarget(
-            address(midnight), 100, borrower, takes, type(uint256).max, new CollateralTransfer[](0), address(0)
+            address(midnight), 100, borrower, takes, new CollateralTransfer[](0), address(0)
         );
     }
 
@@ -135,7 +135,7 @@ contract BundlerTest is BaseTest {
         if (offerUnits1 >= units - fromOffer0) {
             vm.prank(borrower);
             takeBundler.sellUnitsTarget(
-                address(midnight), units, borrower, borrower, takes, 0, new CollateralTransfer[](0)
+                address(midnight), units, borrower, borrower, takes, new CollateralTransfer[](0)
             );
 
             uint256 consumed0 = midnight.consumed(offers[0].maker, offers[0].group);
@@ -147,7 +147,7 @@ contract BundlerTest is BaseTest {
             vm.prank(borrower);
             vm.expectRevert(ITakeBundler.InsufficientLiquidity.selector);
             takeBundler.sellUnitsTarget(
-                address(midnight), units, borrower, borrower, takes, 0, new CollateralTransfer[](0)
+                address(midnight), units, borrower, borrower, takes, new CollateralTransfer[](0)
             );
         }
     }
@@ -200,8 +200,6 @@ contract BundlerTest is BaseTest {
                 targetBuyerAssets,
                 borrower,
                 takes,
-                0,
-                type(uint256).max,
                 new CollateralTransfer[](0),
                 address(0)
             );
@@ -221,8 +219,6 @@ contract BundlerTest is BaseTest {
                 targetBuyerAssets,
                 borrower,
                 takes,
-                0,
-                type(uint256).max,
                 new CollateralTransfer[](0),
                 address(0)
             );
@@ -275,8 +271,6 @@ contract BundlerTest is BaseTest {
                 borrower,
                 borrower,
                 takes,
-                0,
-                type(uint256).max,
                 new CollateralTransfer[](0)
             );
 
@@ -294,8 +288,6 @@ contract BundlerTest is BaseTest {
                 borrower,
                 borrower,
                 takes,
-                0,
-                type(uint256).max,
                 new CollateralTransfer[](0)
             );
         }
@@ -359,7 +351,7 @@ contract BundlerTest is BaseTest {
         }
 
         vm.prank(borrower);
-        takeBundler.buyUnitsTarget(address(midnight), units, borrower, takes, type(uint256).max, withdrawals, receiver);
+        takeBundler.buyUnitsTarget(address(midnight), units, borrower, takes, withdrawals, receiver);
 
         for (uint256 i; i < numCollaterals; i++) {
             assertEq(midnight.collateral(id, borrower, i), amounts[i] - amounts[i] / 4);
@@ -405,7 +397,7 @@ contract BundlerTest is BaseTest {
 
         vm.prank(borrower);
         takeBundler.buyBuyerAssetsTarget(
-            address(midnight), targetBuyerAssets, borrower, takes, 0, type(uint256).max, withdrawals, receiver
+            address(midnight), targetBuyerAssets, borrower, takes, withdrawals, receiver
         );
 
         for (uint256 i; i < numCollaterals; i++) {
@@ -441,7 +433,7 @@ contract BundlerTest is BaseTest {
         });
 
         vm.prank(borrower);
-        takeBundler.sellUnitsTarget(address(midnight), units, borrower, borrower, takes, 0, supplies);
+        takeBundler.sellUnitsTarget(address(midnight), units, borrower, borrower, takes, supplies);
 
         for (uint256 i; i < numCollaterals; i++) {
             assertEq(midnight.collateral(id, borrower, i), supplies[i].assets);
@@ -483,7 +475,7 @@ contract BundlerTest is BaseTest {
 
         vm.prank(borrower);
         takeBundler.sellSellerAssetsTarget(
-            address(midnight), targetSellerAssets, borrower, borrower, takes, 0, type(uint256).max, supplies
+            address(midnight), targetSellerAssets, borrower, borrower, takes, supplies
         );
 
         for (uint256 i; i < numCollaterals; i++) {
@@ -492,147 +484,4 @@ contract BundlerTest is BaseTest {
         assertEq(loanToken.balanceOf(borrower), targetSellerAssets);
     }
 
-    // Average prices.
-
-    /// @dev Computes the expected totalBuyerAssets for buyUnitsTarget.
-    /// @dev Since buy=false, buyerPrice == tickToPrice(tick) + tradingFee.
-    function _expectedBuyerAssets(uint256 targetUnits, uint256 offerUnits0, uint256 tick0, uint256 tick1)
-        internal
-        view
-        returns (uint256)
-    {
-        uint256 fee = midnight.tradingFee(id, obligation.maturity - block.timestamp);
-        uint256 fromOffer0 = UtilsLib.min(targetUnits, offerUnits0);
-        uint256 fromOffer1 = targetUnits - fromOffer0;
-        return fromOffer0.mulDivUp(TickLib.tickToPrice(tick0) + fee, WAD)
-            + fromOffer1.mulDivUp(TickLib.tickToPrice(tick1) + fee, WAD);
-    }
-
-    /// @dev Computes the expected totalSellerAssets for sellUnitsTarget.
-    /// @dev Since buy=true, sellerPrice == tickToPrice(tick) - tradingFee.
-    function _expectedSellerAssets(uint256 targetUnits, uint256 offerUnits0, uint256 tick0, uint256 tick1)
-        internal
-        view
-        returns (uint256)
-    {
-        uint256 fee = midnight.tradingFee(id, obligation.maturity - block.timestamp);
-        uint256 fromOffer0 = UtilsLib.min(targetUnits, offerUnits0);
-        uint256 fromOffer1 = targetUnits - fromOffer0;
-        return fromOffer0.mulDivDown(TickLib.tickToPrice(tick0) - fee, WAD)
-            + fromOffer1.mulDivDown(TickLib.tickToPrice(tick1) - fee, WAD);
-    }
-
-    function testAveragePriceTooHigh(
-        uint256 offerUnits0,
-        uint256 offerUnits1,
-        uint256 targetUnits,
-        uint256 tick0,
-        uint256 tick1,
-        uint256 maxBuyerAssets
-    ) public {
-        tick0 = bound(tick0, 0, MAX_TICK);
-        tick1 = bound(tick1, 0, MAX_TICK);
-        // Ensure buyerAssets > 0 so the max bound actually triggers.
-        uint256 fee = midnight.tradingFee(id, obligation.maturity - block.timestamp);
-        uint256 minBuyerPrice = UtilsLib.min(TickLib.tickToPrice(tick0) + fee, TickLib.tickToPrice(tick1) + fee);
-        targetUnits = bound(targetUnits, WAD / minBuyerPrice + 1, uint256(type(uint128).max) * 3 / 4);
-
-        offers[0].buy = false;
-        offers[0].receiverIfMakerIsSeller = lender;
-        offers[0].maxUnits = offerUnits0;
-        offers[0].tick = tick0;
-        offers[1].buy = false;
-        offers[1].receiverIfMakerIsSeller = lender;
-        offers[1].maxUnits = offerUnits1;
-        offers[1].tick = tick1;
-        deal(address(loanToken), lender, 0);
-
-        uint256 fromOffer0 = UtilsLib.min(targetUnits, offerUnits0);
-        vm.assume(offerUnits1 >= targetUnits - fromOffer0);
-
-        uint256 expected = _expectedBuyerAssets(targetUnits, offerUnits0, tick0, tick1);
-        vm.assume(expected > 0);
-        maxBuyerAssets = bound(maxBuyerAssets, 0, expected - 1);
-
-        collateralize(obligation, lender, targetUnits);
-
-        Take[] memory takes = new Take[](2);
-        takes[0] = Take({
-            offer: offers[0],
-            units: offerUnits0,
-            ratifierData: ratifierData([offers[0]]),
-            root: root([offers[0]]),
-            proof: proof([offers[0]])
-        });
-        takes[1] = Take({
-            offer: offers[1],
-            units: offerUnits1,
-            ratifierData: ratifierData([offers[1]]),
-            root: root([offers[1]]),
-            proof: proof([offers[1]])
-        });
-
-        _authorizeBundler();
-
-        vm.prank(borrower);
-        vm.expectRevert(ITakeBundler.BuyerAssetsAboveMax.selector);
-        takeBundler.buyUnitsTarget(
-            address(midnight), targetUnits, borrower, takes, maxBuyerAssets, new CollateralTransfer[](0), address(0)
-        );
-    }
-
-    function testAveragePriceTooLow(
-        uint256 offerUnits0,
-        uint256 offerUnits1,
-        uint256 targetUnits,
-        uint256 tick0,
-        uint256 tick1,
-        uint256 minSellerAssets
-    ) public {
-        // Ensure sellerPrice > 0 so the min bound actually triggers.
-        uint256 fee = midnight.tradingFee(id, obligation.maturity - block.timestamp);
-        uint256 minTick = TickLib.priceToTick(fee + 1);
-        tick0 = bound(tick0, minTick, MAX_TICK);
-        tick1 = bound(tick1, minTick, MAX_TICK);
-        uint256 minSellerPrice = UtilsLib.min(TickLib.tickToPrice(tick0) - fee, TickLib.tickToPrice(tick1) - fee);
-        targetUnits = bound(targetUnits, WAD / minSellerPrice + 1, uint256(type(uint128).max) * 3 / 4);
-
-        offers[0].maxUnits = offerUnits0;
-        offers[0].tick = tick0;
-        offers[1].maxUnits = offerUnits1;
-        offers[1].tick = tick1;
-
-        uint256 fromOffer0 = UtilsLib.min(targetUnits, offerUnits0);
-        vm.assume(offerUnits1 >= targetUnits - fromOffer0);
-
-        uint256 expected = _expectedSellerAssets(targetUnits, offerUnits0, tick0, tick1);
-        vm.assume(expected > 0);
-        minSellerAssets = bound(minSellerAssets, expected + 1, type(uint256).max);
-
-        collateralize(obligation, borrower, targetUnits);
-
-        Take[] memory takes = new Take[](2);
-        takes[0] = Take({
-            offer: offers[0],
-            units: offerUnits0,
-            ratifierData: ratifierData([offers[0]]),
-            root: root([offers[0]]),
-            proof: proof([offers[0]])
-        });
-        takes[1] = Take({
-            offer: offers[1],
-            units: offerUnits1,
-            ratifierData: ratifierData([offers[1]]),
-            root: root([offers[1]]),
-            proof: proof([offers[1]])
-        });
-
-        _authorizeBundler();
-
-        vm.prank(borrower);
-        vm.expectRevert(ITakeBundler.SellerAssetsBelowMin.selector);
-        takeBundler.sellUnitsTarget(
-            address(midnight), targetUnits, borrower, borrower, takes, minSellerAssets, new CollateralTransfer[](0)
-        );
-    }
 }

--- a/test/BundlerTest.sol
+++ b/test/BundlerTest.sol
@@ -101,9 +101,7 @@ contract BundlerTest is BaseTest {
 
         vm.prank(address(0xdead));
         vm.expectRevert(ITakeBundler.Unauthorized.selector);
-        takeBundler.buyUnitsTarget(
-            address(midnight), 100, borrower, takes, new CollateralTransfer[](0), address(0)
-        );
+        takeBundler.buyUnitsTarget(address(midnight), 100, borrower, takes, new CollateralTransfer[](0), address(0));
     }
 
     function testSellUnitsTarget(uint256 offerUnits0, uint256 offerUnits1, uint256 units) public {
@@ -196,12 +194,7 @@ contract BundlerTest is BaseTest {
         if (offerUnits1 >= units - fromOffer0) {
             vm.prank(borrower);
             takeBundler.buyBuyerAssetsTarget(
-                address(midnight),
-                targetBuyerAssets,
-                borrower,
-                takes,
-                new CollateralTransfer[](0),
-                address(0)
+                address(midnight), targetBuyerAssets, borrower, takes, new CollateralTransfer[](0), address(0)
             );
 
             uint256 consumed0 = midnight.consumed(offers[0].maker, offers[0].group);
@@ -215,12 +208,7 @@ contract BundlerTest is BaseTest {
             vm.prank(borrower);
             vm.expectRevert(ITakeBundler.InsufficientLiquidity.selector);
             takeBundler.buyBuyerAssetsTarget(
-                address(midnight),
-                targetBuyerAssets,
-                borrower,
-                takes,
-                new CollateralTransfer[](0),
-                address(0)
+                address(midnight), targetBuyerAssets, borrower, takes, new CollateralTransfer[](0), address(0)
             );
         }
     }
@@ -266,12 +254,7 @@ contract BundlerTest is BaseTest {
         if (offerUnits1 >= neededFromOffer1) {
             vm.prank(borrower);
             takeBundler.sellSellerAssetsTarget(
-                address(midnight),
-                targetSellerAssets,
-                borrower,
-                borrower,
-                takes,
-                new CollateralTransfer[](0)
+                address(midnight), targetSellerAssets, borrower, borrower, takes, new CollateralTransfer[](0)
             );
 
             uint256 consumed0 = midnight.consumed(offers[0].maker, offers[0].group);
@@ -283,12 +266,7 @@ contract BundlerTest is BaseTest {
             vm.prank(borrower);
             vm.expectRevert(ITakeBundler.InsufficientLiquidity.selector);
             takeBundler.sellSellerAssetsTarget(
-                address(midnight),
-                targetSellerAssets,
-                borrower,
-                borrower,
-                takes,
-                new CollateralTransfer[](0)
+                address(midnight), targetSellerAssets, borrower, borrower, takes, new CollateralTransfer[](0)
             );
         }
     }
@@ -396,9 +374,7 @@ contract BundlerTest is BaseTest {
         }
 
         vm.prank(borrower);
-        takeBundler.buyBuyerAssetsTarget(
-            address(midnight), targetBuyerAssets, borrower, takes, withdrawals, receiver
-        );
+        takeBundler.buyBuyerAssetsTarget(address(midnight), targetBuyerAssets, borrower, takes, withdrawals, receiver);
 
         for (uint256 i; i < numCollaterals; i++) {
             assertEq(midnight.collateral(id, borrower, i), amounts[i] - amounts[i] / 4);
@@ -474,14 +450,11 @@ contract BundlerTest is BaseTest {
         });
 
         vm.prank(borrower);
-        takeBundler.sellSellerAssetsTarget(
-            address(midnight), targetSellerAssets, borrower, borrower, takes, supplies
-        );
+        takeBundler.sellSellerAssetsTarget(address(midnight), targetSellerAssets, borrower, borrower, takes, supplies);
 
         for (uint256 i; i < numCollaterals; i++) {
             assertEq(midnight.collateral(id, borrower, i), supplies[i].assets);
         }
         assertEq(loanToken.balanceOf(borrower), targetSellerAssets);
     }
-
 }


### PR DESCRIPTION
rationale: the natural worst average formed by the offers that you pass goes a very long way, and it simplifies #717 