### PR TITLE
inline isLiquidatable

### DIFF
--- a/certora/specs/Liquidate.spec
+++ b/certora/specs/Liquidate.spec
@@ -52,8 +52,7 @@ rule liquidateOnlyAffectsBalancesWhenLiquidatable(env e, Midnight.Obligation obl
     address user;
     uint256 collateralIndex;
 
-    bool wasLiquidatable = debtOf(id, liqUser) > 0 && !liquidationLocked(id, liqUser)
-        && (e.block.timestamp > obligation.maturity || !isHealthy(obligation, id, liqUser));
+    bool wasLiquidatable = debtOf(id, liqUser) > 0 && !liquidationLocked(id, liqUser) && (e.block.timestamp > obligation.maturity || !isHealthy(obligation, id, liqUser));
 
     uint256 creditBefore = creditOf(id, user);
     uint256 debtBefore = debtOf(id, user);

--- a/certora/specs/Liquidate.spec
+++ b/certora/specs/Liquidate.spec
@@ -20,6 +20,8 @@ methods {
     function creditOf(bytes32 id, address user) external returns (uint256) envfree;
     function debtOf(bytes32 id, address user) external returns (uint256) envfree;
     function collateral(bytes32 id, address user, uint256 index) external returns (uint128) envfree;
+    function liquidationLocked(bytes32 id, address user) external returns (bool) envfree;
+    function isHealthy(Midnight.Obligation, bytes32, address) external returns (bool) envfree;
 }
 
 /// HELPERS ///
@@ -50,7 +52,8 @@ rule liquidateOnlyAffectsBalancesWhenLiquidatable(env e, Midnight.Obligation obl
     address user;
     uint256 collateralIndex;
 
-    bool wasLiquidatable = isLiquidatable(e, obligation, id, liqUser);
+    bool wasLiquidatable = debtOf(id, liqUser) > 0 && !liquidationLocked(id, liqUser)
+        && (e.block.timestamp > obligation.maturity || !isHealthy(obligation, id, liqUser));
 
     uint256 creditBefore = creditOf(id, user);
     uint256 debtBefore = debtOf(id, user);

--- a/certora/specs/Reverts.spec
+++ b/certora/specs/Reverts.spec
@@ -227,14 +227,14 @@ rule oracleRevertCausesIsHealthyRevert(env e, Midnight.Obligation obligation, by
 }
 
 /// If an activated collateral oracle reverts on price and take succeeds, the seller must have no debt.
-/// Assumption : collateralIndex is the MSB otherwise isLiquidatable -> isHealthy short-circuit could find a CEX where first collateral is enough to have maxDebt >= debt and return true.
+/// Assumption : collateralIndex is the MSB otherwise take's isHealthy short-circuit could find a CEX where first collateral is enough to have maxDebt >= debt and return true.
 rule oracleRevertPreventsTakeWhenSellerHasDebt(env e, uint256 units, address taker, address takerCallback, bytes takerCallbackData, address receiver, Midnight.Offer offer, bytes ratifierData, bytes32 root, bytes32[] proof, uint256 collateralIndex) {
     require singleRevertingOracle == offer.obligation.collateralParams[collateralIndex].oracle, "oracle is reverting";
 
     bytes32 id = summaryToId(offer.obligation);
     address seller = offer.buy ? taker : offer.maker;
 
-    // Without this, isLiquidatable short-circuits to false (without calling isHealthy) because
+    // Without this, take's liquidatability check short-circuits to false (without calling isHealthy) because
     // take's tExchange keeps the lock set when wasLocked is true, so the oracle is never queried.
     require !liquidationLocked(id, seller), "seller is not liquidation locked";
 
@@ -286,7 +286,7 @@ rule oracleZeroPreventsWithdrawWhenBorrowerHasDebt(env e, Midnight.Obligation ob
 }
 
 /// If all oracles return 0 and take succeeds, the seller must have no debt.
-/// Note: same short-circuit limitation — take calls isLiquidatable → isHealthy, which may short-circuit.
+/// Note: same short-circuit limitation — take's liquidatability check calls isHealthy, which may short-circuit.
 rule oracleZeroPreventsTakeWhenSellerHasDebt(env e, uint256 units, address taker, address takerCallback, bytes takerCallbackData, address receiver, Midnight.Offer offer, bytes ratifierData, bytes32 root, bytes32[] proof) {
     require forceOracleReturnZero, "all oracles return zero";
 

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -436,12 +436,14 @@ contract Midnight is IMidnight {
                 WrongSellCallbackReturnValue()
             );
         }
-        if (!wasLocked) UtilsLib.tExchange(LIQUIDATION_LOCK_SLOT, id, seller, false);
-        require(
-            position[id][seller].debt == 0
-                || (block.timestamp <= offer.obligation.maturity && isHealthy(offer.obligation, id, seller)),
-            SellerIsLiquidatable()
-        );
+        if (!wasLocked) {
+            UtilsLib.tExchange(LIQUIDATION_LOCK_SLOT, id, seller, false);
+            require(
+                position[id][seller].debt == 0
+                    || (block.timestamp <= offer.obligation.maturity && isHealthy(offer.obligation, id, seller)),
+                SellerIsLiquidatable()
+            );
+        }
 
         return (buyerAssets, sellerAssets, units);
     }

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -435,7 +435,11 @@ contract Midnight is IMidnight {
             );
         }
         if (!wasLocked) UtilsLib.tExchange(LIQUIDATION_LOCK_SLOT, id, seller, false);
-        require(!isLiquidatable(offer.obligation, id, seller), SellerIsLiquidatable());
+        require(
+            position[id][seller].debt == 0
+                || (block.timestamp <= offer.obligation.maturity && isHealthy(offer.obligation, id, seller)),
+            SellerIsLiquidatable()
+        );
 
         return (buyerAssets, sellerAssets, units);
     }
