### PR TITLE
bundler forces same obligation

### DIFF
--- a/src/periphery/TakeBundler.sol
+++ b/src/periphery/TakeBundler.sol
@@ -145,7 +145,6 @@ contract TakeBundler is ITakeBundler {
     /// @dev The taker must have authorized this bundler and the msg.sender (if different from the taker) on Midnight.
     /// @dev The bundler skips every reason why `take` can revert (including ones that are not asynchrony related).
     /// @dev If taking an offer reverts, the bundler will completely skip this offer.
-    /// @dev Takes could have different obligations (with the same loan token).
     /// @dev Total cost is `targetBuyerAssets`.
     /// @dev The referral fee changes the amount that must be filled, which can change the average taking price.
     function buyBuyerAssetsTarget(
@@ -162,6 +161,8 @@ contract TakeBundler is ITakeBundler {
         require(referralFeePct < WAD, PctExceeded());
 
         address loanToken = takes[0].offer.obligation.loanToken;
+        // touchObligation to have the correct trading fees.
+        bytes32 id = IMidnight(midnight).touchObligation(takes[0].offer.obligation);
         _forceApproveMax(loanToken, midnight);
         SafeTransferLib.safeTransferFrom(loanToken, msg.sender, address(this), targetBuyerAssets);
 
@@ -171,9 +172,7 @@ contract TakeBundler is ITakeBundler {
         uint256 filledBuyerAssets;
         for (uint256 i; i < takes.length && filledBuyerAssets < targetFilledBuyerAssets; i++) {
             require(!takes[i].offer.buy, InconsistentSide());
-            require(takes[i].offer.obligation.loanToken == loanToken, InconsistentLoanToken());
-            // touchObligation to have the correct trading fees.
-            bytes32 id = IMidnight(midnight).touchObligation(takes[i].offer.obligation);
+            require(IMidnight(midnight).toId(takes[i].offer.obligation) == id, InconsistentObligation());
             try IMidnight(midnight)
                 .take(
                     UtilsLib.min(
@@ -218,7 +217,6 @@ contract TakeBundler is ITakeBundler {
     /// @dev The bundler skips every reason why `take` can revert (including ones that are not asynchrony related).
     /// @dev If taking an offer reverts, the bundler will completely skip this offer.
     /// @dev The msg.sender should have approved the bundler to transfer enough collateral.
-    /// @dev Takes could have different obligations (with the same loan token).
     /// @dev Total receipt is `targetSellerAssets`.
     /// @dev The referral fee changes the amount that must be filled, which can change the average taking price.
     function sellSellerAssetsTarget(
@@ -234,6 +232,8 @@ contract TakeBundler is ITakeBundler {
         require(taker == msg.sender || IMidnight(midnight).isAuthorized(taker, msg.sender), Unauthorized());
         require(referralFeePct < WAD, PctExceeded());
         address loanToken = takes[0].offer.obligation.loanToken;
+        // touchObligation to have the correct trading fees.
+        bytes32 id = IMidnight(midnight).touchObligation(takes[0].offer.obligation);
 
         Obligation memory obligation = takes[0].offer.obligation;
         for (uint256 i; i < collateralSupplies.length; i++) {
@@ -252,9 +252,7 @@ contract TakeBundler is ITakeBundler {
         uint256 filledSellerAssets;
         for (uint256 i; i < takes.length && filledSellerAssets < targetFilledSellerAssets; i++) {
             require(takes[i].offer.buy, InconsistentSide());
-            require(takes[i].offer.obligation.loanToken == loanToken, InconsistentLoanToken());
-            // touchObligation to have the correct trading fees.
-            bytes32 id = IMidnight(midnight).touchObligation(takes[i].offer.obligation);
+            require(IMidnight(midnight).toId(takes[i].offer.obligation) == id, InconsistentObligation());
             try IMidnight(midnight)
                 .take(
                     UtilsLib.min(

--- a/src/periphery/interfaces/ITakeBundler.sol
+++ b/src/periphery/interfaces/ITakeBundler.sol
@@ -19,7 +19,6 @@ struct CollateralTransfer {
 
 interface ITakeBundler {
     /// ERRORS ///
-    error InconsistentLoanToken();
     error InconsistentObligation();
     error InconsistentSide();
     error OutOfOffers();

--- a/test/BundlerTest.sol
+++ b/test/BundlerTest.sol
@@ -227,6 +227,74 @@ contract BundlerTest is BaseTest {
         }
     }
 
+    function testBuyUnitsTargetInconsistentObligation() public {
+        Obligation memory otherObligation = obligation;
+        otherObligation.maturity = block.timestamp + 360 days;
+
+        offers[0].buy = false;
+        offers[0].maker = borrower;
+        offers[0].receiverIfMakerIsSeller = borrower;
+        offers[0].maxUnits = 1;
+        offers[1].buy = false;
+        offers[1].maker = borrower;
+        offers[1].receiverIfMakerIsSeller = borrower;
+        offers[1].obligation = otherObligation;
+        offers[1].maxUnits = 1;
+
+        Take[] memory takes = new Take[](2);
+        takes[0] = Take({
+            offer: offers[0],
+            units: 1,
+            ratifierData: ratifierData([offers[0]]),
+            root: root([offers[0]]),
+            proof: proof([offers[0]])
+        });
+        takes[1] = Take({
+            offer: offers[1],
+            units: 1,
+            ratifierData: ratifierData([offers[1]]),
+            root: root([offers[1]]),
+            proof: proof([offers[1]])
+        });
+
+        vm.prank(lender);
+        vm.expectRevert(ITakeBundler.InconsistentObligation.selector);
+        takeBundler.buyUnitsTarget(
+            address(midnight), 2, type(uint256).max, lender, takes, new CollateralTransfer[](0), address(0), 0, address(0)
+        );
+    }
+
+    function testSellUnitsTargetInconsistentObligation() public {
+        Obligation memory otherObligation = obligation;
+        otherObligation.maturity = block.timestamp + 360 days;
+
+        offers[0].maxUnits = 1;
+        offers[1].obligation = otherObligation;
+        offers[1].maxUnits = 1;
+
+        Take[] memory takes = new Take[](2);
+        takes[0] = Take({
+            offer: offers[0],
+            units: 1,
+            ratifierData: ratifierData([offers[0]]),
+            root: root([offers[0]]),
+            proof: proof([offers[0]])
+        });
+        takes[1] = Take({
+            offer: offers[1],
+            units: 1,
+            ratifierData: ratifierData([offers[1]]),
+            root: root([offers[1]]),
+            proof: proof([offers[1]])
+        });
+
+        vm.prank(borrower);
+        vm.expectRevert(ITakeBundler.InconsistentObligation.selector);
+        takeBundler.sellUnitsTarget(
+            address(midnight), 2, borrower, borrower, takes, new CollateralTransfer[](0), 0, address(0)
+        );
+    }
+
     function testBuyBuyerAssetsTargetInconsistentObligation() public {
         for (uint256 i; i <= 6; i++) {
             midnight.setObligationTradingFee(id, i, 0);

--- a/test/BundlerTest.sol
+++ b/test/BundlerTest.sol
@@ -260,7 +260,15 @@ contract BundlerTest is BaseTest {
         vm.prank(lender);
         vm.expectRevert(ITakeBundler.InconsistentObligation.selector);
         takeBundler.buyUnitsTarget(
-            address(midnight), 2, type(uint256).max, lender, takes, new CollateralTransfer[](0), address(0), 0, address(0)
+            address(midnight),
+            2,
+            type(uint256).max,
+            lender,
+            takes,
+            new CollateralTransfer[](0),
+            address(0),
+            0,
+            address(0)
         );
     }
 

--- a/test/BundlerTest.sol
+++ b/test/BundlerTest.sol
@@ -227,69 +227,45 @@ contract BundlerTest is BaseTest {
         }
     }
 
-    function testBuyBuyerAssetsTargetUsesEachOfferObligationId() public {
-        uint256 tick = TickLib.priceToTick(0.99e18);
-        uint256 offerPrice = TickLib.tickToPrice(tick);
-
+    function testBuyBuyerAssetsTargetInconsistentObligation() public {
         for (uint256 i; i <= 6; i++) {
             midnight.setObligationTradingFee(id, i, 0);
         }
 
         Obligation memory otherObligation = obligation;
         otherObligation.maturity = block.timestamp + 360 days;
-        bytes32 otherId = midnight.touchObligation(otherObligation);
-        uint256 otherTradingFee = midnight.tradingFee(otherId, otherObligation.maturity - block.timestamp);
-        uint256 otherBuyerPrice = offerPrice + otherTradingFee;
-        require(otherTradingFee > 0, "trading fee zero");
-        require(otherBuyerPrice <= WAD, "buyer price greater than one");
-
-        uint256 firstUnits = 10e18;
-        uint256 firstBuyerAssets = firstUnits.mulDivUp(offerPrice, WAD);
-        uint256 remainingBuyerAssets = 1000e18;
-        uint256 expectedSecondUnits = remainingBuyerAssets.mulDivDown(WAD, otherBuyerPrice);
-        uint256 maxSecondUnits = remainingBuyerAssets.mulDivUp(WAD, offerPrice);
-        uint256 targetBuyerAssets = firstBuyerAssets + remainingBuyerAssets;
 
         offers[0].buy = false;
         offers[0].maker = borrower;
         offers[0].receiverIfMakerIsSeller = borrower;
-        offers[0].tick = tick;
-        offers[0].maxUnits = firstUnits;
+        offers[0].maxUnits = 1;
         offers[1].buy = false;
         offers[1].maker = borrower;
         offers[1].receiverIfMakerIsSeller = borrower;
         offers[1].obligation = otherObligation;
-        offers[1].tick = tick;
-        offers[1].maxUnits = maxSecondUnits;
-
-        collateralize(obligation, borrower, firstUnits);
-        collateralize(otherObligation, borrower, maxSecondUnits);
+        offers[1].maxUnits = 1;
 
         Take[] memory takes = new Take[](2);
         takes[0] = Take({
             offer: offers[0],
-            units: firstUnits,
+            units: 1,
             ratifierData: ratifierData([offers[0]]),
             root: root([offers[0]]),
             proof: proof([offers[0]])
         });
         takes[1] = Take({
             offer: offers[1],
-            units: maxSecondUnits,
+            units: 1,
             ratifierData: ratifierData([offers[1]]),
             root: root([offers[1]]),
             proof: proof([offers[1]])
         });
 
         vm.prank(lender);
+        vm.expectRevert(ITakeBundler.InconsistentObligation.selector);
         takeBundler.buyBuyerAssetsTarget(
-            address(midnight), targetBuyerAssets, lender, takes, new CollateralTransfer[](0), address(0), 0, address(0)
+            address(midnight), 1000, lender, takes, new CollateralTransfer[](0), address(0), 0, address(0)
         );
-
-        assertEq(type(uint256).max - loanToken.balanceOf(lender), targetBuyerAssets, "lender total cost");
-        assertEq(midnight.creditOf(id, lender), firstUnits, "first obligation lender credit");
-        assertEq(midnight.creditOf(otherId, lender), expectedSecondUnits, "second obligation lender credit");
-        assertEq(loanToken.balanceOf(address(takeBundler)), 0, "bundler residual");
     }
 
     function testSellSellerAssetsTarget(uint256 offerUnits0, uint256 offerUnits1, uint256 targetSellerAssets) public {
@@ -362,57 +338,35 @@ contract BundlerTest is BaseTest {
         }
     }
 
-    function testSellSellerAssetsTargetUsesEachOfferObligationId() public {
-        for (uint256 i; i <= 6; i++) {
-            midnight.setObligationTradingFee(id, i, 0);
-        }
-
+    function testSellSellerAssetsTargetInconsistentObligation() public {
         Obligation memory otherObligation = obligation;
         otherObligation.maturity = block.timestamp + 360 days;
-        bytes32 otherId = midnight.touchObligation(otherObligation);
-        uint256 otherTradingFee = midnight.tradingFee(otherId, otherObligation.maturity - block.timestamp);
-        require(otherTradingFee > 0, "trading fee zero");
 
-        uint256 offerPrice = TickLib.tickToPrice(MAX_TICK);
-        uint256 otherSellerPrice = offerPrice - otherTradingFee;
-        uint256 firstUnits = 10e18;
-        uint256 firstSellerAssets = firstUnits.mulDivDown(offerPrice, WAD);
-        uint256 remainingSellerAssets = 1000e18;
-        uint256 maxSecondUnits = remainingSellerAssets.mulDivUp(WAD, otherSellerPrice);
-        uint256 targetSellerAssets = firstSellerAssets + remainingSellerAssets;
-
-        offers[0].maxUnits = firstUnits;
+        offers[0].maxUnits = 1;
         offers[1].obligation = otherObligation;
-        offers[1].maxUnits = maxSecondUnits;
-
-        collateralize(obligation, borrower, firstUnits);
-        collateralize(otherObligation, borrower, maxSecondUnits);
+        offers[1].maxUnits = 1;
 
         Take[] memory takes = new Take[](2);
         takes[0] = Take({
             offer: offers[0],
-            units: firstUnits,
+            units: 1,
             ratifierData: ratifierData([offers[0]]),
             root: root([offers[0]]),
             proof: proof([offers[0]])
         });
         takes[1] = Take({
             offer: offers[1],
-            units: maxSecondUnits,
+            units: 1,
             ratifierData: ratifierData([offers[1]]),
             root: root([offers[1]]),
             proof: proof([offers[1]])
         });
 
         vm.prank(borrower);
+        vm.expectRevert(ITakeBundler.InconsistentObligation.selector);
         takeBundler.sellSellerAssetsTarget(
-            address(midnight), targetSellerAssets, borrower, borrower, takes, new CollateralTransfer[](0), 0, address(0)
+            address(midnight), 1000, borrower, borrower, takes, new CollateralTransfer[](0), 0, address(0)
         );
-
-        assertEq(loanToken.balanceOf(borrower), targetSellerAssets, "borrower receipt");
-        assertEq(midnight.creditOf(id, lender), firstUnits, "first obligation lender credit");
-        assertEq(midnight.creditOf(otherId, lender), maxSecondUnits, "second obligation lender credit");
-        assertEq(loanToken.balanceOf(address(takeBundler)), 0, "bundler residual");
     }
 
     // Referral fee.


### PR DESCRIPTION
at the end we remove the multi obligation take because 1) it's a narrow use-case, you go a long way with async cross-obligation routing and 2) it create issues with collateral management (similar to partial fills), see #730