### PR TITLE
Perf: hash collaterals

### DIFF
--- a/src/ratifiers/HashLib.sol
+++ b/src/ratifiers/HashLib.sol
@@ -26,11 +26,19 @@ library HashLib {
             collateralParamsHashes[i] = hashCollateralParams(obligation.collateralParams[i]);
         }
 
+        bytes32 collateralParamsHash;
+        assembly ("memory-safe") {
+            collateralParamsHash := keccak256(
+                add(collateralParamsHashes, 0x20),
+                mul(mload(collateralParamsHashes), 0x20)
+            )
+        }
+
         return keccak256(
             abi.encode(
                 OBLIGATION_TYPEHASH,
                 obligation.loanToken,
-                keccak256(abi.encodePacked(collateralParamsHashes)),
+                collateralParamsHash,
                 obligation.maturity,
                 obligation.rcfThreshold,
                 obligation.enterGate,

--- a/src/ratifiers/HashLib.sol
+++ b/src/ratifiers/HashLib.sol
@@ -27,6 +27,7 @@ library HashLib {
         }
 
         bytes32 collateralParamsHash;
+        // same as keccak256(abi.encodePacked(collateralParamsHashes));
         assembly ("memory-safe") {
             collateralParamsHash := keccak256(
                 add(collateralParamsHashes, 0x20),

--- a/test/HashLibTest.sol
+++ b/test/HashLibTest.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.0;
 
 import {Test} from "../lib/forge-std/src/Test.sol";
 import {HashLib} from "../src/ratifiers/HashLib.sol";
-import {Offer} from "../src/interfaces/IMidnight.sol";
-import {OFFER_TYPEHASH} from "../src/libraries/ConstantsLib.sol";
+import {Offer, Obligation} from "../src/interfaces/IMidnight.sol";
+import {OBLIGATION_TYPEHASH, OFFER_TYPEHASH} from "../src/libraries/ConstantsLib.sol";
 
 contract HashLibTest is Test {
     function testHashOfferMatchesReference(Offer memory offer) public pure {
@@ -31,5 +31,24 @@ contract HashLibTest is Test {
             )
         );
         assertEq(HashLib.hashOffer(offer), expectedHash);
+    }
+
+    function testHashObligationMatchesReference(Obligation memory obligation) public pure {
+        bytes32[] memory collateralParamsHashes = new bytes32[](obligation.collateralParams.length);
+        for (uint256 i = 0; i < obligation.collateralParams.length; i++) {
+            collateralParamsHashes[i] = HashLib.hashCollateralParams(obligation.collateralParams[i]);
+        }
+        bytes32 expectedHash = keccak256(
+            abi.encode(
+                OBLIGATION_TYPEHASH,
+                obligation.loanToken,
+                keccak256(abi.encodePacked(collateralParamsHashes)),
+                obligation.maturity,
+                obligation.rcfThreshold,
+                obligation.enterGate,
+                obligation.liquidatorGate
+            )
+        );
+        assertEq(HashLib.hashObligation(obligation), expectedHash);
     }
 }


### PR DESCRIPTION
<img width="502" height="195" alt="Screenshot 2026-05-11 at 23 48 56" src="https://github.com/user-attachments/assets/c7ed37e9-6246-429c-b79e-0fa084b503a8" />

<details>
<summary>Tested with</summary>

```solidity
// SPDX-License-Identifier: GPL-2.0-or-later
pragma solidity ^0.8.0;

import {Test, console} from "../lib/forge-std/src/Test.sol";
import {HashLib} from "../src/ratifiers/HashLib.sol";
import {Offer, Obligation, CollateralParams} from "../src/interfaces/IMidnight.sol";
import {OBLIGATION_TYPEHASH, OFFER_TYPEHASH} from "../src/libraries/ConstantsLib.sol";

contract HashLibTest is Test {
    Obligation internal obligationStorage;

    function testHashOfferMatchesReference(Offer memory offer) public pure {
        /// Equivalent to HashLib.hashOffer but does not compile under Certora's mode (stack-too-deep).
        bytes32 expectedHash = keccak256(
            abi.encode(
                OFFER_TYPEHASH,
                HashLib.hashObligation(offer.obligation),
                offer.buy,
                offer.maker,
                offer.start,
                offer.expiry,
                offer.tick,
                offer.group,
                offer.session,
                offer.callback,
                keccak256(offer.callbackData),
                offer.receiverIfMakerIsSeller,
                offer.ratifier,
                offer.reduceOnly,
                offer.maxUnits,
                offer.maxSellerAssets,
                offer.maxBuyerAssets
            )
        );
        assertEq(HashLib.hashOffer(offer), expectedHash);
    }

    /// @dev Reference implementation that uses Solidity's `abi.encodePacked` for the collateralParamsHashes hash.
    function hashObligationReference(Obligation memory obligation) internal pure returns (bytes32) {
        bytes32[] memory collateralParamsHashes = new bytes32[](obligation.collateralParams.length);
        for (uint256 i = 0; i < obligation.collateralParams.length; i++) {
            collateralParamsHashes[i] = HashLib.hashCollateralParams(obligation.collateralParams[i]);
        }
        return keccak256(
            abi.encode(
                OBLIGATION_TYPEHASH,
                obligation.loanToken,
                keccak256(abi.encodePacked(collateralParamsHashes)),
                obligation.maturity,
                obligation.rcfThreshold,
                obligation.enterGate,
                obligation.liquidatorGate
            )
        );
    }

    function testHashObligationMatchesReference(Obligation memory obligation) public pure {
        assertEq(HashLib.hashObligation(obligation), hashObligationReference(obligation));
    }

    /// @dev Sets up an obligation with `n` distinct collateral params in storage and returns it.
    function _setupObligation(uint256 n) internal returns (Obligation memory) {
        delete obligationStorage;
        obligationStorage.loanToken = address(uint160(0x1234));
        obligationStorage.maturity = 1_700_000_000;
        obligationStorage.rcfThreshold = 12345;
        obligationStorage.enterGate = address(uint160(0xABCD));
        obligationStorage.liquidatorGate = address(uint160(0xBEEF));
        for (uint256 i = 0; i < n; i++) {
            obligationStorage.collateralParams.push(
                CollateralParams({
                    token: address(uint160(0xC000 + i)),
                    lltv: 0.86e18,
                    maxLif: 1.15e18 + i,
                    oracle: address(uint160(0xD000 + i))
                })
            );
        }
        return obligationStorage;
    }

    function _measure(uint256 n) internal returns (uint256 gasNew, uint256 gasOld) {
        Obligation memory obligation = _setupObligation(n);

        uint256 g1 = gasleft();
        bytes32 newHash = HashLib.hashObligation(obligation);
        gasNew = g1 - gasleft();

        uint256 g2 = gasleft();
        bytes32 oldHash = hashObligationReference(obligation);
        gasOld = g2 - gasleft();

        // Use the return values to defeat dead-code elimination.
        require(newHash == oldHash, "mismatch");
    }

    function testGasHashObligation() public {
        uint256[5] memory sizes = [uint256(1), 2, 5, 10, 128];
        for (uint256 i = 0; i < sizes.length; i++) {
            (uint256 gasNew, uint256 gasOld) = _measure(sizes[i]);
            console.log("collateralParams.length =", sizes[i]);
            console.log("  old gas =", gasOld);
            console.log("  new gas =", gasNew);
            console.log("  saved   =", gasOld - gasNew);
            assertLt(gasNew, gasOld, "assembly hash should be cheaper");
        }
    }
}
```
</details>