@@ -881,13 +885,6 @@ contract Midnight is IMidnight {
 
     function liquidationLocked(bytes32 id, address user) public view returns (bool) {
         return UtilsLib.tGet(LIQUIDATION_LOCK_SLOT, id, user);
-    }
-
-    /// @dev A borrower is liquidatable if they have debt, liquidation is not transiently locked, and they are
-    /// past maturity or not healthy.
-    function isLiquidatable(Obligation memory obligation, bytes32 id, address borrower) public view returns (bool) {
-        return position[id][borrower].debt > 0 && !liquidationLocked(id, borrower)
-            && (block.timestamp > obligation.maturity || !isHealthy(obligation, id, borrower));
     }
 
     /// @dev This function should be called with the id corresponding to the obligation.

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -439,14 +439,12 @@ contract Midnight is IMidnight {
                 WrongSellCallbackReturnValue()
             );
         }
-        if (!wasLocked) {
-            UtilsLib.tExchange(LIQUIDATION_LOCK_SLOT, id, seller, false);
-            require(
-                position[id][seller].debt == 0
-                    || (block.timestamp <= offer.obligation.maturity && isHealthy(offer.obligation, id, seller)),
-                SellerIsLiquidatable()
-            );
-        }
+        if (!wasLocked) UtilsLib.tExchange(LIQUIDATION_LOCK_SLOT, id, seller, false);
+        require(
+            position[id][seller].debt == 0 || liquidationLocked(id, seller)
+                || (block.timestamp <= offer.obligation.maturity && isHealthy(offer.obligation, id, seller)),
+            SellerIsLiquidatable()
+        );
 
         return (buyerAssets, sellerAssets, units);
     }

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -48,7 +48,8 @@ import {EventsLib} from "./libraries/EventsLib.sol";
 /// @dev Absent bad debt, the face value of a lender's position is `credit - pendingFee`.
 ///
 /// LIQUIDATIONS
