### PR TITLE
increasing wExp

### DIFF
--- a/src/libraries/TickLib.sol
+++ b/src/libraries/TickLib.sol
@@ -26,7 +26,8 @@ library TickLib {
                 return 1e36 / wExp(-x);
             } else {
                 int256 ln2 = 0.693147180559945309e18; // floor(ln(2) * 1e18)
-                int256 q = (x + ln2 / 2) / ln2;
+                int256 offset = 0.32261121498945987e18;
+                int256 q = (x + offset) / ln2;
                 int256 r = x - q * ln2;
                 int256 secondTerm = r * r / (2 * 1e18);
                 int256 thirdTerm = secondTerm * r / (3 * 1e18);

--- a/src/libraries/TickLib.sol
+++ b/src/libraries/TickLib.sol
@@ -26,6 +26,7 @@ library TickLib {
                 return 1e36 / wExp(-x);
             } else {
                 int256 ln2 = 0.693147180559945309e18; // floor(ln(2) * 1e18)
+                // offset is chosen such that expR(-offset) == expR(ln2 - offset - 1), so wExp is non-decreasing.
                 int256 offset = 0.32261121498945987e18;
                 int256 q = (x + offset) / ln2;
                 int256 r = x - q * ln2;

--- a/test/TickLibTest.sol
+++ b/test/TickLibTest.sol
@@ -117,10 +117,10 @@ contract TickLibTest is BaseTest {
             totalRelErrorWad += relErrorWad;
             maxRelErrorWad = max(maxRelErrorWad, relErrorWad);
 
-            // 3-term Taylor in wExp yields max ~1.7 bps absolute error; 2 bps threshold leaves headroom.
-            assertLe(absErrorWad, 0.0002e18, string.concat("Tick ", vm.toString(tick), " error exceeds 2 bps"));
+            // 3-term Taylor in wExp yields max ~1.4 bps absolute error; 2 bps threshold leaves headroom.
+            assertLe(absErrorWad, 0.00014e18, string.concat("Tick ", vm.toString(tick), " error exceeds 2 bps"));
             if (solPrice > 0.01e18) {
-                assertLe(relErrorWad, 0.0015e18, string.concat("Tick ", vm.toString(tick), " error exceeds 0.15%"));
+                assertLe(relErrorWad, 0.0007e18, string.concat("Tick ", vm.toString(tick), " error exceeds 0.07%"));
             }
 
             // Check exact price is bracketed by adjacent sol prices in the bulk of the range,

--- a/test/TickLibTest.sol
+++ b/test/TickLibTest.sol
@@ -120,7 +120,7 @@ contract TickLibTest is BaseTest {
             // 3-term Taylor in wExp yields max ~1.4 bps absolute error; 2 bps threshold leaves headroom.
             assertLe(absErrorWad, 0.00014e18, string.concat("Tick ", vm.toString(tick), " error exceeds 2 bps"));
             if (solPrice > 0.01e18) {
-                assertLe(relErrorWad, 0.0007e18, string.concat("Tick ", vm.toString(tick), " error exceeds 0.07%"));
+                assertLe(relErrorWad, 0.0007e18, string.concat("Tick ", vm.toString(tick), " error exceeds 7 bps"));
             }
 
             // Check exact price is bracketed by adjacent sol prices in the bulk of the range,


### PR DESCRIPTION
Found while doing the verification of `TickLib`, see #880.

In the current code it is not true that `wExp` is increasing:
- `wExp(ln2 / 2) = 1413568230602850528`
- `wExp(ln2 / 2 + 1) = 1413090045753399652`
- so `wExp(ln2 / 2) > wExp(ln2 / 2 + 1)`

Note that in practice it is not an issue because `tick -> wExp(LN_ONE_PLUS_DELTA * (int256(MAX_TICK / 2) - int256(tick)))` is actually increasing (but it's not clear how to prove that other than by exhaustive testing).

This PR:
- makes so the computation is more precise (see bounds being reduced in the tests)
- changes the computation very little. It changes `ln2 / 2` into `offset`, where offset is very close to `ln2 / 2` (only about 7% difference)
- makes so $\mathrm{wExp}$ is actually increasing, see proof below

# Proof that $\mathrm{wExp}$ is increasing

To show that $\mathrm{wExp}$ is increasing, it is enough to restrict to non-negative inputs and check consecutive inputs.

Let $P_3(r)=10^{18}+r+\mathrm{secondTerm}+\mathrm{thirdTerm}$, and let $q(x)$ be the quotient in the Euclidean division of $x+\mathrm{offset}$ by $\mathrm{ln2}$. Then

$$
\begin{aligned}
x+\mathrm{offset} &= q(x)\mathrm{ln2}+g,\quad 0\le g<\mathrm{ln2}\\
r(x) &= x-q(x)\mathrm{ln2}=g-\mathrm{offset}\\
-\mathrm{offset} &\le r(x)\le \mathrm{ln2}-\mathrm{offset}-1
\end{aligned}
$$

Note that $\mathrm{offset}<\mathrm{ln2}$.
Note also that we still have $|r(x)|<\mathrm{ln2}$ which is relevant in a casting comment of $\mathrm{wExp}$.

## 1. Monotonicity away from the wraparound point

We show that $P_3(r)$ is non-decreasing in the relevant range. Thus $\mathrm{wExp}(x+1)\ge \mathrm{wExp}(x)$ whenever

$$
r(x)<\mathrm{ln2}-\mathrm{offset}-1.
$$

Clearly this is true for non-negative $r$. For negative $r$, it is enough to show that

$$
f(r)=r+\mathrm{secondTerm}=r+\frac{r^2}{2\cdot 10^{18}}
$$

is non-decreasing. Indeed,

$$
\begin{aligned}
f(r+1)&=r+1+\frac{(r+1)^2}{2\cdot 10^{18}}\\
&=r+1+\frac{r^2+2r+1}{2\cdot 10^{18}}\\
&\ge r+1+\frac{r^2-2\cdot 10^{18}}{2\cdot 10^{18}}\qquad\text{because }r>-\mathrm{offset}>-10^{18}\\
&=r+\frac{r^2}{2\cdot 10^{18}}=f(r).
\end{aligned}
$$

So $P_3(r)$ is non-decreasing on the relevant range.

## 2. The wraparound point

We have, by a direct computation:

$$
2P_3(-\mathrm{offset})=P_3(\mathrm{ln2}-\mathrm{offset}-1).
$$

So for an input $x$ such that

$$
r(x)=\mathrm{ln2}-\mathrm{offset}-1,
$$

the next input satisfies

$$
r(x+1)=-\mathrm{offset}
\quad\text{and}\quad
q(x+1)=q(x)+1.
$$

Using the range-reduced form

$$
\mathrm{wExp}(x)=2^{q(x)}P_3(r(x)),
$$

we get

$$
\begin{aligned}
\mathrm{wExp}(x+1)&=2^{q(x)+1}P_3(-\mathrm{offset})\\
&=2^{q(x)} * (2 P_3(-\mathrm{offset}))\\
&=2^{q(x)}P_3(\mathrm{ln2}-\mathrm{offset}-1)\\
&=\mathrm{wExp}(x).
\end{aligned}
$$

Therefore,

$$
\mathrm{wExp}(x+1)\ge \mathrm{wExp}(x)
$$

for every non-negative integer input $x$, so $\mathrm{wExp}$ is increasing on the non-negative integers.