### PR TITLE
small refactor take

### DIFF
--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -349,8 +349,6 @@ contract Midnight is IMidnight {
 
         require(offer.tick % _marketState.tickSpacing == 0, TickNotAccessible());
 
-        (address buyer, address seller) = offer.buy ? (offer.maker, taker) : (taker, offer.maker);
-
         uint256 offerPrice = TickLib.tickToPrice(offer.tick);
         uint256 timeToMaturity = UtilsLib.zeroFloorSub(offer.market.maturity, block.timestamp);
         uint256 _tradingFee = tradingFee(id, timeToMaturity);
@@ -368,6 +366,7 @@ contract Midnight is IMidnight {
             require(newConsumed <= offer.maxUnits, ConsumedUnits());
         }
 
+        (address buyer, address seller) = offer.buy ? (offer.maker, taker) : (taker, offer.maker);
         Position storage buyerPos = position[id][buyer];
         Position storage sellerPos = position[id][seller];
 
@@ -383,17 +382,6 @@ contract Midnight is IMidnight {
             ? UtilsLib.toUint128(sellerPos.pendingFee.mulDivUp(sellerCreditDecrease, sellerPos.credit))
             : 0;
 
-        buyerPos.debt -= UtilsLib.toUint128(units - buyerCreditIncrease);
-        buyerPos.pendingFee += buyerPendingFeeIncrease;
-        buyerPos.credit += UtilsLib.toUint128(buyerCreditIncrease);
-
-        sellerPos.pendingFee -= sellerPendingFeeDecrease;
-        sellerPos.credit -= UtilsLib.toUint128(sellerCreditDecrease);
-        sellerPos.debt += UtilsLib.toUint128(sellerDebtIncrease);
-
-        _marketState.totalUnits =
-            UtilsLib.toUint128(_marketState.totalUnits + buyerCreditIncrease - sellerCreditDecrease);
-
         if (offer.reduceOnly) {
             require(offer.buy ? buyerCreditIncrease == 0 : sellerDebtIncrease == 0, MakerCreditOrDebtIncreased());
         }
@@ -408,6 +396,17 @@ contract Midnight is IMidnight {
                 || IEnterGate(offer.market.enterGate).canIncreaseDebt(seller),
             SellerGatedFromIncreasingDebt()
         );
+
+        buyerPos.debt -= UtilsLib.toUint128(units - buyerCreditIncrease);
+        buyerPos.pendingFee += buyerPendingFeeIncrease;
+        buyerPos.credit += UtilsLib.toUint128(buyerCreditIncrease);
+
+        sellerPos.pendingFee -= sellerPendingFeeDecrease;
+        sellerPos.credit -= UtilsLib.toUint128(sellerCreditDecrease);
+        sellerPos.debt += UtilsLib.toUint128(sellerDebtIncrease);
+
+        _marketState.totalUnits =
+            UtilsLib.toUint128(_marketState.totalUnits + buyerCreditIncrease - sellerCreditDecrease);
 
         address buyerCallback = offer.buy ? offer.callback : takerCallback;
         address sellerCallback = offer.buy ? takerCallback : offer.callback;

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -341,13 +341,12 @@ contract Midnight is IMidnight {
         MarketState storage _marketState = marketState[id];
         require(_marketState.lossFactor < type(uint128).max, MarketLossFactorMaxedOut());
         require(UtilsLib.atMostOneNonZero(offer.maxAssets, offer.maxUnits), MultipleNonZero());
+        require(offer.tick % _marketState.tickSpacing == 0, TickNotAccessible());
         require(block.timestamp >= offer.start, OfferNotStarted());
         require(block.timestamp <= offer.expiry, OfferExpired());
         require(offer.maker != taker, SelfTake());
         require(isAuthorized[offer.maker][offer.ratifier], RatifierUnauthorized());
         require(IRatifier(offer.ratifier).isRatified(offer, ratifierData) == CALLBACK_SUCCESS, RatifierFail());
-
-        require(offer.tick % _marketState.tickSpacing == 0, TickNotAccessible());
 
         uint256 offerPrice = TickLib.tickToPrice(offer.tick);
         uint256 timeToMaturity = UtilsLib.zeroFloorSub(offer.market.maturity, block.timestamp);

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -381,9 +381,7 @@ contract Midnight is IMidnight {
             ? UtilsLib.toUint128(sellerPos.pendingFee.mulDivUp(sellerCreditDecrease, sellerPos.credit))
             : 0;
 
-        if (offer.reduceOnly) {
-            require(offer.buy ? buyerCreditIncrease == 0 : sellerDebtIncrease == 0, MakerCreditOrDebtIncreased());
-        }
+        require(!offer.reduceOnly || offer.buy ? buyerCreditIncrease == 0 : sellerDebtIncrease == 0, MakerCreditOrDebtIncreased());
 
         require(
             offer.market.enterGate == address(0) || buyerCreditIncrease == 0

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -381,7 +381,10 @@ contract Midnight is IMidnight {
             ? UtilsLib.toUint128(sellerPos.pendingFee.mulDivUp(sellerCreditDecrease, sellerPos.credit))
             : 0;
 
-        require(!offer.reduceOnly || offer.buy ? buyerCreditIncrease == 0 : sellerDebtIncrease == 0, MakerCreditOrDebtIncreased());
+        require(
+            !offer.reduceOnly || (offer.buy ? buyerCreditIncrease == 0 : sellerDebtIncrease == 0),
+            MakerCreditOrDebtIncreased()
+        );
 
         require(
             offer.market.enterGate == address(0) || buyerCreditIncrease == 0


### PR DESCRIPTION
- move variables assignment closer to use
- move reduce only check up, before state update (was here for path dependance), and rewrite it for consistency
- move gates check up, before the state updates to remove this reentrancy view (there is still one anyway)
- move accessible tick up, with the other offer checks