### PR TITLE
perf: constructor (Blackthorn-21)

### DIFF
--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -147,7 +147,7 @@ contract Midnight is IMidnight {
 
     constructor() {
         roleSetter = msg.sender;
-        emit EventsLib.Constructor(roleSetter);
+        emit EventsLib.Constructor(msg.sender);
     }
 
     /// MULTICALL ///


### PR DESCRIPTION
we don't really optimize for constructor gas efficiency. Though it's better to not use immutable variables in the constructor in general, as it's not clear if they have already been set of not

https://github.com/sherlock-audit/2026-04-morpho-midnight-apr-6th-2026/issues/21