-/// @dev Accounts are liquidatable only if the liquidation is not locked and they are either unhealthy or the maturity has passed.
+/// @dev Accounts are liquidatable only if the liquidation is not locked and they are either unhealthy or the maturity
+/// has passed.
 /// @dev Liquidations can revert for other reasons, see LIVENESS.
 /// @dev If an account is healthy, the LIF grows linearly from 1 at maturity to maxLif at maturity + TIME_TO_MAX_LIF.
 /// @dev Before maturity, the liquidation cannot put the borrower back into health (recovery close factor), unless

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -48,7 +48,8 @@ import {EventsLib} from "./libraries/EventsLib.sol";
 /// @dev Absent bad debt, the face value of a lender's position is `credit - pendingFee`.
 ///
 /// LIQUIDATIONS
-/// @dev Accounts with nonzero debt are liquidatable if they are unhealthy or if the maturity has passed.
+/// @dev Accounts are liquidatable only if the liquidation is not locked and they are either unhealthy or the maturity has passed.
+/// @dev Liquidations can revert for other reasons, see LIVENESS.
 /// @dev If an account is healthy, the LIF grows linearly from 1 at maturity to maxLif at maturity + TIME_TO_MAX_LIF.
 /// @dev Before maturity, the liquidation cannot put the borrower back into health (recovery close factor), unless
 /// the liquidation could leave a collateral with a value that would not be enough to repay rcfThreshold units.

--- a/src/interfaces/IMidnight.sol
+++ b/src/interfaces/IMidnight.sol
@@ -175,7 +175,6 @@ interface IMidnight {
     function pendingFee(bytes32 id, address user) external view returns (uint128);
     function lastAccrual(bytes32 id, address user) external view returns (uint128);
     function liquidationLocked(bytes32 id, address user) external view returns (bool);
-    function isLiquidatable(Obligation memory obligation, bytes32 id, address borrower) external view returns (bool);
     function isHealthy(Obligation memory obligation, bytes32 id, address borrower) external view returns (bool);
     function maxLif(uint256 lltv, uint256 cursor) external pure returns (uint256);
     function maxTradingFee(uint256 index) external pure returns (uint256);

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -898,32 +898,10 @@ contract LiquidationTest is BaseTest {
         assertLt(midnight.debtOf(id, borrower), debtBefore, "debt should decrease after liquidation");
     }
 
-    function testIsLiquidatableNoDebt() public {
+    function testLiquidateNoDebtReverts() public {
         midnight.touchObligation(obligation);
-        assertFalse(midnight.isLiquidatable(obligation, id, borrower), "no debt not liquidatable");
-    }
-
-    function testIsLiquidatableHealthyPreMaturityView(uint256 units) public {
-        units = bound(units, 1, MAX_UNITS);
-        collateralize(obligation, borrower, units);
-        setupObligation(obligation, units);
-        assertFalse(midnight.isLiquidatable(obligation, id, borrower), "healthy pre-maturity not liquidatable");
-    }
-
-    function testIsLiquidatablePostMaturityView(uint256 units) public {
-        units = bound(units, 1, MAX_UNITS);
-        collateralize(obligation, borrower, units);
-        setupObligation(obligation, units);
-        vm.warp(obligation.maturity + 1);
-        assertTrue(midnight.isLiquidatable(obligation, id, borrower), "post-maturity with debt is liquidatable");
-    }
-
-    function testIsLiquidatableUnhealthyPreMaturityView(uint256 units) public {
-        units = bound(units, 1, MAX_UNITS);
-        collateralize(obligation, borrower, units);
-        setupObligation(obligation, units);
-        Oracle(obligation.collateralParams[0].oracle).setPrice(ORACLE_PRICE_SCALE / 2);
-        assertTrue(midnight.isLiquidatable(obligation, id, borrower), "unhealthy pre-maturity is liquidatable");
+        vm.expectRevert(IMidnight.NotLiquidatable.selector);
+        midnight.liquidate(obligation, 0, 0, 0, borrower, address(this), address(0), "");
     }
 
     function onLiquidate(


### PR DESCRIPTION
rationale:
- it "hides" some stuff in take (notably why it's not possible to borrow after the maturity)
- not having to document the spec of isLiquidatable reverts vs liquidate reverts (~~~as we did it anyway)

keeps the liquidationLock check in take for [this](https://github.com/morpho-org/midnight/pull/772#discussion_r3189114689).

didn't put the require in the if above to have a clear mirror with the require in liquidate.

fixes #760