### PR TITLE
rcf for unhealthy liq post maturity

### DIFF
--- a/certora/specs/BalanceEffects.spec
+++ b/certora/specs/BalanceEffects.spec
@@ -168,7 +168,7 @@ rule repayEffects(env e, Midnight.Market market, uint256 units, address onBehalf
 
 /// Liquidate decreases the borrower's debt by at least repaidUnits,
 /// and only changes position[id][borrower].debt.
-rule liquidateEffects(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bytes32 anyId, address anyUser) {
+rule liquidateEffects(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bytes32 anyId, address anyUser, bool unhealthyPath) {
     bytes32 id = toId(e, market);
 
     uint256 debtBefore = debtOf(id, borrower);
@@ -177,8 +177,7 @@ rule liquidateEffects(env e, Midnight.Market market, uint256 collateralIndex, ui
 
     uint256 seizedResult;
     uint256 repaidResult;
-    bool _unhealthyPath;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthyPath, receiver, callback, data);
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
 
     assert debtOf(id, borrower) <= debtBefore - repaidResult;
     assert creditOf(anyId, anyUser) == otherCreditBefore;
@@ -240,15 +239,14 @@ rule withdrawCollateralCollateralEffects(env e, Midnight.Market market, uint256 
 
 /// liquidate decreases the borrower's collateral at collateralIndex by exactly seizedResult,
 /// and only changes position[id][borrower].collateral[collateralIndex].
-rule liquidateCollateralEffects(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bytes32 anyId, address anyUser, uint256 anyIndex) {
+rule liquidateCollateralEffects(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bytes32 anyId, address anyUser, uint256 anyIndex, bool unhealthyPath) {
     bytes32 id = toId(e, market);
 
     uint256 collateralBefore = collateral(id, borrower, collateralIndex);
     uint256 otherCollateralBefore = collateral(anyId, anyUser, anyIndex);
 
     uint256 seizedResult;
-    bool _unhealthyPath;
-    seizedResult, _ = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthyPath, receiver, callback, data);
+    seizedResult, _ = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
 
     assert collateral(id, borrower, collateralIndex) == collateralBefore - seizedResult;
     assert anyUser != borrower || anyId != id || anyIndex != collateralIndex => collateral(anyId, anyUser, anyIndex) == otherCollateralBefore;

--- a/certora/specs/BalanceEffects.spec
+++ b/certora/specs/BalanceEffects.spec
@@ -177,7 +177,8 @@ rule liquidateEffects(env e, Midnight.Market market, uint256 collateralIndex, ui
 
     uint256 seizedResult;
     uint256 repaidResult;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, receiver, callback, data);
+    bool _unhealthy;
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthy, receiver, callback, data);
 
     assert debtOf(id, borrower) <= debtBefore - repaidResult;
     assert creditOf(anyId, anyUser) == otherCreditBefore;
@@ -193,7 +194,7 @@ filtered {
         && f.selector != sig:take(Midnight.Offer, uint256, address, address, address, bytes, bytes).selector
         && f.selector != sig:withdraw(Midnight.Market, uint256, address, address).selector
         && f.selector != sig:repay(Midnight.Market, uint256, address, address, bytes).selector
-        && f.selector != sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, address, address, bytes).selector
+        && f.selector != sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, bool, address, address, bytes).selector
         && f.selector != sig:updatePosition(Midnight.Market, address).selector
 } {
     uint256 creditBefore = creditOf(id, user);
@@ -246,7 +247,8 @@ rule liquidateCollateralEffects(env e, Midnight.Market market, uint256 collatera
     uint256 otherCollateralBefore = collateral(anyId, anyUser, anyIndex);
 
     uint256 seizedResult;
-    seizedResult, _ = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, receiver, callback, data);
+    bool _unhealthy;
+    seizedResult, _ = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthy, receiver, callback, data);
 
     assert collateral(id, borrower, collateralIndex) == collateralBefore - seizedResult;
     assert anyUser != borrower || anyId != id || anyIndex != collateralIndex => collateral(anyId, anyUser, anyIndex) == otherCollateralBefore;
@@ -260,7 +262,7 @@ filtered {
     f -> !f.isView
         && f.selector != sig:supplyCollateral(Midnight.Market, uint256, uint256, address).selector
         && f.selector != sig:withdrawCollateral(Midnight.Market, uint256, uint256, address, address).selector
-        && f.selector != sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, address, address, bytes).selector
+        && f.selector != sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, bool, address, address, bytes).selector
 } {
     uint256 collateralBefore = collateral(id, user, colIdx);
     f(e, args);

--- a/certora/specs/BalanceEffects.spec
+++ b/certora/specs/BalanceEffects.spec
@@ -168,7 +168,7 @@ rule repayEffects(env e, Midnight.Market market, uint256 units, address onBehalf
 
 /// Liquidate decreases the borrower's debt by at least repaidUnits,
 /// and only changes position[id][borrower].debt.
-rule liquidateEffects(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bytes32 anyId, address anyUser, bool unhealthyPath) {
+rule liquidateEffects(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bytes32 anyId, address anyUser, bool healthyPath) {
     bytes32 id = toId(e, market);
 
     uint256 debtBefore = debtOf(id, borrower);
@@ -177,7 +177,7 @@ rule liquidateEffects(env e, Midnight.Market market, uint256 collateralIndex, ui
 
     uint256 seizedResult;
     uint256 repaidResult;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, healthyPath, receiver, callback, data);
 
     assert debtOf(id, borrower) <= debtBefore - repaidResult;
     assert creditOf(anyId, anyUser) == otherCreditBefore;
@@ -239,14 +239,14 @@ rule withdrawCollateralCollateralEffects(env e, Midnight.Market market, uint256 
 
 /// liquidate decreases the borrower's collateral at collateralIndex by exactly seizedResult,
 /// and only changes position[id][borrower].collateral[collateralIndex].
-rule liquidateCollateralEffects(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bytes32 anyId, address anyUser, uint256 anyIndex, bool unhealthyPath) {
+rule liquidateCollateralEffects(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bytes32 anyId, address anyUser, uint256 anyIndex, bool healthyPath) {
     bytes32 id = toId(e, market);
 
     uint256 collateralBefore = collateral(id, borrower, collateralIndex);
     uint256 otherCollateralBefore = collateral(anyId, anyUser, anyIndex);
 
     uint256 seizedResult;
-    seizedResult, _ = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
+    seizedResult, _ = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, healthyPath, receiver, callback, data);
 
     assert collateral(id, borrower, collateralIndex) == collateralBefore - seizedResult;
     assert anyUser != borrower || anyId != id || anyIndex != collateralIndex => collateral(anyId, anyUser, anyIndex) == otherCollateralBefore;

--- a/certora/specs/BalanceEffects.spec
+++ b/certora/specs/BalanceEffects.spec
@@ -177,8 +177,8 @@ rule liquidateEffects(env e, Midnight.Market market, uint256 collateralIndex, ui
 
     uint256 seizedResult;
     uint256 repaidResult;
-    bool _unhealthy;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthy, receiver, callback, data);
+    bool _unhealthyPath;
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthyPath, receiver, callback, data);
 
     assert debtOf(id, borrower) <= debtBefore - repaidResult;
     assert creditOf(anyId, anyUser) == otherCreditBefore;
@@ -247,8 +247,8 @@ rule liquidateCollateralEffects(env e, Midnight.Market market, uint256 collatera
     uint256 otherCollateralBefore = collateral(anyId, anyUser, anyIndex);
 
     uint256 seizedResult;
-    bool _unhealthy;
-    seizedResult, _ = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthy, receiver, callback, data);
+    bool _unhealthyPath;
+    seizedResult, _ = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthyPath, receiver, callback, data);
 
     assert collateral(id, borrower, collateralIndex) == collateralBefore - seizedResult;
     assert anyUser != borrower || anyId != id || anyIndex != collateralIndex => collateral(anyId, anyUser, anyIndex) == otherCollateralBefore;

--- a/certora/specs/CreatedMarkets.spec
+++ b/certora/specs/CreatedMarkets.spec
@@ -117,8 +117,8 @@ rule marketIsCreatedAfterWithdrawCollateral(env e, Midnight.Market market, uint2
     assert marketIsCreated(market);
 }
 
-rule marketIsCreatedAfterLiquidate(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
-    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
+rule marketIsCreatedAfterLiquidate(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool healthyPath) {
+    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, healthyPath, receiver, callback, data);
     assert marketIsCreated(market);
 }
 

--- a/certora/specs/CreatedMarkets.spec
+++ b/certora/specs/CreatedMarkets.spec
@@ -118,7 +118,8 @@ rule marketIsCreatedAfterWithdrawCollateral(env e, Midnight.Market market, uint2
 }
 
 rule marketIsCreatedAfterLiquidate(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data) {
-    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, receiver, callback, data);
+    bool _unhealthy;
+    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthy, receiver, callback, data);
     assert marketIsCreated(market);
 }
 
@@ -131,7 +132,7 @@ filtered {
         && f.selector != sig:repay(Midnight.Market, uint256, address, address, bytes).selector
         && f.selector != sig:supplyCollateral(Midnight.Market, uint256, uint256, address).selector
         && f.selector != sig:withdrawCollateral(Midnight.Market, uint256, uint256, address, address).selector
-        && f.selector != sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, address, address, bytes).selector
+        && f.selector != sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, bool, address, address, bytes).selector
 } {
     require !marketIsCreated(market), "Assume that the market is not created";
     f(e, args);

--- a/certora/specs/CreatedMarkets.spec
+++ b/certora/specs/CreatedMarkets.spec
@@ -117,9 +117,8 @@ rule marketIsCreatedAfterWithdrawCollateral(env e, Midnight.Market market, uint2
     assert marketIsCreated(market);
 }
 
-rule marketIsCreatedAfterLiquidate(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data) {
-    bool _unhealthyPath;
-    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthyPath, receiver, callback, data);
+rule marketIsCreatedAfterLiquidate(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
+    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
     assert marketIsCreated(market);
 }
 

--- a/certora/specs/CreatedMarkets.spec
+++ b/certora/specs/CreatedMarkets.spec
@@ -118,8 +118,8 @@ rule marketIsCreatedAfterWithdrawCollateral(env e, Midnight.Market market, uint2
 }
 
 rule marketIsCreatedAfterLiquidate(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data) {
-    bool _unhealthy;
-    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthy, receiver, callback, data);
+    bool _unhealthyPath;
+    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthyPath, receiver, callback, data);
     assert marketIsCreated(market);
 }
 

--- a/certora/specs/Healthiness.spec
+++ b/certora/specs/Healthiness.spec
@@ -200,7 +200,7 @@ function genericCallbackBytes32() returns (bytes32) {
 // and then we have a final rule for all other functions of the contract.
 
 // Show that the user stays healthy on liquidate, if the user gets liquidated (can occur if blocktime exceeds maturity)
-rule stayHealthyLiquidateSameBorrower(env e, uint256 collateralIndex, uint256 seizedAssetsIn, uint256 repaidUnitsIn, address receiver, address callbackAddr, bytes data, bool unhealthyPath) {
+rule stayHealthyLiquidateSameBorrower(env e, uint256 collateralIndex, uint256 seizedAssetsIn, uint256 repaidUnitsIn, address receiver, address callbackAddr, bytes data, bool healthyPath) {
     useIsHealthyNoBitmap = false;
 
     // This variable is set to false whenever isHealthy() is violated before a callback.  Initially we set it to true to indicate no violations detected.
@@ -218,7 +218,7 @@ rule stayHealthyLiquidateSameBorrower(env e, uint256 collateralIndex, uint256 se
     uint256 seizedAssetsOut;
     uint256 repaidUnitsOut;
 
-    seizedAssetsOut, repaidUnitsOut = liquidate(e, globalMarket, collateralIndex, seizedAssetsIn, repaidUnitsIn, globalBorrower, unhealthyPath, receiver, callbackAddr, data);
+    seizedAssetsOut, repaidUnitsOut = liquidate(e, globalMarket, collateralIndex, seizedAssetsIn, repaidUnitsIn, globalBorrower, healthyPath, receiver, callbackAddr, data);
 
     // we cannot use collateral, as it may already have been changed by the callbacks.
     mathint collateralAfter = collateralBefore - seizedAssetsOut;
@@ -241,7 +241,7 @@ rule stayHealthyLiquidateSameBorrower(env e, uint256 collateralIndex, uint256 se
 }
 
 // Show that the user stays healthy on liquidate, if another user gets liquidated or market differs.
-rule stayHealthyLiquidateOtherBorrower(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callbackAddr, bytes data, bool unhealthyPath) {
+rule stayHealthyLiquidateOtherBorrower(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callbackAddr, bytes data, bool healthyPath) {
     useIsHealthyNoBitmap = true;
 
     // This variable is set to false whenever isHealthy() is violated before a callback.  Initially we set it to true to indicate no violations detected.
@@ -254,7 +254,7 @@ rule stayHealthyLiquidateOtherBorrower(env e, Midnight.Market market, uint256 co
 
     require callIsHealthy(globalMarket, globalId, globalBorrower), "user is healthy before call";
 
-    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callbackAddr, data);
+    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, healthyPath, receiver, callbackAddr, data);
 
     assert healthyBeforeCallback, "user is healthy before callbacks";
     assert callIsHealthy(globalMarket, globalId, globalBorrower), "user is healthy after call";

--- a/certora/specs/Healthiness.spec
+++ b/certora/specs/Healthiness.spec
@@ -218,8 +218,8 @@ rule stayHealthyLiquidateSameBorrower(env e, uint256 collateralIndex, uint256 se
     uint256 seizedAssetsOut;
     uint256 repaidUnitsOut;
 
-    bool _unhealthy;
-    seizedAssetsOut, repaidUnitsOut = liquidate(e, globalMarket, collateralIndex, seizedAssetsIn, repaidUnitsIn, globalBorrower, _unhealthy, receiver, callbackAddr, data);
+    bool _unhealthyPath;
+    seizedAssetsOut, repaidUnitsOut = liquidate(e, globalMarket, collateralIndex, seizedAssetsIn, repaidUnitsIn, globalBorrower, _unhealthyPath, receiver, callbackAddr, data);
 
     // we cannot use collateral, as it may already have been changed by the callbacks.
     mathint collateralAfter = collateralBefore - seizedAssetsOut;
@@ -255,8 +255,8 @@ rule stayHealthyLiquidateOtherBorrower(env e, Midnight.Market market, uint256 co
 
     require callIsHealthy(globalMarket, globalId, globalBorrower), "user is healthy before call";
 
-    bool _unhealthy;
-    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthy, receiver, callbackAddr, data);
+    bool _unhealthyPath;
+    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthyPath, receiver, callbackAddr, data);
 
     assert healthyBeforeCallback, "user is healthy before callbacks";
     assert callIsHealthy(globalMarket, globalId, globalBorrower), "user is healthy after call";

--- a/certora/specs/Healthiness.spec
+++ b/certora/specs/Healthiness.spec
@@ -218,7 +218,8 @@ rule stayHealthyLiquidateSameBorrower(env e, uint256 collateralIndex, uint256 se
     uint256 seizedAssetsOut;
     uint256 repaidUnitsOut;
 
-    seizedAssetsOut, repaidUnitsOut = liquidate(e, globalMarket, collateralIndex, seizedAssetsIn, repaidUnitsIn, globalBorrower, receiver, callbackAddr, data);
+    bool _unhealthy;
+    seizedAssetsOut, repaidUnitsOut = liquidate(e, globalMarket, collateralIndex, seizedAssetsIn, repaidUnitsIn, globalBorrower, _unhealthy, receiver, callbackAddr, data);
 
     // we cannot use collateral, as it may already have been changed by the callbacks.
     mathint collateralAfter = collateralBefore - seizedAssetsOut;
@@ -254,14 +255,15 @@ rule stayHealthyLiquidateOtherBorrower(env e, Midnight.Market market, uint256 co
 
     require callIsHealthy(globalMarket, globalId, globalBorrower), "user is healthy before call";
 
-    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, receiver, callbackAddr, data);
+    bool _unhealthy;
+    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthy, receiver, callbackAddr, data);
 
     assert healthyBeforeCallback, "user is healthy before callbacks";
     assert callIsHealthy(globalMarket, globalId, globalBorrower), "user is healthy after call";
 }
 
 // Show that the user stays healthy on any other function than liquidate or take.
-rule stayHealthy(env e, method f, calldataarg args) filtered { f -> f.selector != sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, address, address, bytes).selector && f.selector != sig:take(Midnight.Offer, uint256, address, address, address, bytes, bytes).selector } {
+rule stayHealthy(env e, method f, calldataarg args) filtered { f -> f.selector != sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, bool, address, address, bytes).selector && f.selector != sig:take(Midnight.Offer, uint256, address, address, address, bytes, bytes).selector } {
     // for withdraw collateral we choose isHealthy() for all others the isHealthyNoBitmap function.
     useIsHealthyNoBitmap = (f.selector != sig:withdrawCollateral(Midnight.Market, uint256, uint256, address, address).selector);
 

--- a/certora/specs/Healthiness.spec
+++ b/certora/specs/Healthiness.spec
@@ -200,7 +200,7 @@ function genericCallbackBytes32() returns (bytes32) {
 // and then we have a final rule for all other functions of the contract.
 
 // Show that the user stays healthy on liquidate, if the user gets liquidated (can occur if blocktime exceeds maturity)
-rule stayHealthyLiquidateSameBorrower(env e, uint256 collateralIndex, uint256 seizedAssetsIn, uint256 repaidUnitsIn, address receiver, address callbackAddr, bytes data) {
+rule stayHealthyLiquidateSameBorrower(env e, uint256 collateralIndex, uint256 seizedAssetsIn, uint256 repaidUnitsIn, address receiver, address callbackAddr, bytes data, bool unhealthyPath) {
     useIsHealthyNoBitmap = false;
 
     // This variable is set to false whenever isHealthy() is violated before a callback.  Initially we set it to true to indicate no violations detected.
@@ -218,8 +218,7 @@ rule stayHealthyLiquidateSameBorrower(env e, uint256 collateralIndex, uint256 se
     uint256 seizedAssetsOut;
     uint256 repaidUnitsOut;
 
-    bool _unhealthyPath;
-    seizedAssetsOut, repaidUnitsOut = liquidate(e, globalMarket, collateralIndex, seizedAssetsIn, repaidUnitsIn, globalBorrower, _unhealthyPath, receiver, callbackAddr, data);
+    seizedAssetsOut, repaidUnitsOut = liquidate(e, globalMarket, collateralIndex, seizedAssetsIn, repaidUnitsIn, globalBorrower, unhealthyPath, receiver, callbackAddr, data);
 
     // we cannot use collateral, as it may already have been changed by the callbacks.
     mathint collateralAfter = collateralBefore - seizedAssetsOut;
@@ -242,7 +241,7 @@ rule stayHealthyLiquidateSameBorrower(env e, uint256 collateralIndex, uint256 se
 }
 
 // Show that the user stays healthy on liquidate, if another user gets liquidated or market differs.
-rule stayHealthyLiquidateOtherBorrower(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callbackAddr, bytes data) {
+rule stayHealthyLiquidateOtherBorrower(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callbackAddr, bytes data, bool unhealthyPath) {
     useIsHealthyNoBitmap = true;
 
     // This variable is set to false whenever isHealthy() is violated before a callback.  Initially we set it to true to indicate no violations detected.
@@ -255,8 +254,7 @@ rule stayHealthyLiquidateOtherBorrower(env e, Midnight.Market market, uint256 co
 
     require callIsHealthy(globalMarket, globalId, globalBorrower), "user is healthy before call";
 
-    bool _unhealthyPath;
-    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthyPath, receiver, callbackAddr, data);
+    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callbackAddr, data);
 
     assert healthyBeforeCallback, "user is healthy before callbacks";
     assert callIsHealthy(globalMarket, globalId, globalBorrower), "user is healthy after call";

--- a/certora/specs/Liquidate.spec
+++ b/certora/specs/Liquidate.spec
@@ -44,7 +44,7 @@ ghost summaryPrice(address) returns uint256;
 /// Credit does not change on liquidate. Debt and collateral of a user can only change via liquidate if the position is liquidatable and user is borrower.
 /// Furthermore, liquidate can only decrease the borrower's debt and collateral (w.r.t the collateralIndex passed in liquidate).
 /// Also show that liquidate can only be called on liquidatable positions.
-rule liquidateOnlyAffectsBalancesWhenLiquidatable(env e, Midnight.Market market, uint256 liqIndex, uint256 seizedAssets, uint256 repaidUnits, address liqUser, address receiver, address callback, bytes data, bool unhealthyPath) {
+rule liquidateOnlyAffectsBalancesWhenLiquidatable(env e, Midnight.Market market, uint256 liqIndex, uint256 seizedAssets, uint256 repaidUnits, address liqUser, address receiver, address callback, bytes data, bool healthyPath) {
     bytes32 id;
     address user;
     uint256 collateralIndex;
@@ -55,7 +55,7 @@ rule liquidateOnlyAffectsBalancesWhenLiquidatable(env e, Midnight.Market market,
     uint256 debtBefore = debtOf(id, user);
     uint256 collateralBefore = collateral(id, user, collateralIndex);
 
-    liquidate(e, market, liqIndex, seizedAssets, repaidUnits, liqUser, unhealthyPath, receiver, callback, data);
+    liquidate(e, market, liqIndex, seizedAssets, repaidUnits, liqUser, healthyPath, receiver, callback, data);
 
     uint256 creditAfter = creditOf(id, user);
     uint256 debtAfter = debtOf(id, user);

--- a/certora/specs/Liquidate.spec
+++ b/certora/specs/Liquidate.spec
@@ -55,7 +55,8 @@ rule liquidateOnlyAffectsBalancesWhenLiquidatable(env e, Midnight.Market market,
     uint256 debtBefore = debtOf(id, user);
     uint256 collateralBefore = collateral(id, user, collateralIndex);
 
-    liquidate(e, market, liqIndex, seizedAssets, repaidUnits, liqUser, receiver, callback, data);
+    bool _unhealthy;
+    liquidate(e, market, liqIndex, seizedAssets, repaidUnits, liqUser, _unhealthy, receiver, callback, data);
 
     uint256 creditAfter = creditOf(id, user);
     uint256 debtAfter = debtOf(id, user);

--- a/certora/specs/Liquidate.spec
+++ b/certora/specs/Liquidate.spec
@@ -44,7 +44,7 @@ ghost summaryPrice(address) returns uint256;
 /// Credit does not change on liquidate. Debt and collateral of a user can only change via liquidate if the position is liquidatable and user is borrower.
 /// Furthermore, liquidate can only decrease the borrower's debt and collateral (w.r.t the collateralIndex passed in liquidate).
 /// Also show that liquidate can only be called on liquidatable positions.
-rule liquidateOnlyAffectsBalancesWhenLiquidatable(env e, Midnight.Market market, uint256 liqIndex, uint256 seizedAssets, uint256 repaidUnits, address liqUser, address receiver, address callback, bytes data) {
+rule liquidateOnlyAffectsBalancesWhenLiquidatable(env e, Midnight.Market market, uint256 liqIndex, uint256 seizedAssets, uint256 repaidUnits, address liqUser, address receiver, address callback, bytes data, bool unhealthyPath) {
     bytes32 id;
     address user;
     uint256 collateralIndex;
@@ -55,8 +55,7 @@ rule liquidateOnlyAffectsBalancesWhenLiquidatable(env e, Midnight.Market market,
     uint256 debtBefore = debtOf(id, user);
     uint256 collateralBefore = collateral(id, user, collateralIndex);
 
-    bool _unhealthyPath;
-    liquidate(e, market, liqIndex, seizedAssets, repaidUnits, liqUser, _unhealthyPath, receiver, callback, data);
+    liquidate(e, market, liqIndex, seizedAssets, repaidUnits, liqUser, unhealthyPath, receiver, callback, data);
 
     uint256 creditAfter = creditOf(id, user);
     uint256 debtAfter = debtOf(id, user);

--- a/certora/specs/Liquidate.spec
+++ b/certora/specs/Liquidate.spec
@@ -55,8 +55,8 @@ rule liquidateOnlyAffectsBalancesWhenLiquidatable(env e, Midnight.Market market,
     uint256 debtBefore = debtOf(id, user);
     uint256 collateralBefore = collateral(id, user, collateralIndex);
 
-    bool _unhealthy;
-    liquidate(e, market, liqIndex, seizedAssets, repaidUnits, liqUser, _unhealthy, receiver, callback, data);
+    bool _unhealthyPath;
+    liquidate(e, market, liqIndex, seizedAssets, repaidUnits, liqUser, _unhealthyPath, receiver, callback, data);
 
     uint256 creditAfter = creditOf(id, user);
     uint256 debtAfter = debtOf(id, user);

--- a/certora/specs/LiquidationBoundedByLIF.spec
+++ b/certora/specs/LiquidationBoundedByLIF.spec
@@ -75,14 +75,14 @@ strong invariant nonZeroCollateralsAreActivated(bytes32 id, address user, uint25
 
 /// Liquidation profit is bounded by maxLif (repaidUnits input).
 /// Unlike the seizedAssets rule, no requireInvariant is needed here: if collateralIndex is not in the bitmap because mulDivDown(..., 0) reverts.
-rule liquidationProfitBoundedInputRepaidUnits(env e, Midnight.Market market, uint256 collateralIndex, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
+rule liquidationProfitBoundedInputRepaidUnits(env e, Midnight.Market market, uint256 collateralIndex, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool healthyPath) {
     mathint maxLif = market.collateralParams[collateralIndex].maxLif;
     require data.length == 0, "no callback for prover performance";
     require maxLif >= WAD(), "maxLif must be at least 1x for profit boundedness (see touchMarket validation and ExactMath.spec)";
 
     uint256 seizedResult;
     uint256 repaidResult;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, 0, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, 0, repaidUnits, borrower, healthyPath, receiver, callback, data);
 
     mathint price = summaryPrice(market.collateralParams[collateralIndex].oracle);
 
@@ -90,7 +90,7 @@ rule liquidationProfitBoundedInputRepaidUnits(env e, Midnight.Market market, uin
 }
 
 /// Liquidation profit is bounded by maxLif (seizedAssets input)
-rule liquidationProfitBoundedSeizedAssets(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
+rule liquidationProfitBoundedSeizedAssets(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, address borrower, address receiver, address callback, bytes data, bool healthyPath) {
     mathint maxLif = market.collateralParams[collateralIndex].maxLif;
     require data.length == 0, "no callback for prover performance";
     require maxLif >= WAD(), "maxLif must be at least 1x for profit boundedness (see touchMarket validation and ExactMath.spec)";
@@ -101,7 +101,7 @@ rule liquidationProfitBoundedSeizedAssets(env e, Midnight.Market market, uint256
 
     uint256 seizedResult;
     uint256 repaidResult;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, 0, borrower, unhealthyPath, receiver, callback, data);
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, 0, borrower, healthyPath, receiver, callback, data);
 
     mathint price = summaryPrice(market.collateralParams[collateralIndex].oracle);
 

--- a/certora/specs/LiquidationBoundedByLIF.spec
+++ b/certora/specs/LiquidationBoundedByLIF.spec
@@ -82,7 +82,8 @@ rule liquidationProfitBoundedInputRepaidUnits(env e, Midnight.Market market, uin
 
     uint256 seizedResult;
     uint256 repaidResult;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, 0, repaidUnits, borrower, receiver, callback, data);
+    bool _unhealthy;
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, 0, repaidUnits, borrower, _unhealthy, receiver, callback, data);
 
     mathint price = summaryPrice(market.collateralParams[collateralIndex].oracle);
 
@@ -101,7 +102,8 @@ rule liquidationProfitBoundedSeizedAssets(env e, Midnight.Market market, uint256
 
     uint256 seizedResult;
     uint256 repaidResult;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, 0, borrower, receiver, callback, data);
+    bool _unhealthy;
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, 0, borrower, _unhealthy, receiver, callback, data);
 
     mathint price = summaryPrice(market.collateralParams[collateralIndex].oracle);
 

--- a/certora/specs/LiquidationBoundedByLIF.spec
+++ b/certora/specs/LiquidationBoundedByLIF.spec
@@ -82,8 +82,8 @@ rule liquidationProfitBoundedInputRepaidUnits(env e, Midnight.Market market, uin
 
     uint256 seizedResult;
     uint256 repaidResult;
-    bool _unhealthy;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, 0, repaidUnits, borrower, _unhealthy, receiver, callback, data);
+    bool _unhealthyPath;
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, 0, repaidUnits, borrower, _unhealthyPath, receiver, callback, data);
 
     mathint price = summaryPrice(market.collateralParams[collateralIndex].oracle);
 
@@ -102,8 +102,8 @@ rule liquidationProfitBoundedSeizedAssets(env e, Midnight.Market market, uint256
 
     uint256 seizedResult;
     uint256 repaidResult;
-    bool _unhealthy;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, 0, borrower, _unhealthy, receiver, callback, data);
+    bool _unhealthyPath;
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, 0, borrower, _unhealthyPath, receiver, callback, data);
 
     mathint price = summaryPrice(market.collateralParams[collateralIndex].oracle);
 

--- a/certora/specs/LiquidationBoundedByLIF.spec
+++ b/certora/specs/LiquidationBoundedByLIF.spec
@@ -75,15 +75,14 @@ strong invariant nonZeroCollateralsAreActivated(bytes32 id, address user, uint25
 
 /// Liquidation profit is bounded by maxLif (repaidUnits input).
 /// Unlike the seizedAssets rule, no requireInvariant is needed here: if collateralIndex is not in the bitmap because mulDivDown(..., 0) reverts.
-rule liquidationProfitBoundedInputRepaidUnits(env e, Midnight.Market market, uint256 collateralIndex, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data) {
+rule liquidationProfitBoundedInputRepaidUnits(env e, Midnight.Market market, uint256 collateralIndex, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
     mathint maxLif = market.collateralParams[collateralIndex].maxLif;
     require data.length == 0, "no callback for prover performance";
     require maxLif >= WAD(), "maxLif must be at least 1x for profit boundedness (see touchMarket validation and ExactMath.spec)";
 
     uint256 seizedResult;
     uint256 repaidResult;
-    bool _unhealthyPath;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, 0, repaidUnits, borrower, _unhealthyPath, receiver, callback, data);
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, 0, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
 
     mathint price = summaryPrice(market.collateralParams[collateralIndex].oracle);
 
@@ -91,7 +90,7 @@ rule liquidationProfitBoundedInputRepaidUnits(env e, Midnight.Market market, uin
 }
 
 /// Liquidation profit is bounded by maxLif (seizedAssets input)
-rule liquidationProfitBoundedSeizedAssets(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, address borrower, address receiver, address callback, bytes data) {
+rule liquidationProfitBoundedSeizedAssets(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
     mathint maxLif = market.collateralParams[collateralIndex].maxLif;
     require data.length == 0, "no callback for prover performance";
     require maxLif >= WAD(), "maxLif must be at least 1x for profit boundedness (see touchMarket validation and ExactMath.spec)";
@@ -102,8 +101,7 @@ rule liquidationProfitBoundedSeizedAssets(env e, Midnight.Market market, uint256
 
     uint256 seizedResult;
     uint256 repaidResult;
-    bool _unhealthyPath;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, 0, borrower, _unhealthyPath, receiver, callback, data);
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, 0, borrower, unhealthyPath, receiver, callback, data);
 
     mathint price = summaryPrice(market.collateralParams[collateralIndex].oracle);
 

--- a/certora/specs/LiquidationProfitability.spec
+++ b/certora/specs/LiquidationProfitability.spec
@@ -78,8 +78,8 @@ rule liquidationLifRepaidUnits(env e, Midnight.Market market, uint256 collateral
 
     uint256 seizedResult;
     uint256 repaidResult;
-    bool _unhealthy;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, 0, repaidUnits, borrower, _unhealthy, receiver, callback, data);
+    bool _unhealthyPath;
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, 0, repaidUnits, borrower, _unhealthyPath, receiver, callback, data);
 
     mathint price = summaryPrice(market.collateralParams[collateralIndex].oracle);
 
@@ -100,8 +100,8 @@ rule liquidationLifSeizedAssets(env e, Midnight.Market market, uint256 collatera
 
     uint256 seizedResult;
     uint256 repaidResult;
-    bool _unhealthy;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, 0, borrower, _unhealthy, receiver, callback, data);
+    bool _unhealthyPath;
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, 0, borrower, _unhealthyPath, receiver, callback, data);
 
     mathint price = summaryPrice(market.collateralParams[collateralIndex].oracle);
 

--- a/certora/specs/LiquidationProfitability.spec
+++ b/certora/specs/LiquidationProfitability.spec
@@ -5,7 +5,6 @@ using Utils as Utils;
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;
 
-    function isHealthy(Midnight.Market market, bytes32 id, address borrower) external returns (bool) envfree;
     function Utils.hashMarket(Midnight.Market) external returns (bytes32) envfree;
 
     // Summary to capture the oracle price so the spec can reference it in assertions.
@@ -68,13 +67,12 @@ function summaryMulDivUp(uint256 a, uint256 b, uint256 d) returns uint256 {
 
 /// LIF CHARACTERIZATION ///
 
-/// For repaidUnits input: lif >= WAD (solvency), and lif == maxLif when borrower is unhealthy or >= 15 min post-maturity (profitability).
+/// For repaidUnits input: lif >= WAD (solvency), and lif == maxLif when the unhealthy path is taken or the call is >= 15 min post-maturity (profitability).
 rule liquidationLifRepaidUnits(env e, Midnight.Market market, uint256 collateralIndex, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
     uint256 maxLif = market.collateralParams[collateralIndex].maxLif;
     require maxLif >= WAD(), "see the rule maxLifIsAtLeastWad";
 
-    bytes32 id = toId(e, market);
-    bool maxLifReached = !isHealthy(market, id, borrower) || e.block.timestamp >= require_uint256(market.maturity + TIME_TO_MAX_LIF());
+    bool maxLifReached = unhealthyPath || e.block.timestamp >= require_uint256(market.maturity + TIME_TO_MAX_LIF());
 
     uint256 seizedResult;
     uint256 repaidResult;
@@ -85,17 +83,16 @@ rule liquidationLifRepaidUnits(env e, Midnight.Market market, uint256 collateral
     // lif >= WAD: liquidator receives collateral worth at least the repaid debt (up to 1 unit floor rounding on seizedAssets) at the oracle price.
     assert (seizedResult + 1) * price >= repaidResult * ORACLE_PRICE_SCALE();
 
-    // lif == maxLif when borrower is unhealthy or >= 15 min post-maturity: full liquidation incentive factor applies.
+    // lif == maxLif when the unhealthy path is taken or >= 15 min post-maturity: full liquidation incentive factor applies.
     assert maxLifReached => (seizedResult + 1) * price * WAD() + ORACLE_PRICE_SCALE() * WAD() > repaidResult * maxLif * ORACLE_PRICE_SCALE();
 }
 
-/// For seizedAssets input: lif >= WAD (solvency), and lif == maxLif when borrower is unhealthy or >= 15 min post-maturity (profitability).
+/// For seizedAssets input: lif >= WAD (solvency), and lif == maxLif when the unhealthy path is taken or the call is >= 15 min post-maturity (profitability).
 rule liquidationLifSeizedAssets(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
     uint256 maxLif = market.collateralParams[collateralIndex].maxLif;
     require maxLif >= WAD(), "see the rule maxLifIsAtLeastWad";
 
-    bytes32 id = toId(e, market);
-    bool maxLifReached = !isHealthy(market, id, borrower) || e.block.timestamp >= require_uint256(market.maturity + TIME_TO_MAX_LIF());
+    bool maxLifReached = unhealthyPath || e.block.timestamp >= require_uint256(market.maturity + TIME_TO_MAX_LIF());
 
     uint256 seizedResult;
     uint256 repaidResult;
@@ -106,6 +103,6 @@ rule liquidationLifSeizedAssets(env e, Midnight.Market market, uint256 collatera
     // lif >= WAD: liquidator receives collateral worth at least the repaid debt (up to 1 unit ceil rounding on repaidUnits) at the oracle price.
     assert seizedResult * price > (repaidResult - 1) * ORACLE_PRICE_SCALE();
 
-    // lif == maxLif when borrower is unhealthy or >= 15 min post-maturity: full liquidation incentive factor applies.
+    // lif == maxLif when the unhealthy path is taken or >= 15 min post-maturity: full liquidation incentive factor applies.
     assert maxLifReached => seizedResult * price * WAD() + ORACLE_PRICE_SCALE() * WAD() > (repaidResult - 1) * maxLif * ORACLE_PRICE_SCALE();
 }

--- a/certora/specs/LiquidationProfitability.spec
+++ b/certora/specs/LiquidationProfitability.spec
@@ -68,15 +68,15 @@ function summaryMulDivUp(uint256 a, uint256 b, uint256 d) returns uint256 {
 /// LIF CHARACTERIZATION ///
 
 /// For repaidUnits input: lif >= WAD (solvency), and lif == maxLif when the unhealthy path is taken or the call is >= 15 min post-maturity (profitability).
-rule liquidationLifRepaidUnits(env e, Midnight.Market market, uint256 collateralIndex, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
+rule liquidationLifRepaidUnits(env e, Midnight.Market market, uint256 collateralIndex, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool healthyPath) {
     uint256 maxLif = market.collateralParams[collateralIndex].maxLif;
     require maxLif >= WAD(), "see the rule maxLifIsAtLeastWad";
 
-    bool maxLifReached = unhealthyPath || e.block.timestamp >= require_uint256(market.maturity + TIME_TO_MAX_LIF());
+    bool maxLifReached = !healthyPath || e.block.timestamp >= require_uint256(market.maturity + TIME_TO_MAX_LIF());
 
     uint256 seizedResult;
     uint256 repaidResult;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, 0, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, 0, repaidUnits, borrower, healthyPath, receiver, callback, data);
 
     mathint price = summaryPrice(market.collateralParams[collateralIndex].oracle);
 
@@ -88,15 +88,15 @@ rule liquidationLifRepaidUnits(env e, Midnight.Market market, uint256 collateral
 }
 
 /// For seizedAssets input: lif >= WAD (solvency), and lif == maxLif when the unhealthy path is taken or the call is >= 15 min post-maturity (profitability).
-rule liquidationLifSeizedAssets(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
+rule liquidationLifSeizedAssets(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, address borrower, address receiver, address callback, bytes data, bool healthyPath) {
     uint256 maxLif = market.collateralParams[collateralIndex].maxLif;
     require maxLif >= WAD(), "see the rule maxLifIsAtLeastWad";
 
-    bool maxLifReached = unhealthyPath || e.block.timestamp >= require_uint256(market.maturity + TIME_TO_MAX_LIF());
+    bool maxLifReached = !healthyPath || e.block.timestamp >= require_uint256(market.maturity + TIME_TO_MAX_LIF());
 
     uint256 seizedResult;
     uint256 repaidResult;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, 0, borrower, unhealthyPath, receiver, callback, data);
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, 0, borrower, healthyPath, receiver, callback, data);
 
     mathint price = summaryPrice(market.collateralParams[collateralIndex].oracle);
 

--- a/certora/specs/LiquidationProfitability.spec
+++ b/certora/specs/LiquidationProfitability.spec
@@ -69,7 +69,7 @@ function summaryMulDivUp(uint256 a, uint256 b, uint256 d) returns uint256 {
 /// LIF CHARACTERIZATION ///
 
 /// For repaidUnits input: lif >= WAD (solvency), and lif == maxLif when borrower is unhealthy or >= 15 min post-maturity (profitability).
-rule liquidationLifRepaidUnits(env e, Midnight.Market market, uint256 collateralIndex, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data) {
+rule liquidationLifRepaidUnits(env e, Midnight.Market market, uint256 collateralIndex, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
     uint256 maxLif = market.collateralParams[collateralIndex].maxLif;
     require maxLif >= WAD(), "see the rule maxLifIsAtLeastWad";
 
@@ -78,8 +78,7 @@ rule liquidationLifRepaidUnits(env e, Midnight.Market market, uint256 collateral
 
     uint256 seizedResult;
     uint256 repaidResult;
-    bool _unhealthyPath;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, 0, repaidUnits, borrower, _unhealthyPath, receiver, callback, data);
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, 0, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
 
     mathint price = summaryPrice(market.collateralParams[collateralIndex].oracle);
 
@@ -91,7 +90,7 @@ rule liquidationLifRepaidUnits(env e, Midnight.Market market, uint256 collateral
 }
 
 /// For seizedAssets input: lif >= WAD (solvency), and lif == maxLif when borrower is unhealthy or >= 15 min post-maturity (profitability).
-rule liquidationLifSeizedAssets(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, address borrower, address receiver, address callback, bytes data) {
+rule liquidationLifSeizedAssets(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
     uint256 maxLif = market.collateralParams[collateralIndex].maxLif;
     require maxLif >= WAD(), "see the rule maxLifIsAtLeastWad";
 
@@ -100,8 +99,7 @@ rule liquidationLifSeizedAssets(env e, Midnight.Market market, uint256 collatera
 
     uint256 seizedResult;
     uint256 repaidResult;
-    bool _unhealthyPath;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, 0, borrower, _unhealthyPath, receiver, callback, data);
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, 0, borrower, unhealthyPath, receiver, callback, data);
 
     mathint price = summaryPrice(market.collateralParams[collateralIndex].oracle);
 

--- a/certora/specs/LiquidationProfitability.spec
+++ b/certora/specs/LiquidationProfitability.spec
@@ -78,7 +78,8 @@ rule liquidationLifRepaidUnits(env e, Midnight.Market market, uint256 collateral
 
     uint256 seizedResult;
     uint256 repaidResult;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, 0, repaidUnits, borrower, receiver, callback, data);
+    bool _unhealthy;
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, 0, repaidUnits, borrower, _unhealthy, receiver, callback, data);
 
     mathint price = summaryPrice(market.collateralParams[collateralIndex].oracle);
 
@@ -99,7 +100,8 @@ rule liquidationLifSeizedAssets(env e, Midnight.Market market, uint256 collatera
 
     uint256 seizedResult;
     uint256 repaidResult;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, 0, borrower, receiver, callback, data);
+    bool _unhealthy;
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, 0, borrower, _unhealthy, receiver, callback, data);
 
     mathint price = summaryPrice(market.collateralParams[collateralIndex].oracle);
 

--- a/certora/specs/LossFactor.spec
+++ b/certora/specs/LossFactor.spec
@@ -44,15 +44,14 @@ rule onlyLiquidateChangesMarketLossFactor(bytes32 id, method f, env e, calldataa
 }
 
 /// In liquidate, the market's lossFactor changes if and only if bad debt is realized (totalUnits decreases).
-rule lossFactorChangesIffBadDebt(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data) {
+rule lossFactorChangesIffBadDebt(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
     bytes32 id = summaryToId(market);
     uint128 lossFactorBefore = currentContract.marketState[id].lossFactor;
     uint256 totalUnitsBefore = totalUnits(id);
 
     require lossFactorBefore < max_uint128, "market lossFactor must not be saturated";
 
-    bool _unhealthyPath;
-    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthyPath, receiver, callback, data);
+    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
 
     bool lossFactorChanged = currentContract.marketState[id].lossFactor != lossFactorBefore;
     bool badDebtOccurred = totalUnits(id) < totalUnitsBefore;
@@ -101,7 +100,7 @@ rule liquidateLossFactorDoesNotRevert(env e, Midnight.Market market, address bor
     require e.msg.value == 0, "Midnight is not payable";
 
     address zero = 0;
-    liquidate@withrevert(e, market, 0, 0, 0, borrower, borrower, zero, data);
+    liquidate@withrevert(e, market, 0, 0, 0, borrower, true, borrower, zero, data);
 
     assert !lastReverted, "liquidate should not revert under valid state (bad debt realization path)";
 }

--- a/certora/specs/LossFactor.spec
+++ b/certora/specs/LossFactor.spec
@@ -44,14 +44,14 @@ rule onlyLiquidateChangesMarketLossFactor(bytes32 id, method f, env e, calldataa
 }
 
 /// In liquidate, the market's lossFactor changes if and only if bad debt is realized (totalUnits decreases).
-rule lossFactorChangesIffBadDebt(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
+rule lossFactorChangesIffBadDebt(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool healthyPath) {
     bytes32 id = summaryToId(market);
     uint128 lossFactorBefore = currentContract.marketState[id].lossFactor;
     uint256 totalUnitsBefore = totalUnits(id);
 
     require lossFactorBefore < max_uint128, "market lossFactor must not be saturated";
 
-    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
+    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, healthyPath, receiver, callback, data);
 
     bool lossFactorChanged = currentContract.marketState[id].lossFactor != lossFactorBefore;
     bool badDebtOccurred = totalUnits(id) < totalUnitsBefore;

--- a/certora/specs/LossFactor.spec
+++ b/certora/specs/LossFactor.spec
@@ -86,7 +86,7 @@ rule updatePositionDoesNotRevert(env e, Midnight.Market market, address user) {
 }
 
 /// The loss factor arithmetic in liquidate does not revert under valid state. Uses seizedAssets=0, repaidUnits=0 to isolate the bad debt realization path. Uses collateralBitmap=0 to skip the collateral loop, ensuring badDebt == position.debt.
-rule liquidateLossFactorDoesNotRevert(env e, Midnight.Market market, address borrower, bytes data, bool healthyPath) {
+rule liquidateLossFactorDoesNotRevert(env e, Midnight.Market market, address borrower, bytes data) {
     bytes32 id = summaryToId(market);
 
     require data.length == 0, "no callback to avoid unrelated external call reverts";
@@ -100,7 +100,7 @@ rule liquidateLossFactorDoesNotRevert(env e, Midnight.Market market, address bor
     require e.msg.value == 0, "Midnight is not payable";
 
     address zero = 0;
-    liquidate@withrevert(e, market, 0, 0, 0, borrower, healthyPath, borrower, zero, data);
+    liquidate@withrevert(e, market, 0, 0, 0, borrower, false, borrower, zero, data);
 
     assert !lastReverted, "liquidate should not revert under valid state (bad debt realization path)";
 }

--- a/certora/specs/LossFactor.spec
+++ b/certora/specs/LossFactor.spec
@@ -51,8 +51,8 @@ rule lossFactorChangesIffBadDebt(env e, Midnight.Market market, uint256 collater
 
     require lossFactorBefore < max_uint128, "market lossFactor must not be saturated";
 
-    bool _unhealthy;
-    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthy, receiver, callback, data);
+    bool _unhealthyPath;
+    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthyPath, receiver, callback, data);
 
     bool lossFactorChanged = currentContract.marketState[id].lossFactor != lossFactorBefore;
     bool badDebtOccurred = totalUnits(id) < totalUnitsBefore;

--- a/certora/specs/LossFactor.spec
+++ b/certora/specs/LossFactor.spec
@@ -35,7 +35,7 @@ function marketIsCreated(Midnight.Market market) returns (bool) {
 }
 
 /// The market's lossFactor is only modified by liquidate.
-rule onlyLiquidateChangesMarketLossFactor(bytes32 id, method f, env e, calldataarg args) filtered { f -> !f.isView && f.selector != sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, address, address, bytes).selector } {
+rule onlyLiquidateChangesMarketLossFactor(bytes32 id, method f, env e, calldataarg args) filtered { f -> !f.isView && f.selector != sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, bool, address, address, bytes).selector } {
     uint128 lossFactorBefore = currentContract.marketState[id].lossFactor;
 
     f(e, args);
@@ -51,7 +51,8 @@ rule lossFactorChangesIffBadDebt(env e, Midnight.Market market, uint256 collater
 
     require lossFactorBefore < max_uint128, "market lossFactor must not be saturated";
 
-    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, receiver, callback, data);
+    bool _unhealthy;
+    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthy, receiver, callback, data);
 
     bool lossFactorChanged = currentContract.marketState[id].lossFactor != lossFactorBefore;
     bool badDebtOccurred = totalUnits(id) < totalUnitsBefore;

--- a/certora/specs/LossFactor.spec
+++ b/certora/specs/LossFactor.spec
@@ -86,7 +86,7 @@ rule updatePositionDoesNotRevert(env e, Midnight.Market market, address user) {
 }
 
 /// The loss factor arithmetic in liquidate does not revert under valid state. Uses seizedAssets=0, repaidUnits=0 to isolate the bad debt realization path. Uses collateralBitmap=0 to skip the collateral loop, ensuring badDebt == position.debt.
-rule liquidateLossFactorDoesNotRevert(env e, Midnight.Market market, address borrower, bytes data) {
+rule liquidateLossFactorDoesNotRevert(env e, Midnight.Market market, address borrower, bytes data, bool healthyPath) {
     bytes32 id = summaryToId(market);
 
     require data.length == 0, "no callback to avoid unrelated external call reverts";
@@ -100,7 +100,7 @@ rule liquidateLossFactorDoesNotRevert(env e, Midnight.Market market, address bor
     require e.msg.value == 0, "Midnight is not payable";
 
     address zero = 0;
-    liquidate@withrevert(e, market, 0, 0, 0, borrower, true, borrower, zero, data);
+    liquidate@withrevert(e, market, 0, 0, 0, borrower, healthyPath, borrower, zero, data);
 
     assert !lastReverted, "liquidate should not revert under valid state (bad debt realization path)";
 }

--- a/certora/specs/Midnight.spec
+++ b/certora/specs/Midnight.spec
@@ -77,11 +77,11 @@ rule takeInputOutputConsistency(env e, Midnight.Offer offer, uint256 unitsInput,
     assert claimableTradingFee(offer.market.loanToken) == claimableBefore + buyerAssetsOutput - sellerAssetsOutput;
 }
 
-rule liquidateInputOutputConsistency(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
+rule liquidateInputOutputConsistency(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool healthyPath) {
     uint256 seizedAssetsOutput;
     uint256 repaidUnitsOutput;
 
-    seizedAssetsOutput, repaidUnitsOutput = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
+    seizedAssetsOutput, repaidUnitsOutput = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, healthyPath, receiver, callback, data);
 
     // At most one of the input arguments can be zero.
     assert seizedAssets == 0 || repaidUnits == 0;

--- a/certora/specs/Midnight.spec
+++ b/certora/specs/Midnight.spec
@@ -81,8 +81,8 @@ rule liquidateInputOutputConsistency(env e, Midnight.Market market, uint256 coll
     uint256 seizedAssetsOutput;
     uint256 repaidUnitsOutput;
 
-    bool _unhealthy;
-    seizedAssetsOutput, repaidUnitsOutput = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthy, receiver, callback, data);
+    bool _unhealthyPath;
+    seizedAssetsOutput, repaidUnitsOutput = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthyPath, receiver, callback, data);
 
     // At most one of the input arguments can be zero.
     assert seizedAssets == 0 || repaidUnits == 0;

--- a/certora/specs/Midnight.spec
+++ b/certora/specs/Midnight.spec
@@ -81,7 +81,8 @@ rule liquidateInputOutputConsistency(env e, Midnight.Market market, uint256 coll
     uint256 seizedAssetsOutput;
     uint256 repaidUnitsOutput;
 
-    seizedAssetsOutput, repaidUnitsOutput = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, receiver, callback, data);
+    bool _unhealthy;
+    seizedAssetsOutput, repaidUnitsOutput = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthy, receiver, callback, data);
 
     // At most one of the input arguments can be zero.
     assert seizedAssets == 0 || repaidUnits == 0;

--- a/certora/specs/Midnight.spec
+++ b/certora/specs/Midnight.spec
@@ -77,12 +77,11 @@ rule takeInputOutputConsistency(env e, Midnight.Offer offer, uint256 unitsInput,
     assert claimableTradingFee(offer.market.loanToken) == claimableBefore + buyerAssetsOutput - sellerAssetsOutput;
 }
 
-rule liquidateInputOutputConsistency(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data) {
+rule liquidateInputOutputConsistency(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
     uint256 seizedAssetsOutput;
     uint256 repaidUnitsOutput;
 
-    bool _unhealthyPath;
-    seizedAssetsOutput, repaidUnitsOutput = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthyPath, receiver, callback, data);
+    seizedAssetsOutput, repaidUnitsOutput = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
 
     // At most one of the input arguments can be zero.
     assert seizedAssets == 0 || repaidUnits == 0;

--- a/certora/specs/NoDivisionByZero.spec
+++ b/certora/specs/NoDivisionByZero.spec
@@ -112,7 +112,7 @@ rule noDivisionByZero(method f, env e, calldataarg args) filtered { f -> f.selec
 }
 
 // Show that liquidate does not cause a division by zero, in case the oracle price is non-zero and the collateral is active.
-rule noDivisionByZeroLiquidate(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
+rule noDivisionByZeroLiquidate(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool healthyPath) {
     require equalsGlobalMarket(market);
 
     // Needed for the bitmap loop which calls mulDivUp(WAD, maxLif) for every activated collateral.
@@ -124,6 +124,6 @@ rule noDivisionByZeroLiquidate(env e, Midnight.Market market, uint256 collateral
     require ghostPrice(market.collateralParams[collateralIndex].oracle) > 0, "Assumption: the collateral price is not zero";
     require summaryGetBit(currentContract.position[globalId][borrower].collateralBitmap, collateralIndex), "Assumption: liquidated collateral was activated";
 
-    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
+    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, healthyPath, receiver, callback, data);
     assert true;
 }

--- a/certora/specs/NoDivisionByZero.spec
+++ b/certora/specs/NoDivisionByZero.spec
@@ -112,7 +112,7 @@ rule noDivisionByZero(method f, env e, calldataarg args) filtered { f -> f.selec
 }
 
 // Show that liquidate does not cause a division by zero, in case the oracle price is non-zero and the collateral is active.
-rule noDivisionByZeroLiquidate(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data) {
+rule noDivisionByZeroLiquidate(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
     require equalsGlobalMarket(market);
 
     // Needed for the bitmap loop which calls mulDivUp(WAD, maxLif) for every activated collateral.
@@ -124,7 +124,6 @@ rule noDivisionByZeroLiquidate(env e, Midnight.Market market, uint256 collateral
     require ghostPrice(market.collateralParams[collateralIndex].oracle) > 0, "Assumption: the collateral price is not zero";
     require summaryGetBit(currentContract.position[globalId][borrower].collateralBitmap, collateralIndex), "Assumption: liquidated collateral was activated";
 
-    bool _unhealthyPath;
-    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthyPath, receiver, callback, data);
+    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
     assert true;
 }

--- a/certora/specs/NoDivisionByZero.spec
+++ b/certora/specs/NoDivisionByZero.spec
@@ -124,7 +124,7 @@ rule noDivisionByZeroLiquidate(env e, Midnight.Market market, uint256 collateral
     require ghostPrice(market.collateralParams[collateralIndex].oracle) > 0, "Assumption: the collateral price is not zero";
     require summaryGetBit(currentContract.position[globalId][borrower].collateralBitmap, collateralIndex), "Assumption: liquidated collateral was activated";
 
-    bool _unhealthy;
-    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthy, receiver, callback, data);
+    bool _unhealthyPath;
+    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthyPath, receiver, callback, data);
     assert true;
 }

--- a/certora/specs/NoDivisionByZero.spec
+++ b/certora/specs/NoDivisionByZero.spec
@@ -106,7 +106,7 @@ function mulDivUpSummary(uint256 x, uint256 y, uint256 d) returns uint256 {
 /// RULES ///
 
 // The liquidate function is verified in a separate rule (noDivisionByZeroLiquidate).
-rule noDivisionByZero(method f, env e, calldataarg args) filtered { f -> f.selector != sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, address, address, bytes).selector } {
+rule noDivisionByZero(method f, env e, calldataarg args) filtered { f -> f.selector != sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, bool, address, address, bytes).selector } {
     f(e, args);
     assert true;
 }
@@ -124,6 +124,7 @@ rule noDivisionByZeroLiquidate(env e, Midnight.Market market, uint256 collateral
     require ghostPrice(market.collateralParams[collateralIndex].oracle) > 0, "Assumption: the collateral price is not zero";
     require summaryGetBit(currentContract.position[globalId][borrower].collateralBitmap, collateralIndex), "Assumption: liquidated collateral was activated";
 
-    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, receiver, callback, data);
+    bool _unhealthy;
+    liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthy, receiver, callback, data);
     assert true;
 }

--- a/certora/specs/OnlyAuthorizedCanChange.spec
+++ b/certora/specs/OnlyAuthorizedCanChange.spec
@@ -54,7 +54,7 @@ definition noAccrual(env e, bytes32 id, address borrower) returns bool = current
 
 /// An unauthorized caller cannot change a user's credit and debt except via liquidate and updatePosition.
 /// Assumes no reentrancy: callbacks (onBuy, onSell) and token transfers are not modeled as re-entering Midnight, so re-entrant credit and debt changes are not covered.
-rule onlyAuthorizedCanChangeCreditAndDebtExceptLiquidateAndUpdatePosition(env e, method f, calldataarg args, bytes32 id, address user) filtered { f -> f.selector != sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, address, address, bytes).selector && f.selector != sig:updatePosition(Midnight.Market, address).selector } {
+rule onlyAuthorizedCanChangeCreditAndDebtExceptLiquidateAndUpdatePosition(env e, method f, calldataarg args, bytes32 id, address user) filtered { f -> f.selector != sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, bool, address, address, bytes).selector && f.selector != sig:updatePosition(Midnight.Market, address).selector } {
     bool userIsAuthorized = user == e.msg.sender || isAuthorized(user, e.msg.sender);
 
     uint256 creditBefore = creditOf(id, user);
@@ -70,7 +70,7 @@ rule onlyAuthorizedCanChangeCreditAndDebtExceptLiquidateAndUpdatePosition(env e,
 
 /// An unauthorized caller cannot change a user's collateral except via liquidate.
 /// Assumes no reentrancy: callbacks and token transfers are not modeled as re-entering Midnight, so re-entrant collateral changes are not covered.
-rule onlyAuthorizedCanChangeCollateralExceptLiquidate(env e, method f, calldataarg args, bytes32 id, address user, uint256 collateralIndex) filtered { f -> f.selector != sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, address, address, bytes).selector } {
+rule onlyAuthorizedCanChangeCollateralExceptLiquidate(env e, method f, calldataarg args, bytes32 id, address user, uint256 collateralIndex) filtered { f -> f.selector != sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, bool, address, address, bytes).selector } {
     bool userIsAuthorized = user == e.msg.sender || isAuthorized(user, e.msg.sender);
 
     uint256 collateralBefore = collateral(id, user, collateralIndex);

--- a/certora/specs/OnlyExplicitPayerCanLoseTokens.spec
+++ b/certora/specs/OnlyExplicitPayerCanLoseTokens.spec
@@ -125,7 +125,7 @@ rule otherEntryPointsOnlyPullFromCaller(method f, env e, calldataarg args) filte
     makerAllowed = false;
 
     buyCallbackAllowed = false;
-    liquidateCallbackAllowed = f.selector == sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, address, address, bytes).selector;
+    liquidateCallbackAllowed = f.selector == sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, bool, address, address, bytes).selector;
     repayCallbackAllowed = f.selector == sig:repay(Midnight.Market, uint256, address, address, bytes).selector;
     flashLoanCallbackAllowed = f.selector == sig:flashLoan(address[], uint256[], address, bytes).selector;
     badPullSeen = false;

--- a/certora/specs/Reverts.spec
+++ b/certora/specs/Reverts.spec
@@ -339,7 +339,7 @@ filtered {
     f -> f.selector == sig:take(Midnight.Offer, uint256, address, address, address, bytes, bytes).selector
         || f.selector == sig:repay(Midnight.Market, uint256, address, address, bytes).selector
         || f.selector == sig:supplyCollateral(Midnight.Market, uint256, uint256, address).selector
-        || f.selector == sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, address, address, bytes).selector
+        || f.selector == sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, bool, address, address, bytes).selector
 } {
     require forceTransferFromRevert, "transferFrom reverts";
     f@withrevert(e, args);
@@ -361,7 +361,7 @@ filtered {
         || f.selector == sig:withdrawCollateral(Midnight.Market, uint256, uint256, address, address).selector
         || f.selector == sig:claimTradingFee(address, uint256, address).selector
         || f.selector == sig:claimContinuousFee(Midnight.Market, uint256, address).selector
-        || f.selector == sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, address, address, bytes).selector
+        || f.selector == sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, bool, address, address, bytes).selector
 } {
     require forceTransferRevert, "transfer reverts";
     f@withrevert(e, args);

--- a/certora/specs/Reverts.spec
+++ b/certora/specs/Reverts.spec
@@ -180,14 +180,14 @@ function CVL_safeTransfer() {
 /// ORACLE REVERT PROPAGATION ///
 
 /// If any activated collateral oracle reverts on price, liquidate reverts.
-rule oracleRevertCausesLiquidateRevert(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, uint256 revertingCollateralIndex, bool unhealthyPath) {
+rule oracleRevertCausesLiquidateRevert(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, uint256 revertingCollateralIndex, bool healthyPath) {
     require singleRevertingOracle == market.collateralParams[revertingCollateralIndex].oracle, "oracle is reverting";
 
     bytes32 id = summaryToId(market);
     uint128 bitmap = collateralBitmap(id, borrower);
     require summaryGetBit(bitmap, revertingCollateralIndex), "revertingCollateralIndex is activated";
 
-    liquidate@withrevert(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
+    liquidate@withrevert(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, healthyPath, receiver, callback, data);
 
     assert lastReverted;
 }
@@ -243,11 +243,11 @@ rule oracleRevertPreventsTakeWhenSellerHasDebt(env e, Midnight.Offer offer, uint
 /// ORACLE RETURNS ZERO ///
 
 /// If liquidated collateral oracle returns 0 on price, liquidate with repaid input reverts.
-rule oracleZeroCausesLiquidateWithRepaidRevert(env e, Midnight.Market market, uint256 collateralIndex, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
+rule oracleZeroCausesLiquidateWithRepaidRevert(env e, Midnight.Market market, uint256 collateralIndex, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool healthyPath) {
     require singleZeroOracle == market.collateralParams[collateralIndex].oracle, "oracle returns zero";
     require repaidUnits > 0, "using repaid units as input";
 
-    liquidate@withrevert(e, market, collateralIndex, 0, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
+    liquidate@withrevert(e, market, collateralIndex, 0, repaidUnits, borrower, healthyPath, receiver, callback, data);
 
     assert lastReverted;
 }
@@ -322,11 +322,11 @@ rule enterGateBlocksDebtIncrease(env e, Midnight.Offer offer, uint256 units, add
 }
 
 /// If the liquidator gate returns false on canLiquidate, liquidate reverts.
-rule liquidatorGateBlocksLiquidation(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
+rule liquidatorGateBlocksLiquidation(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool healthyPath) {
     require !ghostCanLiquidate(market.liquidatorGate), "canLiquidate blocked";
     require market.liquidatorGate != 0, "liquidator gate is set";
 
-    liquidate@withrevert(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
+    liquidate@withrevert(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, healthyPath, receiver, callback, data);
 
     assert lastReverted;
 }
@@ -389,11 +389,11 @@ rule callbackRevertOrBadReturnCausesRepayRevert(env e, Midnight.Market market, u
 }
 
 /// If the callback reverts or returns something other than CALLBACK_SUCCESS, callback-enabled liquidate (non-zero callback) reverts.
-rule callbackRevertOrBadReturnCausesLiquidateRevert(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
+rule callbackRevertOrBadReturnCausesLiquidateRevert(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool healthyPath) {
     require forceCallbackRevert || forceCallbackBadReturn, "callback reverts or returns bad value";
     require callback != 0, "callback-enabled liquidate";
 
-    liquidate@withrevert(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
+    liquidate@withrevert(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, healthyPath, receiver, callback, data);
 
     assert lastReverted;
 }

--- a/certora/specs/Reverts.spec
+++ b/certora/specs/Reverts.spec
@@ -180,14 +180,14 @@ function CVL_safeTransfer() {
 /// ORACLE REVERT PROPAGATION ///
 
 /// If any activated collateral oracle reverts on price, liquidate reverts.
-rule oracleRevertCausesLiquidateRevert(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, uint256 revertingCollateralIndex) {
+rule oracleRevertCausesLiquidateRevert(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, uint256 revertingCollateralIndex, bool unhealthyPath) {
     require singleRevertingOracle == market.collateralParams[revertingCollateralIndex].oracle, "oracle is reverting";
 
     bytes32 id = summaryToId(market);
     uint128 bitmap = collateralBitmap(id, borrower);
     require summaryGetBit(bitmap, revertingCollateralIndex), "revertingCollateralIndex is activated";
 
-    liquidate@withrevert(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, receiver, callback, data);
+    liquidate@withrevert(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
 
     assert lastReverted;
 }
@@ -243,11 +243,11 @@ rule oracleRevertPreventsTakeWhenSellerHasDebt(env e, Midnight.Offer offer, uint
 /// ORACLE RETURNS ZERO ///
 
 /// If liquidated collateral oracle returns 0 on price, liquidate with repaid input reverts.
-rule oracleZeroCausesLiquidateWithRepaidRevert(env e, Midnight.Market market, uint256 collateralIndex, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data) {
+rule oracleZeroCausesLiquidateWithRepaidRevert(env e, Midnight.Market market, uint256 collateralIndex, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
     require singleZeroOracle == market.collateralParams[collateralIndex].oracle, "oracle returns zero";
     require repaidUnits > 0, "using repaid units as input";
 
-    liquidate@withrevert(e, market, collateralIndex, 0, repaidUnits, borrower, receiver, callback, data);
+    liquidate@withrevert(e, market, collateralIndex, 0, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
 
     assert lastReverted;
 }
@@ -322,11 +322,11 @@ rule enterGateBlocksDebtIncrease(env e, Midnight.Offer offer, uint256 units, add
 }
 
 /// If the liquidator gate returns false on canLiquidate, liquidate reverts.
-rule liquidatorGateBlocksLiquidation(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data) {
+rule liquidatorGateBlocksLiquidation(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
     require !ghostCanLiquidate(market.liquidatorGate), "canLiquidate blocked";
     require market.liquidatorGate != 0, "liquidator gate is set";
 
-    liquidate@withrevert(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, receiver, callback, data);
+    liquidate@withrevert(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
 
     assert lastReverted;
 }
@@ -389,11 +389,11 @@ rule callbackRevertOrBadReturnCausesRepayRevert(env e, Midnight.Market market, u
 }
 
 /// If the callback reverts or returns something other than CALLBACK_SUCCESS, callback-enabled liquidate (non-zero callback) reverts.
-rule callbackRevertOrBadReturnCausesLiquidateRevert(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data) {
+rule callbackRevertOrBadReturnCausesLiquidateRevert(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
     require forceCallbackRevert || forceCallbackBadReturn, "callback reverts or returns bad value";
     require callback != 0, "callback-enabled liquidate";
 
-    liquidate@withrevert(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, receiver, callback, data);
+    liquidate@withrevert(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
 
     assert lastReverted;
 }

--- a/certora/specs/TradingFeeBoundaries.spec
+++ b/certora/specs/TradingFeeBoundaries.spec
@@ -55,7 +55,7 @@ invariant marketTradingFeePerIndexBound(bytes32 id, uint256 index)
         preserved withdrawCollateral(Midnight.Market market, uint256 collateralIndex, uint256 assets, address onBehalf, address receiver) with (env e) {
             requireInvariant defaultTradingFeePerIndexBound(market.loanToken, index);
         }
-        preserved liquidate(Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data) with (env e) {
+        preserved liquidate(Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, bool unhealthyPath, address receiver, address callback, bytes data) with (env e) {
             requireInvariant defaultTradingFeePerIndexBound(market.loanToken, index);
         }
         preserved take(Midnight.Offer offer, uint256 units, address taker, address receiverIfTakerIsSeller, address takerCallback, bytes takerCallbackData, bytes ratifierData) with (env e) {

--- a/certora/specs/TradingFeeBoundaries.spec
+++ b/certora/specs/TradingFeeBoundaries.spec
@@ -55,7 +55,7 @@ invariant marketTradingFeePerIndexBound(bytes32 id, uint256 index)
         preserved withdrawCollateral(Midnight.Market market, uint256 collateralIndex, uint256 assets, address onBehalf, address receiver) with (env e) {
             requireInvariant defaultTradingFeePerIndexBound(market.loanToken, index);
         }
-        preserved liquidate(Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, bool unhealthyPath, address receiver, address callback, bytes data) with (env e) {
+        preserved liquidate(Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, bool healthyPath, address receiver, address callback, bytes data) with (env e) {
             requireInvariant defaultTradingFeePerIndexBound(market.loanToken, index);
         }
         preserved take(Midnight.Offer offer, uint256 units, address taker, address receiverIfTakerIsSeller, address takerCallback, bytes takerCallbackData, bytes ratifierData) with (env e) {

--- a/certora/specs/WithdrawableMonotonicity.spec
+++ b/certora/specs/WithdrawableMonotonicity.spec
@@ -16,12 +16,12 @@ rule repayIncreasesWithdrawable(env e, Midnight.Market market, uint256 units, ad
     assert withdrawableAfter == withdrawableBefore + units;
 }
 
-rule liquidateIncreasesWithdrawable(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
+rule liquidateIncreasesWithdrawable(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool healthyPath) {
     bytes32 id = toId(e, market);
     uint256 withdrawableBefore = withdrawable(id);
     uint256 seizedResult;
     uint256 repaidResult;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, healthyPath, receiver, callback, data);
     uint256 withdrawableAfter = withdrawable(id);
     assert withdrawableAfter == withdrawableBefore + repaidResult;
 }

--- a/certora/specs/WithdrawableMonotonicity.spec
+++ b/certora/specs/WithdrawableMonotonicity.spec
@@ -21,8 +21,8 @@ rule liquidateIncreasesWithdrawable(env e, Midnight.Market market, uint256 colla
     uint256 withdrawableBefore = withdrawable(id);
     uint256 seizedResult;
     uint256 repaidResult;
-    bool _unhealthy;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthy, receiver, callback, data);
+    bool _unhealthyPath;
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthyPath, receiver, callback, data);
     uint256 withdrawableAfter = withdrawable(id);
     assert withdrawableAfter == withdrawableBefore + repaidResult;
 }

--- a/certora/specs/WithdrawableMonotonicity.spec
+++ b/certora/specs/WithdrawableMonotonicity.spec
@@ -16,13 +16,12 @@ rule repayIncreasesWithdrawable(env e, Midnight.Market market, uint256 units, ad
     assert withdrawableAfter == withdrawableBefore + units;
 }
 
-rule liquidateIncreasesWithdrawable(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data) {
+rule liquidateIncreasesWithdrawable(env e, Midnight.Market market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes data, bool unhealthyPath) {
     bytes32 id = toId(e, market);
     uint256 withdrawableBefore = withdrawable(id);
     uint256 seizedResult;
     uint256 repaidResult;
-    bool _unhealthyPath;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthyPath, receiver, callback, data);
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, unhealthyPath, receiver, callback, data);
     uint256 withdrawableAfter = withdrawable(id);
     assert withdrawableAfter == withdrawableBefore + repaidResult;
 }

--- a/certora/specs/WithdrawableMonotonicity.spec
+++ b/certora/specs/WithdrawableMonotonicity.spec
@@ -21,7 +21,8 @@ rule liquidateIncreasesWithdrawable(env e, Midnight.Market market, uint256 colla
     uint256 withdrawableBefore = withdrawable(id);
     uint256 seizedResult;
     uint256 repaidResult;
-    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, receiver, callback, data);
+    bool _unhealthy;
+    seizedResult, repaidResult = liquidate(e, market, collateralIndex, seizedAssets, repaidUnits, borrower, _unhealthy, receiver, callback, data);
     uint256 withdrawableAfter = withdrawable(id);
     assert withdrawableAfter == withdrawableBefore + repaidResult;
 }
@@ -46,7 +47,7 @@ rule withdrawableUnchanged(method f, env e, calldataarg args, bytes32 id)
 filtered {
     f -> !f.isView
         && f.selector != sig:repay(Midnight.Market, uint256, address, address, bytes).selector
-        && f.selector != sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, address, address, bytes).selector
+        && f.selector != sig:liquidate(Midnight.Market, uint256, uint256, uint256, address, bool, address, address, bytes).selector
         && f.selector != sig:withdraw(Midnight.Market, uint256, address, address).selector
         && f.selector != sig:claimContinuousFee(Midnight.Market, uint256, address).selector
 } {

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -63,8 +63,7 @@ import {IMidnight, Market, Offer, CollateralParams, MarketState, Position} from 
 /// "post-maturity path", available after the market's maturity. For an unhealthy borrower after the maturity, the
 /// liquidator can choose between both modes.
 /// @dev In the "unhealthy path", the liquidation incentive factor (LIF) is maxLif and the liquidation amount is capped
-/// by what is needed to put back the position into health ("recovery close factor", or "RCF"). The RCF is deactivated
-/// if the liquidation could leave a collateral with a value that would not be enough to repay rcfThreshold.
+/// by what is needed to put back the position into health ("recovery close factor", or "RCF").
 /// @dev The RCF means (omitting scaling and roundings):
 ///   newDebt >= newMaxDebt <=> debtOf - repaidUnits >= maxDebt - repaidUnits*LIF*LLTV
 ///                         <=> repaidUnits <= (debtOf-maxDebt) / (1 - LIF*LLTV).

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -71,6 +71,9 @@ import {IMidnight, Market, Offer, CollateralParams, MarketState, Position} from 
 /// The maxRepaid computation is rounded up to avoid consecutive max liquidations, so the position could be slightly
 /// healthy after a liquidation.
 /// @dev The RCF is deactivated for post-maturity healthy borrowers.
+/// @dev The liquidator chooses the liquidation path via the `unhealthyPath` flag:
+/// - unhealthyPath=true: uses maxLif and enforces RCF; requires the borrower to be unhealthy.
+/// - unhealthyPath=false: uses the ramped LIF and skips RCF; requires the maturity to have passed.
 /// @dev The RCF is deactivated for small collateral amount, essentially to mitigate issues with liquidations that are
 /// too small compared to the gas cost. More precisely, it is deactivated if the liquidation could leave a collateral
 /// with a value that would not be enough to repay rcfThreshold units. Which means (omitting scaling and roundings):
@@ -581,6 +584,7 @@ contract Midnight is IMidnight {
         uint256 seizedAssets,
         uint256 repaidUnits,
         address borrower,
+        bool unhealthyPath,
         address receiver,
         address callback,
         bytes calldata data
@@ -614,7 +618,7 @@ contract Midnight is IMidnight {
 
         require(
             originalDebt > 0 && !liquidationLocked(id, borrower)
-                && (block.timestamp > market.maturity || originalDebt > maxDebt),
+                && (unhealthyPath ? originalDebt > maxDebt : block.timestamp > market.maturity),
             NotLiquidatable()
         );
 
@@ -637,7 +641,7 @@ contract Midnight is IMidnight {
 
         if (repaidUnits > 0 || seizedAssets > 0) {
             uint256 _maxLif = market.collateralParams[collateralIndex].maxLif;
-            uint256 lif = originalDebt > maxDebt
+            uint256 lif = unhealthyPath
                 ? _maxLif
                 : UtilsLib.min(_maxLif, WAD + (_maxLif - WAD) * (block.timestamp - market.maturity) / TIME_TO_MAX_LIF);
 
@@ -647,7 +651,7 @@ contract Midnight is IMidnight {
                 seizedAssets = repaidUnits.mulDivDown(lif, WAD).mulDivDown(ORACLE_PRICE_SCALE, liquidatedCollatPrice);
             }
 
-            if (originalDebt > maxDebt) {
+            if (unhealthyPath) {
                 uint256 lltv = market.collateralParams[collateralIndex].lltv;
                 // Note that debt >= maxDebt in this branch.
                 uint256 maxRepaid = lltv < WAD

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -680,6 +680,7 @@ contract Midnight is IMidnight {
             seizedAssets,
             repaidUnits,
             borrower,
+            unhealthyPath,
             badDebt,
             _marketState.lossFactor,
             _marketState.continuousFeeCredit,

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -61,15 +61,16 @@ import {IMidnight, Market, Offer, CollateralParams, MarketState, Position} from 
 /// @dev Liquidations can revert for other reasons, see LIVENESS.
 /// @dev If an account is healthy, the LIF (liquidation incentive factor) grows linearly from 1 at maturity to maxLif at
 /// maturity + TIME_TO_MAX_LIF.
-/// @dev Before or at maturity, the liquidation cannot put the borrower back into health (recovery close factor), unless
-/// the liquidation could leave a collateral with a value that would not be enough to repay rcfThreshold units.
+/// @dev When the borrower is unhealthy, the liquidation cannot put the borrower back into health (recovery close
+/// factor), unless the liquidation could leave a collateral with a value that would not be enough to repay rcfThreshold
+/// units.
 /// @dev The "recovery close factor" (RCF) limits the amount that can be liquidated. In particular, it prevents the
 /// liquidation from putting the borrower back into health. Which means (omitting scaling and roundings):
 ///   newDebt >= newMaxDebt <=> debtOf - repaidUnits >= maxDebt - repaidUnits*LIF*LLTV
 ///                         <=> repaidUnits <= (debtOf-maxDebt) / (1 - LIF*LLTV).
 /// The maxRepaid computation is rounded up to avoid consecutive max liquidations, so the position could be slightly
 /// healthy after a liquidation.
-/// @dev The RCF is deactivated after the maturity.
+/// @dev The RCF is deactivated when the borrower is healthy (which can only happen after the maturity).
 /// @dev The RCF is deactivated for small collateral amount, essentially to mitigate issues with liquidations that are
 /// too small compared to the gas cost. More precisely, it is deactivated if the liquidation could leave a collateral
 /// with a value that would not be enough to repay rcfThreshold units. Which means (omitting scaling and roundings):
@@ -646,7 +647,7 @@ contract Midnight is IMidnight {
                 seizedAssets = repaidUnits.mulDivDown(lif, WAD).mulDivDown(ORACLE_PRICE_SCALE, liquidatedCollatPrice);
             }
 
-            if (block.timestamp <= market.maturity) {
+            if (originalDebt > maxDebt) {
                 uint256 lltv = market.collateralParams[collateralIndex].lltv;
                 // Note that debt >= maxDebt in this branch.
                 uint256 maxRepaid = lltv < WAD

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -59,27 +59,25 @@ import {IMidnight, Market, Offer, CollateralParams, MarketState, Position} from 
 /// shouldn't be locked either.
 /// @dev Liquidations are locked for the seller during the callbacks of take.
 /// @dev Liquidations can revert for other reasons, see LIVENESS.
-/// @dev If an account is healthy, the LIF (liquidation incentive factor) grows linearly from 1 at maturity to maxLif at
-/// maturity + TIME_TO_MAX_LIF.
-/// @dev When the borrower is unhealthy, the liquidation cannot put the borrower back into health (recovery close
-/// factor), unless the liquidation could leave a collateral with a value that would not be enough to repay rcfThreshold
-/// units.
-/// @dev The "recovery close factor" (RCF) limits the amount that can be liquidated. In particular, it prevents the
-/// liquidation from putting the borrower back into health. Which means (omitting scaling and roundings):
+/// @dev There are two liquidations modes: The "unhealthy path", available if the borrower is unhealthy and the
+/// "post-maturity path", available after the market's maturity. For a unhealthy borrower after the maturity, the
+/// liquidator can choose between both modes.
+/// @dev In the "unhealthy path", the liquidation incentive factor (LIF) is maxLif and the liquidation amount is capped
+/// by what is needed to put back the position into health ("recovery close factor", or "RCF"). The RCF is deactivated
+/// if the liquidation could leave a collateral with a value that would not be enough to repay rcfThreshold.
+/// @dev The RCF means (omitting scaling and roundings):
 ///   newDebt >= newMaxDebt <=> debtOf - repaidUnits >= maxDebt - repaidUnits*LIF*LLTV
 ///                         <=> repaidUnits <= (debtOf-maxDebt) / (1 - LIF*LLTV).
 /// The maxRepaid computation is rounded up to avoid consecutive max liquidations, so the position could be slightly
 /// healthy after a liquidation.
-/// @dev The RCF is deactivated for post-maturity healthy borrowers.
-/// @dev The liquidator chooses the liquidation path via the `unhealthyPath` flag:
-/// - unhealthyPath=true: uses maxLif and enforces RCF; requires the borrower to be unhealthy.
-/// - unhealthyPath=false: uses the ramped LIF and skips RCF; requires the maturity to have passed.
 /// @dev The RCF is deactivated for small collateral amount, essentially to mitigate issues with liquidations that are
 /// too small compared to the gas cost. More precisely, it is deactivated if the liquidation could leave a collateral
 /// with a value that would not be enough to repay rcfThreshold units. Which means (omitting scaling and roundings):
 ///   minNewCollateral * liquidatedCollatPrice / LIF < rcfThreshold
 ///     <=> (collateral - maxRepaid * LIF / liquidatedCollatPrice) * liquidatedCollatPrice / LIF < rcfThreshold
 ///     <=> collateral * liquidatedCollatPrice / LIF - maxRepaid < rcfThreshold
+/// @dev In the "post-maturity path", the LIF (liquidation incentive factor) grows linearly from 1 at maturity to maxLif
+/// at maturity + TIME_TO_MAX_LIF, and the RCF is deactivated.
 ///
 /// SLASHING
 /// @dev When a borrower's bad debt is realized, it is socialized among lenders in this market.

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -64,7 +64,7 @@ import {IMidnight, Market, Offer, CollateralParams, MarketState, Position} from 
 /// liquidator can choose between both modes.
 /// @dev In the "unhealthy path", the liquidation incentive factor (LIF) is maxLif and the liquidation amount is capped
 /// by what is needed to put back the position into health ("recovery close factor", or "RCF").
-/// @dev The RCF means (omitting scaling and roundings):
+/// @dev The RCF condition is (omitting scaling and roundings):
 ///   newDebt >= newMaxDebt <=> debtOf - repaidUnits >= maxDebt - repaidUnits*LIF*LLTV
 ///                         <=> repaidUnits <= (debtOf-maxDebt) / (1 - LIF*LLTV).
 /// The maxRepaid computation is rounded up to avoid consecutive max liquidations, so the position could be slightly

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -59,7 +59,7 @@ import {IMidnight, Market, Offer, CollateralParams, MarketState, Position} from 
 /// shouldn't be locked either.
 /// @dev Liquidations are locked for the seller during the callbacks of take.
 /// @dev Liquidations can revert for other reasons, see LIVENESS.
-/// @dev There are two liquidations modes: The "unhealthy path", available if the borrower is unhealthy and the
+/// @dev There are two liquidation modes: The "unhealthy path", available if the borrower is unhealthy and the
 /// "post-maturity path", available after the market's maturity. For an unhealthy borrower after the maturity, the
 /// liquidator can choose between both modes.
 /// @dev In the "unhealthy path", the liquidation incentive factor (LIF) is maxLif and the liquidation amount is capped

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -581,7 +581,7 @@ contract Midnight is IMidnight {
         uint256 seizedAssets,
         uint256 repaidUnits,
         address borrower,
-        bool unhealthyPath,
+        bool healthyPath,
         address receiver,
         address callback,
         bytes calldata data
@@ -615,7 +615,7 @@ contract Midnight is IMidnight {
 
         require(
             originalDebt > 0 && !liquidationLocked(id, borrower)
-                && (unhealthyPath ? originalDebt > maxDebt : block.timestamp > market.maturity),
+                && (healthyPath ? block.timestamp > market.maturity : originalDebt > maxDebt),
             NotLiquidatable()
         );
 
@@ -638,9 +638,9 @@ contract Midnight is IMidnight {
 
         if (repaidUnits > 0 || seizedAssets > 0) {
             uint256 _maxLif = market.collateralParams[collateralIndex].maxLif;
-            uint256 lif = unhealthyPath
-                ? _maxLif
-                : UtilsLib.min(_maxLif, WAD + (_maxLif - WAD) * (block.timestamp - market.maturity) / TIME_TO_MAX_LIF);
+            uint256 lif = healthyPath
+                ? UtilsLib.min(_maxLif, WAD + (_maxLif - WAD) * (block.timestamp - market.maturity) / TIME_TO_MAX_LIF)
+                : _maxLif;
 
             if (seizedAssets > 0) {
                 repaidUnits = seizedAssets.mulDivUp(liquidatedCollatPrice, ORACLE_PRICE_SCALE).mulDivUp(WAD, lif);
@@ -648,7 +648,7 @@ contract Midnight is IMidnight {
                 seizedAssets = repaidUnits.mulDivDown(lif, WAD).mulDivDown(ORACLE_PRICE_SCALE, liquidatedCollatPrice);
             }
 
-            if (unhealthyPath) {
+            if (!healthyPath) {
                 uint256 lltv = market.collateralParams[collateralIndex].lltv;
                 // Note that debt >= maxDebt in this branch.
                 uint256 maxRepaid = lltv < WAD
@@ -680,7 +680,7 @@ contract Midnight is IMidnight {
             seizedAssets,
             repaidUnits,
             borrower,
-            unhealthyPath,
+            healthyPath,
             badDebt,
             _marketState.lossFactor,
             _marketState.continuousFeeCredit,

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -60,7 +60,7 @@ import {IMidnight, Market, Offer, CollateralParams, MarketState, Position} from 
 /// @dev Liquidations are locked for the seller during the callbacks of take.
 /// @dev Liquidations can revert for other reasons, see LIVENESS.
 /// @dev There are two liquidations modes: The "unhealthy path", available if the borrower is unhealthy and the
-/// "post-maturity path", available after the market's maturity. For a unhealthy borrower after the maturity, the
+/// "post-maturity path", available after the market's maturity. For an unhealthy borrower after the maturity, the
 /// liquidator can choose between both modes.
 /// @dev In the "unhealthy path", the liquidation incentive factor (LIF) is maxLif and the liquidation amount is capped
 /// by what is needed to put back the position into health ("recovery close factor", or "RCF"). The RCF is deactivated

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -70,7 +70,7 @@ import {IMidnight, Market, Offer, CollateralParams, MarketState, Position} from 
 ///                         <=> repaidUnits <= (debtOf-maxDebt) / (1 - LIF*LLTV).
 /// The maxRepaid computation is rounded up to avoid consecutive max liquidations, so the position could be slightly
 /// healthy after a liquidation.
-/// @dev The RCF is deactivated when the borrower is healthy (which can only happen after the maturity).
+/// @dev The RCF is deactivated for post-maturity healthy borrowers.
 /// @dev The RCF is deactivated for small collateral amount, essentially to mitigate issues with liquidations that are
 /// too small compared to the gas cost. More precisely, it is deactivated if the liquidation could leave a collateral
 /// with a value that would not be enough to repay rcfThreshold units. Which means (omitting scaling and roundings):

--- a/src/interfaces/IMidnight.sol
+++ b/src/interfaces/IMidnight.sol
@@ -149,7 +149,7 @@ interface IMidnight {
     function repay(Market memory market, uint256 units, address onBehalf, address callback, bytes memory data) external;
     function supplyCollateral(Market memory market, uint256 collateralIndex, uint256 assets, address onBehalf) external;
     function withdrawCollateral(Market memory market, uint256 collateralIndex, uint256 assets, address onBehalf, address receiver) external;
-    function liquidate(Market memory market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, address receiver, address callback, bytes memory data) external returns (uint256, uint256);
+    function liquidate(Market memory market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, bool unhealthyPath, address receiver, address callback, bytes memory data) external returns (uint256, uint256);
     function setConsumed(bytes32 group, uint256 amount, address onBehalf) external;
     function setIsAuthorized(address authorized, bool newIsAuthorized, address onBehalf) external;
     function flashLoan(address[] memory tokens, uint256[] memory assets, address callback, bytes memory data) external;

--- a/src/interfaces/IMidnight.sol
+++ b/src/interfaces/IMidnight.sol
@@ -149,7 +149,7 @@ interface IMidnight {
     function repay(Market memory market, uint256 units, address onBehalf, address callback, bytes memory data) external;
     function supplyCollateral(Market memory market, uint256 collateralIndex, uint256 assets, address onBehalf) external;
     function withdrawCollateral(Market memory market, uint256 collateralIndex, uint256 assets, address onBehalf, address receiver) external;
-    function liquidate(Market memory market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, bool unhealthyPath, address receiver, address callback, bytes memory data) external returns (uint256, uint256);
+    function liquidate(Market memory market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, bool healthyPath, address receiver, address callback, bytes memory data) external returns (uint256, uint256);
     function setConsumed(bytes32 group, uint256 amount, address onBehalf) external;
     function setIsAuthorized(address authorized, bool newIsAuthorized, address onBehalf) external;
     function flashLoan(address[] memory tokens, uint256[] memory assets, address callback, bytes memory data) external;

--- a/src/libraries/EventsLib.sol
+++ b/src/libraries/EventsLib.sol
@@ -24,7 +24,7 @@ library EventsLib {
     event Repay(address indexed caller, bytes32 indexed id_, uint256 units, address indexed onBehalf, address payer);
     event SupplyCollateral(address caller, bytes32 indexed id_, address indexed collateral, uint256 assets, address indexed onBehalf);
     event WithdrawCollateral(address caller, bytes32 indexed id_, address indexed collateral, uint256 assets, address indexed onBehalf, address receiver);
-    event Liquidate(address caller, bytes32 indexed id_, address indexed collateral, uint256 seizedAssets, uint256 repaidUnits, address indexed borrower, bool unhealthyPath, uint256 badDebt, uint256 latestLossFactor, uint256 latestContinuousFeeCredit, address payer, address receiver);
+    event Liquidate(address caller, bytes32 indexed id_, address indexed collateral, uint256 seizedAssets, uint256 repaidUnits, address indexed borrower, bool healthyPath, uint256 badDebt, uint256 latestLossFactor, uint256 latestContinuousFeeCredit, address payer, address receiver);
     event SetConsumed(address indexed caller, address indexed onBehalf, bytes32 indexed group, uint256 amount);
     event FlashLoan(address indexed caller, address[] tokens, uint256[] assets, address indexed callback);
     event SetIsAuthorized(address indexed caller, address indexed onBehalf, address indexed authorized, bool newIsAuthorized);

--- a/src/libraries/EventsLib.sol
+++ b/src/libraries/EventsLib.sol
@@ -24,7 +24,7 @@ library EventsLib {
     event Repay(address indexed caller, bytes32 indexed id_, uint256 units, address indexed onBehalf, address payer);
     event SupplyCollateral(address caller, bytes32 indexed id_, address indexed collateral, uint256 assets, address indexed onBehalf);
     event WithdrawCollateral(address caller, bytes32 indexed id_, address indexed collateral, uint256 assets, address indexed onBehalf, address receiver);
-    event Liquidate(address caller, bytes32 indexed id_, address indexed collateral, uint256 seizedAssets, uint256 repaidUnits, address indexed borrower, uint256 badDebt, uint256 latestLossFactor, uint256 latestContinuousFeeCredit, address payer, address receiver);
+    event Liquidate(address caller, bytes32 indexed id_, address indexed collateral, uint256 seizedAssets, uint256 repaidUnits, address indexed borrower, bool unhealthyPath, uint256 badDebt, uint256 latestLossFactor, uint256 latestContinuousFeeCredit, address payer, address receiver);
     event SetConsumed(address indexed caller, address indexed onBehalf, bytes32 indexed group, uint256 amount);
     event FlashLoan(address indexed caller, address[] tokens, uint256[] assets, address indexed callback);
     event SetIsAuthorized(address indexed caller, address indexed onBehalf, address indexed authorized, bool newIsAuthorized);

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -205,7 +205,7 @@ abstract contract BaseTest is Test {
         take(100, unluckyLender, badBorrowerOffer);
 
         Oracle(market.collateralParams[0].oracle).setPrice(ORACLE_PRICE_SCALE / 4);
-        midnight.liquidate(market, 0, 0, 0, badBorrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, badBorrower, false, address(this), address(0), "");
 
         // then empty the market (borrow side only).
         vm.prank(badBorrower);

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -205,7 +205,7 @@ abstract contract BaseTest is Test {
         take(100, unluckyLender, badBorrowerOffer);
 
         Oracle(market.collateralParams[0].oracle).setPrice(ORACLE_PRICE_SCALE / 4);
-        midnight.liquidate(market, 0, 0, 0, badBorrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, badBorrower, true, address(this), address(0), "");
 
         // then empty the market (borrow side only).
         vm.prank(badBorrower);

--- a/test/GateTest.sol
+++ b/test/GateTest.sol
@@ -280,7 +280,7 @@ contract GateTest is BaseTest {
         deal(address(loanToken), liquidator, units);
         vm.prank(liquidator);
         if (!isWhitelisted) vm.expectRevert(IMidnight.LiquidatorGatedFromLiquidating.selector);
-        midnight.liquidate(gatedMarket, 0, 1, 0, borrower, true, address(this), address(0), "");
+        midnight.liquidate(gatedMarket, 0, 1, 0, borrower, false, address(this), address(0), "");
     }
 
     function testLiquidatorGateOnBadDebt(uint256 units, bool isWhitelisted) public {
@@ -296,7 +296,7 @@ contract GateTest is BaseTest {
 
         vm.prank(liquidator);
         if (!isWhitelisted) vm.expectRevert(IMidnight.LiquidatorGatedFromLiquidating.selector);
-        midnight.liquidate(gatedMarket, 0, 0, 0, borrower, true, address(this), address(0), "");
+        midnight.liquidate(gatedMarket, 0, 0, 0, borrower, false, address(this), address(0), "");
     }
 
     // --- Default (no gate) tests ---

--- a/test/GateTest.sol
+++ b/test/GateTest.sol
@@ -280,7 +280,7 @@ contract GateTest is BaseTest {
         deal(address(loanToken), liquidator, units);
         vm.prank(liquidator);
         if (!isWhitelisted) vm.expectRevert(IMidnight.LiquidatorGatedFromLiquidating.selector);
-        midnight.liquidate(gatedMarket, 0, 1, 0, borrower, address(this), address(0), "");
+        midnight.liquidate(gatedMarket, 0, 1, 0, borrower, true, address(this), address(0), "");
     }
 
     function testLiquidatorGateOnBadDebt(uint256 units, bool isWhitelisted) public {
@@ -296,7 +296,7 @@ contract GateTest is BaseTest {
 
         vm.prank(liquidator);
         if (!isWhitelisted) vm.expectRevert(IMidnight.LiquidatorGatedFromLiquidating.selector);
-        midnight.liquidate(gatedMarket, 0, 0, 0, borrower, address(this), address(0), "");
+        midnight.liquidate(gatedMarket, 0, 0, 0, borrower, true, address(this), address(0), "");
     }
 
     // --- Default (no gate) tests ---

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -152,11 +152,13 @@ contract LiquidationTest is BaseTest {
         units = bound(units, 1, MAX_UNITS);
         repaid = bound(repaid, 0, units);
         liquidationOraclePrice = bound(liquidationOraclePrice, fullRepaymentPrice(units), ORACLE_PRICE_SCALE);
+        market.rcfThreshold = type(uint256).max; // Deactivate RCF.
+        id = toId(market);
         collateralize(market, borrower, units);
         setupMarket(market, units);
         uint256 initialCollateral = midnight.collateral(id, borrower, 0);
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
-        vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity to bypass recovery close factor.
+        vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity to get full LIF.
 
         (uint256 seizedAssets, uint256 repaidUnits) =
             midnight.liquidate(market, 0, 0, repaid, borrower, address(this), address(0), "");
@@ -176,6 +178,8 @@ contract LiquidationTest is BaseTest {
     function testLiquidateCollateralInput(uint256 units, uint256 seized, uint256 liquidationOraclePrice) public {
         units = bound(units, 1, MAX_UNITS);
         liquidationOraclePrice = bound(liquidationOraclePrice, badDebtPriceDown(units) + 1, ORACLE_PRICE_SCALE);
+        market.rcfThreshold = type(uint256).max; // Deactivate RCF.
+        id = toId(market);
         collateralize(market, borrower, units);
         setupMarket(market, units);
         uint256 initialCollateral = midnight.collateral(id, borrower, 0);
@@ -189,7 +193,7 @@ contract LiquidationTest is BaseTest {
             )
         );
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
-        vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity to bypass recovery close factor.
+        vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity to get full LIF.
 
         (uint256 seizedAssets, uint256 repaidUnits) =
             midnight.liquidate(market, 0, seized, 0, borrower, address(this), address(0), "");
@@ -216,10 +220,12 @@ contract LiquidationTest is BaseTest {
         units = bound(units, 1, MAX_UNITS);
         liquidationOraclePrice = bound(liquidationOraclePrice, 1, ORACLE_PRICE_SCALE);
         vm.assume(data.length > 0);
+        market.rcfThreshold = type(uint256).max; // Deactivate RCF.
+        id = toId(market);
         collateralize(market, borrower, units);
         setupMarket(market, units);
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
-        vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity to bypass recovery close factor.
+        vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity to get full LIF.
 
         uint256 expectedBadDebt = _badDebt();
         uint256 maxRepaid = midnight.collateral(id, borrower, 0).mulDivDown(liquidationOraclePrice, ORACLE_PRICE_SCALE)
@@ -236,9 +242,11 @@ contract LiquidationTest is BaseTest {
 
     function testCannotRepayMoreThanDebt(uint256 units, uint256 repaid, uint256 liquidationOraclePrice) public {
         units = bound(units, 10, MAX_UNITS - 1);
+        market.rcfThreshold = type(uint256).max; // Deactivate RCF.
+        id = toId(market);
         collateralize(market, borrower, units);
         setupMarket(market, units);
-        vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity to bypass recovery close factor.
+        vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity to get full LIF.
 
         uint256 _maxLif = market.collateralParams[0].maxLif;
         uint256 collateral = midnight.collateral(id, borrower, 0);
@@ -259,9 +267,11 @@ contract LiquidationTest is BaseTest {
     function testCannotSeizeMoreThanCollateral(uint256 units, uint256 seized, uint256 liquidationOraclePrice) public {
         units = bound(units, 10, MAX_UNITS);
         liquidationOraclePrice = bound(liquidationOraclePrice, badDebtPriceDown(units) + 1, ORACLE_PRICE_SCALE);
+        market.rcfThreshold = type(uint256).max; // Deactivate RCF.
+        id = toId(market);
         collateralize(market, borrower, units);
         setupMarket(market, units);
-        vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity to bypass recovery close factor.
+        vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity to get full LIF.
         seized = bound(seized, midnight.collateral(id, borrower, 0) + 1, MAX_TEST_AMOUNT);
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
 
@@ -426,6 +436,8 @@ contract LiquidationTest is BaseTest {
         repaid = bound(repaid, 0, units);
         delay = bound(delay, 0, 100 weeks);
 
+        market.rcfThreshold = type(uint256).max; // Deactivate RCF.
+        id = toId(market);
         collateralize(market, borrower, units);
         setupMarket(market, units);
         liquidationOraclePrice = bound(liquidationOraclePrice, fullRepaymentPrice(units), ORACLE_PRICE_SCALE);
@@ -563,26 +575,30 @@ contract LiquidationTest is BaseTest {
         midnight.liquidate(market, 0, 0, units, borrower, address(this), address(0), "");
     }
 
-    /// @dev Recovery close factor applies at exact maturity but not one second after.
-    function testRecoveryCloseFactorMaturityBoundary(uint256 units, uint256 liquidationOraclePrice) public {
+    /// @dev Recovery close factor still applies after maturity when the borrower is unhealthy.
+    function testRecoveryCloseFactorAppliesPostMaturityWhenUnhealthy(
+        uint256 units,
+        uint256 liquidationOraclePrice,
+        uint256 delay
+    ) public {
         units = bound(units, 100, MAX_UNITS);
         liquidationOraclePrice = bound(liquidationOraclePrice, fullRepaymentPrice(units), ORACLE_PRICE_SCALE - 1);
+        delay = bound(delay, 0, 100 weeks);
         collateralize(market, borrower, units);
         setupMarket(market, units);
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
         uint256 maxRepaid = _maxRepaid(units, units, liquidationOraclePrice);
+        vm.assume(maxRepaid < units);
 
         // At exact maturity: recovery close factor applies.
-        if (maxRepaid < units) {
-            vm.warp(market.maturity);
-            vm.expectRevert(IMidnight.RecoveryCloseFactorConditionsViolated.selector);
-            midnight.liquidate(market, 0, 0, units, borrower, address(this), address(0), "");
-        }
-
-        // One second later: recovery close factor no longer applies.
-        vm.warp(market.maturity + 1);
+        vm.warp(market.maturity);
+        vm.expectRevert(IMidnight.RecoveryCloseFactorConditionsViolated.selector);
         midnight.liquidate(market, 0, 0, units, borrower, address(this), address(0), "");
-        assertEq(midnight.debtOf(id, borrower), 0);
+
+        // After maturity, while still unhealthy: recovery close factor still applies.
+        vm.warp(market.maturity + 1 + delay);
+        vm.expectRevert(IMidnight.RecoveryCloseFactorConditionsViolated.selector);
+        midnight.liquidate(market, 0, 0, units, borrower, address(this), address(0), "");
     }
 
     /// @dev With RCF deactivated, liquidation can always end by fully repaying debt or fully seizing collateral.
@@ -693,6 +709,9 @@ contract LiquidationTest is BaseTest {
     function testGasLiquidateMultipleCollaterals() public {
         uint256 units = 1000e18;
         uint256 collateralAmount = units.mulDivUp(WAD, market.collateralParams[0].lltv);
+
+        market.rcfThreshold = type(uint256).max; // Deactivate RCF.
+        id = toId(market);
 
         vm.prank(borrower);
 

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -372,6 +372,7 @@ contract LiquidationTest is BaseTest {
             0,
             0,
             borrower,
+            true,
             expectedBadDebt,
             expectedLossFactor,
             expectedContinuousFeeCredit,

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -73,7 +73,7 @@ contract LiquidationTest is BaseTest {
         Oracle(market.collateralParams[0].oracle).setPrice(1e36 - 1);
 
         vm.expectRevert(stdError.indexOOBError);
-        midnight.liquidate(market, 2, 0, 0, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 2, 0, 0, borrower, false, address(this), address(0), "");
     }
 
     function testLiquidateInactiveCollateralIndex(uint256 units) public {
@@ -85,13 +85,13 @@ contract LiquidationTest is BaseTest {
         assertEq(midnight.collateral(id, borrower, 1), 0);
 
         vm.expectRevert();
-        midnight.liquidate(market, 1, 0, 1, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 1, 0, 1, borrower, false, address(this), address(0), "");
 
         vm.expectRevert();
-        midnight.liquidate(market, 1, 1, 0, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 1, 1, 0, borrower, false, address(this), address(0), "");
 
         uint256 collatBefore = midnight.collateral(id, borrower, 0);
-        midnight.liquidate(market, 1, 0, 0, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 1, 0, 0, borrower, false, address(this), address(0), "");
         assertEq(midnight.debtOf(id, borrower), 0);
         assertEq(midnight.collateral(id, borrower, 0), collatBefore);
         assertEq(midnight.collateral(id, borrower, 1), 0);
@@ -105,7 +105,7 @@ contract LiquidationTest is BaseTest {
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
 
         vm.expectRevert(IMidnight.NotLiquidatable.selector);
-        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, false, address(this), address(0), "");
     }
 
     function testLiquidateUnhealthyPreMaturity(uint256 units, uint256 liquidationOraclePrice) public {
@@ -115,7 +115,7 @@ contract LiquidationTest is BaseTest {
         setupMarket(market, units);
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
 
-        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, false, address(this), address(0), "");
     }
 
     function testLiquidateHealthyPostMaturity(uint256 units, uint256 liquidationOraclePrice) public {
@@ -126,7 +126,7 @@ contract LiquidationTest is BaseTest {
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
         vm.warp(market.maturity + 1);
 
-        midnight.liquidate(market, 0, 0, 0, borrower, false, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
     }
 
     function testLiquidateUnhealthyPostMaturity(uint256 units, uint256 liquidationOraclePrice) public {
@@ -137,7 +137,7 @@ contract LiquidationTest is BaseTest {
         vm.warp(market.maturity + 1);
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
 
-        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, false, address(this), address(0), "");
     }
 
     function testLiquidateInconsistentInput(uint256 units) public {
@@ -146,7 +146,7 @@ contract LiquidationTest is BaseTest {
         setupMarket(market, units);
 
         vm.expectRevert(IMidnight.InconsistentInput.selector);
-        midnight.liquidate(market, 0, 1, 1, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 1, 1, borrower, false, address(this), address(0), "");
     }
 
     function testLiquidatePostMaturityPathBeforeMaturity(uint256 units, uint256 liquidationOraclePrice) public {
@@ -158,16 +158,16 @@ contract LiquidationTest is BaseTest {
 
         // Pre-maturity: the post-maturity path is not available.
         vm.expectRevert(IMidnight.NotLiquidatable.selector);
-        midnight.liquidate(market, 0, 0, 0, borrower, false, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
 
         // At exact maturity: still not available (only valid strictly after maturity).
         vm.warp(market.maturity);
         vm.expectRevert(IMidnight.NotLiquidatable.selector);
-        midnight.liquidate(market, 0, 0, 0, borrower, false, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
 
         // One second after maturity: accepted.
         vm.warp(market.maturity + 1);
-        midnight.liquidate(market, 0, 0, 0, borrower, false, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
     }
 
     function testLiquidateUnhealthyPathRequiresUnhealthy(uint256 units, uint256 liquidationOraclePrice) public {
@@ -180,7 +180,7 @@ contract LiquidationTest is BaseTest {
 
         // Post-maturity but borrower is healthy: the unhealthy path is rejected.
         vm.expectRevert(IMidnight.NotLiquidatable.selector);
-        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, false, address(this), address(0), "");
     }
 
     function testLiquidateUnitsInput(uint256 units, uint256 repaid, uint256 liquidationOraclePrice) public {
@@ -194,7 +194,7 @@ contract LiquidationTest is BaseTest {
         vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity for full LIF.
 
         (uint256 seizedAssets, uint256 repaidUnits) =
-            midnight.liquidate(market, 0, 0, repaid, borrower, false, address(this), address(0), "");
+            midnight.liquidate(market, 0, 0, repaid, borrower, true, address(this), address(0), "");
 
         assertEq(repaidUnits, repaid, "repaid units");
         assertEq(
@@ -227,7 +227,7 @@ contract LiquidationTest is BaseTest {
         vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity for full LIF.
 
         (uint256 seizedAssets, uint256 repaidUnits) =
-            midnight.liquidate(market, 0, seized, 0, borrower, false, address(this), address(0), "");
+            midnight.liquidate(market, 0, seized, 0, borrower, true, address(this), address(0), "");
 
         assertEq(
             repaidUnits,
@@ -262,7 +262,7 @@ contract LiquidationTest is BaseTest {
         repaid = bound(repaid, 0, UtilsLib.min(units - expectedBadDebt, maxRepaid));
 
         vm.prank(caller);
-        midnight.liquidate(market, 0, 0, repaid, borrower, false, address(this), address(this), data);
+        midnight.liquidate(market, 0, 0, repaid, borrower, true, address(this), address(this), data);
 
         assertEq(recordedRepaidUnits, repaid, "repaid units");
         assertEq(recordedBadDebt, expectedBadDebt, "bad debt");
@@ -288,7 +288,7 @@ contract LiquidationTest is BaseTest {
         repaid = bound(repaid, units + 1, max(maxRepaid, units + 1));
 
         vm.expectRevert(stdError.arithmeticError);
-        midnight.liquidate(market, 0, 0, repaid, borrower, false, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, repaid, borrower, true, address(this), address(0), "");
     }
 
     function testCannotSeizeMoreThanCollateral(uint256 units, uint256 seized, uint256 liquidationOraclePrice) public {
@@ -301,7 +301,7 @@ contract LiquidationTest is BaseTest {
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
 
         vm.expectRevert(stdError.arithmeticError);
-        midnight.liquidate(market, 0, seized, 0, borrower, false, address(this), address(0), "");
+        midnight.liquidate(market, 0, seized, 0, borrower, true, address(this), address(0), "");
     }
 
     function testBadDebtPriceDownGivesBadDebt(uint256 units) public {
@@ -332,7 +332,7 @@ contract LiquidationTest is BaseTest {
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
         uint256 expectedBadDebt = _badDebt();
 
-        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, false, address(this), address(0), "");
 
         assertEq(midnight.debtOf(id, borrower), units - expectedBadDebt, "debt");
         assertEq(midnight.totalUnits(id), units - expectedBadDebt, "total units");
@@ -379,7 +379,7 @@ contract LiquidationTest is BaseTest {
             address(this),
             address(this)
         );
-        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, false, address(this), address(0), "");
     }
 
     function testSlashNonFull(uint256 units) public {
@@ -388,7 +388,7 @@ contract LiquidationTest is BaseTest {
         setupMarket(market, units);
         Oracle(market.collateralParams[0].oracle).setPrice(badDebtPriceDown(units));
 
-        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, false, address(this), address(0), "");
 
         uint256 lossFactor = midnight.lossFactor(id);
         uint256 expectedCredit = units.mulDivDown(type(uint128).max - lossFactor, type(uint128).max);
@@ -410,7 +410,7 @@ contract LiquidationTest is BaseTest {
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
         uint256 debtAfterBadDebt = units - _badDebt();
 
-        (, uint256 repaid) = midnight.liquidate(market, 0, seized, 0, borrower, true, address(this), address(0), "");
+        (, uint256 repaid) = midnight.liquidate(market, 0, seized, 0, borrower, false, address(this), address(0), "");
 
         assertEq(midnight.debtOf(id, borrower), debtAfterBadDebt - repaid, "debt");
         assertEq(midnight.totalUnits(id), debtAfterBadDebt, "total units");
@@ -432,7 +432,7 @@ contract LiquidationTest is BaseTest {
             .mulDivDown(liquidationOraclePrice, ORACLE_PRICE_SCALE).mulDivDown(WAD, lif0);
         repaid = bound(repaid, 0, UtilsLib.min(UtilsLib.min(maxRepaid, debtAfterBadDebt), maxRepaidFromCollat));
 
-        midnight.liquidate(market, 0, 0, repaid, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, repaid, borrower, false, address(this), address(0), "");
 
         assertEq(midnight.debtOf(id, borrower), debtAfterBadDebt - repaid, "debt");
         assertEq(midnight.totalUnits(id), debtAfterBadDebt, "total units");
@@ -450,7 +450,7 @@ contract LiquidationTest is BaseTest {
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
 
         midnight.liquidate(
-            market, 0, midnight.collateral(id, borrower, 0), 0, borrower, true, address(this), address(0), ""
+            market, 0, midnight.collateral(id, borrower, 0), 0, borrower, false, address(this), address(0), ""
         );
 
         assertApproxEqAbs(midnight.debtOf(id, borrower), 0, 1e3, "almost all remaining debt repaid");
@@ -482,7 +482,7 @@ contract LiquidationTest is BaseTest {
 
         uint256 initialCollateral = midnight.collateral(id, borrower, 0);
 
-        midnight.liquidate(market, 0, 0, repaid, borrower, false, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, repaid, borrower, true, address(this), address(0), "");
 
         assertEq(midnight.debtOf(id, borrower), units - repaid, "debt");
         assertEq(
@@ -511,7 +511,7 @@ contract LiquidationTest is BaseTest {
 
         uint256 initialCollateral = midnight.collateral(id, borrower, 0);
 
-        midnight.liquidate(market, 0, 0, repaid, borrower, false, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, repaid, borrower, true, address(this), address(0), "");
 
         uint256 lif = WAD + (market.collateralParams[0].maxLif - WAD) * delay / TIME_TO_MAX_LIF;
 
@@ -535,10 +535,10 @@ contract LiquidationTest is BaseTest {
 
         repaid = bound(repaid, maxR + 1, max(units, maxR + 1));
         vm.expectRevert(IMidnight.RecoveryCloseFactorConditionsViolated.selector);
-        midnight.liquidate(market, 0, 0, repaid, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, repaid, borrower, false, address(this), address(0), "");
 
         repaid = bound(repaid, 0, min(maxR, units));
-        midnight.liquidate(market, 0, 0, repaid, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, repaid, borrower, false, address(this), address(0), "");
     }
 
     function testMaxRepaidMeansRecovery(uint256 units, uint256 liquidationOraclePrice) public {
@@ -549,7 +549,7 @@ contract LiquidationTest is BaseTest {
 
         uint256 maxR = _maxRepaid(units, units, liquidationOraclePrice);
 
-        midnight.liquidate(market, 0, 0, min(maxR, units), borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, min(maxR, units), borrower, false, address(this), address(0), "");
 
         uint256 remainingCollateral = midnight.collateral(id, borrower, 0);
         uint256 remainingDebt = midnight.debtOf(id, borrower);
@@ -580,7 +580,7 @@ contract LiquidationTest is BaseTest {
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
 
         // Full liquidation should succeed because remaining debt < rcfThreshold.
-        midnight.liquidate(market, 0, 0, units, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, units, borrower, false, address(this), address(0), "");
         assertEq(midnight.debtOf(toId(market), borrower), 0, "debt should be zero");
     }
 
@@ -608,7 +608,7 @@ contract LiquidationTest is BaseTest {
 
         // Full liquidation should revert because remaining debt >= rcfThreshold.
         vm.expectRevert(IMidnight.RecoveryCloseFactorConditionsViolated.selector);
-        midnight.liquidate(market, 0, 0, units, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, units, borrower, false, address(this), address(0), "");
     }
 
     /// @dev Recovery close factor still applies after maturity when the borrower is unhealthy.
@@ -629,12 +629,12 @@ contract LiquidationTest is BaseTest {
         // At exact maturity: recovery close factor applies.
         vm.warp(market.maturity);
         vm.expectRevert(IMidnight.RecoveryCloseFactorConditionsViolated.selector);
-        midnight.liquidate(market, 0, 0, units, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, units, borrower, false, address(this), address(0), "");
 
         // After maturity, while still unhealthy: recovery close factor still applies.
         vm.warp(market.maturity + 1 + delay);
         vm.expectRevert(IMidnight.RecoveryCloseFactorConditionsViolated.selector);
-        midnight.liquidate(market, 0, 0, units, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, units, borrower, false, address(this), address(0), "");
     }
 
     /// @dev With RCF deactivated, liquidation can always end by fully repaying debt or fully seizing collateral.
@@ -687,9 +687,9 @@ contract LiquidationTest is BaseTest {
 
         uint256 collateralNeededToRepayAll = units.mulDivDown(market.collateralParams[0].maxLif, WAD);
         if (collateralNeededToRepayAll <= collateral1) {
-            midnight.liquidate(market, 0, 0, units, borrower, true, address(this), address(0), "");
+            midnight.liquidate(market, 0, 0, units, borrower, false, address(this), address(0), "");
         } else {
-            midnight.liquidate(market, 0, collateral1, 0, borrower, true, address(this), address(0), "");
+            midnight.liquidate(market, 0, collateral1, 0, borrower, false, address(this), address(0), "");
         }
 
         uint256 debtAfter = midnight.debtOf(id, borrower);
@@ -736,7 +736,7 @@ contract LiquidationTest is BaseTest {
         uint256 maxR = (units - _maxDebt)
         .mulDivUp(WAD, WAD - market.collateralParams[liqIdx].maxLif.mulDivUp(market.collateralParams[liqIdx].lltv, WAD));
 
-        midnight.liquidate(market, liqIdx, 0, maxR, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, liqIdx, 0, maxR, borrower, false, address(this), address(0), "");
     }
 
     // gas tests
@@ -771,7 +771,7 @@ contract LiquidationTest is BaseTest {
         // Multicall with 1 liquidation.
         bytes[] memory calls1 = new bytes[](1);
         calls1[0] =
-            abi.encodeCall(midnight.liquidate, (market, 0, 0, repay, borrower, false, address(this), address(0), ""));
+            abi.encodeCall(midnight.liquidate, (market, 0, 0, repay, borrower, true, address(this), address(0), ""));
         uint256 gasBefore1 = gasleft();
         midnight.multicall(calls1);
         uint256 gas1 = gasBefore1 - gasleft();
@@ -780,9 +780,9 @@ contract LiquidationTest is BaseTest {
         // Multicall with 2 liquidations.
         bytes[] memory calls2 = new bytes[](2);
         calls2[0] =
-            abi.encodeCall(midnight.liquidate, (market, 0, 0, repay, borrower, false, address(this), address(0), ""));
+            abi.encodeCall(midnight.liquidate, (market, 0, 0, repay, borrower, true, address(this), address(0), ""));
         calls2[1] =
-            abi.encodeCall(midnight.liquidate, (market, 1, 0, repay, borrower, false, address(this), address(0), ""));
+            abi.encodeCall(midnight.liquidate, (market, 1, 0, repay, borrower, true, address(this), address(0), ""));
         uint256 gasBefore2 = gasleft();
         midnight.multicall(calls2);
         uint256 gas2 = gasBefore2 - gasleft();
@@ -811,7 +811,7 @@ contract LiquidationTest is BaseTest {
         setupMarket(market, units);
 
         Oracle(market.collateralParams[0].oracle).setPrice(badDebtPriceDown(units));
-        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, false, address(this), address(0), "");
 
         assertEq(midnight.creditOf(id, borrower), 0, "no credit before");
         uint256 debtBefore = midnight.debtOf(id, borrower);
@@ -831,7 +831,7 @@ contract LiquidationTest is BaseTest {
         setupMarket(market, units);
 
         Oracle(market.collateralParams[0].oracle).setPrice(badDebtPriceDown(units));
-        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, false, address(this), address(0), "");
 
         uint256 creditBeforeSlash = midnight.creditOf(id, lender);
         midnight.updatePosition(market, lender);
@@ -853,7 +853,7 @@ contract LiquidationTest is BaseTest {
         setupMarket(market, units);
 
         Oracle(market.collateralParams[0].oracle).setPrice(0);
-        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, false, address(this), address(0), "");
 
         assertEq(midnight.debtOf(id, borrower), 0, "debt");
         assertEq(midnight.totalUnits(id), 0, "total units");
@@ -952,14 +952,14 @@ contract LiquidationTest is BaseTest {
 
         uint256 debtBefore = midnight.debtOf(id, borrower);
         // Non-zero seizedAssets exercises the recovery close factor path.
-        midnight.liquidate(market, 0, 1, 0, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 1, 0, borrower, false, address(this), address(0), "");
         assertLt(midnight.debtOf(id, borrower), debtBefore, "debt should decrease after liquidation");
     }
 
     function testLiquidateNoDebtReverts() public {
         midnight.touchMarket(market);
         vm.expectRevert(IMidnight.NotLiquidatable.selector);
-        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, false, address(this), address(0), "");
     }
 
     function onLiquidate(

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -372,7 +372,7 @@ contract LiquidationTest is BaseTest {
             0,
             0,
             borrower,
-            true,
+            false,
             expectedBadDebt,
             expectedLossFactor,
             expectedContinuousFeeCredit,

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -72,7 +72,7 @@ contract LiquidationTest is BaseTest {
         Oracle(market.collateralParams[0].oracle).setPrice(1e36 - 1);
 
         vm.expectRevert(stdError.indexOOBError);
-        midnight.liquidate(market, 2, 0, 0, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 2, 0, 0, borrower, true, address(this), address(0), "");
     }
 
     function testLiquidateInactiveCollateralIndex(uint256 units) public {
@@ -84,13 +84,13 @@ contract LiquidationTest is BaseTest {
         assertEq(midnight.collateral(id, borrower, 1), 0);
 
         vm.expectRevert();
-        midnight.liquidate(market, 1, 0, 1, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 1, 0, 1, borrower, true, address(this), address(0), "");
 
         vm.expectRevert();
-        midnight.liquidate(market, 1, 1, 0, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 1, 1, 0, borrower, true, address(this), address(0), "");
 
         uint256 collatBefore = midnight.collateral(id, borrower, 0);
-        midnight.liquidate(market, 1, 0, 0, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 1, 0, 0, borrower, true, address(this), address(0), "");
         assertEq(midnight.debtOf(id, borrower), 0);
         assertEq(midnight.collateral(id, borrower, 0), collatBefore);
         assertEq(midnight.collateral(id, borrower, 1), 0);
@@ -104,7 +104,7 @@ contract LiquidationTest is BaseTest {
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
 
         vm.expectRevert(IMidnight.NotLiquidatable.selector);
-        midnight.liquidate(market, 0, 0, 0, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
     }
 
     function testLiquidateUnhealthyPreMaturity(uint256 units, uint256 liquidationOraclePrice) public {
@@ -114,7 +114,7 @@ contract LiquidationTest is BaseTest {
         setupMarket(market, units);
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
 
-        midnight.liquidate(market, 0, 0, 0, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
     }
 
     function testLiquidateHealthyPostMaturity(uint256 units, uint256 liquidationOraclePrice) public {
@@ -125,7 +125,7 @@ contract LiquidationTest is BaseTest {
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
         vm.warp(market.maturity + 1);
 
-        midnight.liquidate(market, 0, 0, 0, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, false, address(this), address(0), "");
     }
 
     function testLiquidateUnhealthyPostMaturity(uint256 units, uint256 liquidationOraclePrice) public {
@@ -136,7 +136,7 @@ contract LiquidationTest is BaseTest {
         vm.warp(market.maturity + 1);
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
 
-        midnight.liquidate(market, 0, 0, 0, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
     }
 
     function testLiquidateInconsistentInput(uint256 units) public {
@@ -145,23 +145,55 @@ contract LiquidationTest is BaseTest {
         setupMarket(market, units);
 
         vm.expectRevert(IMidnight.InconsistentInput.selector);
-        midnight.liquidate(market, 0, 1, 1, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 1, 1, borrower, true, address(this), address(0), "");
+    }
+
+    function testLiquidatePostMaturityPathBeforeMaturity(uint256 units, uint256 liquidationOraclePrice) public {
+        units = bound(units, 1, MAX_UNITS);
+        liquidationOraclePrice = bound(liquidationOraclePrice, 0, ORACLE_PRICE_SCALE - 1);
+        collateralize(market, borrower, units);
+        setupMarket(market, units);
+        Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
+
+        // Pre-maturity: the post-maturity path is not available.
+        vm.expectRevert(IMidnight.NotLiquidatable.selector);
+        midnight.liquidate(market, 0, 0, 0, borrower, false, address(this), address(0), "");
+
+        // At exact maturity: still not available (only valid strictly after maturity).
+        vm.warp(market.maturity);
+        vm.expectRevert(IMidnight.NotLiquidatable.selector);
+        midnight.liquidate(market, 0, 0, 0, borrower, false, address(this), address(0), "");
+
+        // One second after maturity: accepted.
+        vm.warp(market.maturity + 1);
+        midnight.liquidate(market, 0, 0, 0, borrower, false, address(this), address(0), "");
+    }
+
+    function testLiquidateUnhealthyPathRequiresUnhealthy(uint256 units, uint256 liquidationOraclePrice) public {
+        units = bound(units, 1, MAX_UNITS);
+        liquidationOraclePrice = bound(liquidationOraclePrice, ORACLE_PRICE_SCALE, 10 * ORACLE_PRICE_SCALE);
+        collateralize(market, borrower, units);
+        setupMarket(market, units);
+        Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
+        vm.warp(market.maturity + 1);
+
+        // Post-maturity but borrower is healthy: the unhealthy path is rejected.
+        vm.expectRevert(IMidnight.NotLiquidatable.selector);
+        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
     }
 
     function testLiquidateUnitsInput(uint256 units, uint256 repaid, uint256 liquidationOraclePrice) public {
         units = bound(units, 1, MAX_UNITS);
         repaid = bound(repaid, 0, units);
         liquidationOraclePrice = bound(liquidationOraclePrice, fullRepaymentPrice(units), ORACLE_PRICE_SCALE);
-        market.rcfThreshold = type(uint256).max; // Deactivate RCF.
-        id = toId(market);
         collateralize(market, borrower, units);
         setupMarket(market, units);
         uint256 initialCollateral = midnight.collateral(id, borrower, 0);
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
-        vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity to get full LIF.
+        vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity for full LIF.
 
         (uint256 seizedAssets, uint256 repaidUnits) =
-            midnight.liquidate(market, 0, 0, repaid, borrower, address(this), address(0), "");
+            midnight.liquidate(market, 0, 0, repaid, borrower, false, address(this), address(0), "");
 
         assertEq(repaidUnits, repaid, "repaid units");
         assertEq(
@@ -178,8 +210,6 @@ contract LiquidationTest is BaseTest {
     function testLiquidateCollateralInput(uint256 units, uint256 seized, uint256 liquidationOraclePrice) public {
         units = bound(units, 1, MAX_UNITS);
         liquidationOraclePrice = bound(liquidationOraclePrice, badDebtPriceDown(units) + 1, ORACLE_PRICE_SCALE);
-        market.rcfThreshold = type(uint256).max; // Deactivate RCF.
-        id = toId(market);
         collateralize(market, borrower, units);
         setupMarket(market, units);
         uint256 initialCollateral = midnight.collateral(id, borrower, 0);
@@ -193,10 +223,10 @@ contract LiquidationTest is BaseTest {
             )
         );
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
-        vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity to get full LIF.
+        vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity for full LIF.
 
         (uint256 seizedAssets, uint256 repaidUnits) =
-            midnight.liquidate(market, 0, seized, 0, borrower, address(this), address(0), "");
+            midnight.liquidate(market, 0, seized, 0, borrower, false, address(this), address(0), "");
 
         assertEq(
             repaidUnits,
@@ -220,12 +250,10 @@ contract LiquidationTest is BaseTest {
         units = bound(units, 1, MAX_UNITS);
         liquidationOraclePrice = bound(liquidationOraclePrice, 1, ORACLE_PRICE_SCALE);
         vm.assume(data.length > 0);
-        market.rcfThreshold = type(uint256).max; // Deactivate RCF.
-        id = toId(market);
         collateralize(market, borrower, units);
         setupMarket(market, units);
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
-        vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity to get full LIF.
+        vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity for full LIF.
 
         uint256 expectedBadDebt = _badDebt();
         uint256 maxRepaid = midnight.collateral(id, borrower, 0).mulDivDown(liquidationOraclePrice, ORACLE_PRICE_SCALE)
@@ -233,7 +261,7 @@ contract LiquidationTest is BaseTest {
         repaid = bound(repaid, 0, UtilsLib.min(units - expectedBadDebt, maxRepaid));
 
         vm.prank(caller);
-        midnight.liquidate(market, 0, 0, repaid, borrower, address(this), address(this), data);
+        midnight.liquidate(market, 0, 0, repaid, borrower, false, address(this), address(this), data);
 
         assertEq(recordedRepaidUnits, repaid, "repaid units");
         assertEq(recordedBadDebt, expectedBadDebt, "bad debt");
@@ -242,11 +270,9 @@ contract LiquidationTest is BaseTest {
 
     function testCannotRepayMoreThanDebt(uint256 units, uint256 repaid, uint256 liquidationOraclePrice) public {
         units = bound(units, 10, MAX_UNITS - 1);
-        market.rcfThreshold = type(uint256).max; // Deactivate RCF.
-        id = toId(market);
         collateralize(market, borrower, units);
         setupMarket(market, units);
-        vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity to get full LIF.
+        vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity for full LIF.
 
         uint256 _maxLif = market.collateralParams[0].maxLif;
         uint256 collateral = midnight.collateral(id, borrower, 0);
@@ -261,22 +287,20 @@ contract LiquidationTest is BaseTest {
         repaid = bound(repaid, units + 1, max(maxRepaid, units + 1));
 
         vm.expectRevert(stdError.arithmeticError);
-        midnight.liquidate(market, 0, 0, repaid, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, repaid, borrower, false, address(this), address(0), "");
     }
 
     function testCannotSeizeMoreThanCollateral(uint256 units, uint256 seized, uint256 liquidationOraclePrice) public {
         units = bound(units, 10, MAX_UNITS);
         liquidationOraclePrice = bound(liquidationOraclePrice, badDebtPriceDown(units) + 1, ORACLE_PRICE_SCALE);
-        market.rcfThreshold = type(uint256).max; // Deactivate RCF.
-        id = toId(market);
         collateralize(market, borrower, units);
         setupMarket(market, units);
-        vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity to get full LIF.
+        vm.warp(market.maturity + TIME_TO_MAX_LIF); // Warp to post-maturity for full LIF.
         seized = bound(seized, midnight.collateral(id, borrower, 0) + 1, MAX_TEST_AMOUNT);
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
 
         vm.expectRevert(stdError.arithmeticError);
-        midnight.liquidate(market, 0, seized, 0, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, seized, 0, borrower, false, address(this), address(0), "");
     }
 
     function testBadDebtPriceDownGivesBadDebt(uint256 units) public {
@@ -307,7 +331,7 @@ contract LiquidationTest is BaseTest {
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
         uint256 expectedBadDebt = _badDebt();
 
-        midnight.liquidate(market, 0, 0, 0, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
 
         assertEq(midnight.debtOf(id, borrower), units - expectedBadDebt, "debt");
         assertEq(midnight.totalUnits(id), units - expectedBadDebt, "total units");
@@ -343,7 +367,7 @@ contract LiquidationTest is BaseTest {
             address(this),
             address(this)
         );
-        midnight.liquidate(market, 0, 0, 0, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
     }
 
     function testSlashNonFull(uint256 units) public {
@@ -352,7 +376,7 @@ contract LiquidationTest is BaseTest {
         setupMarket(market, units);
         Oracle(market.collateralParams[0].oracle).setPrice(badDebtPriceDown(units));
 
-        midnight.liquidate(market, 0, 0, 0, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
 
         uint256 lossFactor = midnight.lossFactor(id);
         uint256 expectedCredit = units.mulDivDown(type(uint128).max - lossFactor, type(uint128).max);
@@ -374,7 +398,7 @@ contract LiquidationTest is BaseTest {
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
         uint256 debtAfterBadDebt = units - _badDebt();
 
-        (, uint256 repaid) = midnight.liquidate(market, 0, seized, 0, borrower, address(this), address(0), "");
+        (, uint256 repaid) = midnight.liquidate(market, 0, seized, 0, borrower, true, address(this), address(0), "");
 
         assertEq(midnight.debtOf(id, borrower), debtAfterBadDebt - repaid, "debt");
         assertEq(midnight.totalUnits(id), debtAfterBadDebt, "total units");
@@ -396,7 +420,7 @@ contract LiquidationTest is BaseTest {
             .mulDivDown(liquidationOraclePrice, ORACLE_PRICE_SCALE).mulDivDown(WAD, lif0);
         repaid = bound(repaid, 0, UtilsLib.min(UtilsLib.min(maxRepaid, debtAfterBadDebt), maxRepaidFromCollat));
 
-        midnight.liquidate(market, 0, 0, repaid, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, repaid, borrower, true, address(this), address(0), "");
 
         assertEq(midnight.debtOf(id, borrower), debtAfterBadDebt - repaid, "debt");
         assertEq(midnight.totalUnits(id), debtAfterBadDebt, "total units");
@@ -413,7 +437,9 @@ contract LiquidationTest is BaseTest {
         setupMarket(market, units);
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
 
-        midnight.liquidate(market, 0, midnight.collateral(id, borrower, 0), 0, borrower, address(this), address(0), "");
+        midnight.liquidate(
+            market, 0, midnight.collateral(id, borrower, 0), 0, borrower, true, address(this), address(0), ""
+        );
 
         assertApproxEqAbs(midnight.debtOf(id, borrower), 0, 1e3, "almost all remaining debt repaid");
         assertApproxEqAbs(
@@ -436,8 +462,6 @@ contract LiquidationTest is BaseTest {
         repaid = bound(repaid, 0, units);
         delay = bound(delay, 0, 100 weeks);
 
-        market.rcfThreshold = type(uint256).max; // Deactivate RCF.
-        id = toId(market);
         collateralize(market, borrower, units);
         setupMarket(market, units);
         liquidationOraclePrice = bound(liquidationOraclePrice, fullRepaymentPrice(units), ORACLE_PRICE_SCALE);
@@ -446,7 +470,7 @@ contract LiquidationTest is BaseTest {
 
         uint256 initialCollateral = midnight.collateral(id, borrower, 0);
 
-        midnight.liquidate(market, 0, 0, repaid, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, repaid, borrower, false, address(this), address(0), "");
 
         assertEq(midnight.debtOf(id, borrower), units - repaid, "debt");
         assertEq(
@@ -475,7 +499,7 @@ contract LiquidationTest is BaseTest {
 
         uint256 initialCollateral = midnight.collateral(id, borrower, 0);
 
-        midnight.liquidate(market, 0, 0, repaid, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, repaid, borrower, false, address(this), address(0), "");
 
         uint256 lif = WAD + (market.collateralParams[0].maxLif - WAD) * delay / TIME_TO_MAX_LIF;
 
@@ -499,10 +523,10 @@ contract LiquidationTest is BaseTest {
 
         repaid = bound(repaid, maxR + 1, max(units, maxR + 1));
         vm.expectRevert(IMidnight.RecoveryCloseFactorConditionsViolated.selector);
-        midnight.liquidate(market, 0, 0, repaid, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, repaid, borrower, true, address(this), address(0), "");
 
         repaid = bound(repaid, 0, min(maxR, units));
-        midnight.liquidate(market, 0, 0, repaid, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, repaid, borrower, true, address(this), address(0), "");
     }
 
     function testMaxRepaidMeansRecovery(uint256 units, uint256 liquidationOraclePrice) public {
@@ -513,7 +537,7 @@ contract LiquidationTest is BaseTest {
 
         uint256 maxR = _maxRepaid(units, units, liquidationOraclePrice);
 
-        midnight.liquidate(market, 0, 0, min(maxR, units), borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, min(maxR, units), borrower, true, address(this), address(0), "");
 
         uint256 remainingCollateral = midnight.collateral(id, borrower, 0);
         uint256 remainingDebt = midnight.debtOf(id, borrower);
@@ -544,7 +568,7 @@ contract LiquidationTest is BaseTest {
         Oracle(market.collateralParams[0].oracle).setPrice(liquidationOraclePrice);
 
         // Full liquidation should succeed because remaining debt < rcfThreshold.
-        midnight.liquidate(market, 0, 0, units, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, units, borrower, true, address(this), address(0), "");
         assertEq(midnight.debtOf(toId(market), borrower), 0, "debt should be zero");
     }
 
@@ -572,7 +596,7 @@ contract LiquidationTest is BaseTest {
 
         // Full liquidation should revert because remaining debt >= rcfThreshold.
         vm.expectRevert(IMidnight.RecoveryCloseFactorConditionsViolated.selector);
-        midnight.liquidate(market, 0, 0, units, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, units, borrower, true, address(this), address(0), "");
     }
 
     /// @dev Recovery close factor still applies after maturity when the borrower is unhealthy.
@@ -593,12 +617,12 @@ contract LiquidationTest is BaseTest {
         // At exact maturity: recovery close factor applies.
         vm.warp(market.maturity);
         vm.expectRevert(IMidnight.RecoveryCloseFactorConditionsViolated.selector);
-        midnight.liquidate(market, 0, 0, units, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, units, borrower, true, address(this), address(0), "");
 
         // After maturity, while still unhealthy: recovery close factor still applies.
         vm.warp(market.maturity + 1 + delay);
         vm.expectRevert(IMidnight.RecoveryCloseFactorConditionsViolated.selector);
-        midnight.liquidate(market, 0, 0, units, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, units, borrower, true, address(this), address(0), "");
     }
 
     /// @dev With RCF deactivated, liquidation can always end by fully repaying debt or fully seizing collateral.
@@ -651,9 +675,9 @@ contract LiquidationTest is BaseTest {
 
         uint256 collateralNeededToRepayAll = units.mulDivDown(market.collateralParams[0].maxLif, WAD);
         if (collateralNeededToRepayAll <= collateral1) {
-            midnight.liquidate(market, 0, 0, units, borrower, address(this), address(0), "");
+            midnight.liquidate(market, 0, 0, units, borrower, true, address(this), address(0), "");
         } else {
-            midnight.liquidate(market, 0, collateral1, 0, borrower, address(this), address(0), "");
+            midnight.liquidate(market, 0, collateral1, 0, borrower, true, address(this), address(0), "");
         }
 
         uint256 debtAfter = midnight.debtOf(id, borrower);
@@ -700,7 +724,7 @@ contract LiquidationTest is BaseTest {
         uint256 maxR = (units - _maxDebt)
         .mulDivUp(WAD, WAD - market.collateralParams[liqIdx].maxLif.mulDivUp(market.collateralParams[liqIdx].lltv, WAD));
 
-        midnight.liquidate(market, liqIdx, 0, maxR, borrower, address(this), address(0), "");
+        midnight.liquidate(market, liqIdx, 0, maxR, borrower, true, address(this), address(0), "");
     }
 
     // gas tests
@@ -709,9 +733,6 @@ contract LiquidationTest is BaseTest {
     function testGasLiquidateMultipleCollaterals() public {
         uint256 units = 1000e18;
         uint256 collateralAmount = units.mulDivUp(WAD, market.collateralParams[0].lltv);
-
-        market.rcfThreshold = type(uint256).max; // Deactivate RCF.
-        id = toId(market);
 
         vm.prank(borrower);
 
@@ -737,7 +758,8 @@ contract LiquidationTest is BaseTest {
 
         // Multicall with 1 liquidation.
         bytes[] memory calls1 = new bytes[](1);
-        calls1[0] = abi.encodeCall(midnight.liquidate, (market, 0, 0, repay, borrower, address(this), address(0), ""));
+        calls1[0] =
+            abi.encodeCall(midnight.liquidate, (market, 0, 0, repay, borrower, false, address(this), address(0), ""));
         uint256 gasBefore1 = gasleft();
         midnight.multicall(calls1);
         uint256 gas1 = gasBefore1 - gasleft();
@@ -745,8 +767,10 @@ contract LiquidationTest is BaseTest {
 
         // Multicall with 2 liquidations.
         bytes[] memory calls2 = new bytes[](2);
-        calls2[0] = abi.encodeCall(midnight.liquidate, (market, 0, 0, repay, borrower, address(this), address(0), ""));
-        calls2[1] = abi.encodeCall(midnight.liquidate, (market, 1, 0, repay, borrower, address(this), address(0), ""));
+        calls2[0] =
+            abi.encodeCall(midnight.liquidate, (market, 0, 0, repay, borrower, false, address(this), address(0), ""));
+        calls2[1] =
+            abi.encodeCall(midnight.liquidate, (market, 1, 0, repay, borrower, false, address(this), address(0), ""));
         uint256 gasBefore2 = gasleft();
         midnight.multicall(calls2);
         uint256 gas2 = gasBefore2 - gasleft();
@@ -775,7 +799,7 @@ contract LiquidationTest is BaseTest {
         setupMarket(market, units);
 
         Oracle(market.collateralParams[0].oracle).setPrice(badDebtPriceDown(units));
-        midnight.liquidate(market, 0, 0, 0, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
 
         assertEq(midnight.creditOf(id, borrower), 0, "no credit before");
         uint256 debtBefore = midnight.debtOf(id, borrower);
@@ -795,7 +819,7 @@ contract LiquidationTest is BaseTest {
         setupMarket(market, units);
 
         Oracle(market.collateralParams[0].oracle).setPrice(badDebtPriceDown(units));
-        midnight.liquidate(market, 0, 0, 0, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
 
         uint256 creditBeforeSlash = midnight.creditOf(id, lender);
         midnight.updatePosition(market, lender);
@@ -817,7 +841,7 @@ contract LiquidationTest is BaseTest {
         setupMarket(market, units);
 
         Oracle(market.collateralParams[0].oracle).setPrice(0);
-        midnight.liquidate(market, 0, 0, 0, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
 
         assertEq(midnight.debtOf(id, borrower), 0, "debt");
         assertEq(midnight.totalUnits(id), 0, "total units");
@@ -916,14 +940,14 @@ contract LiquidationTest is BaseTest {
 
         uint256 debtBefore = midnight.debtOf(id, borrower);
         // Non-zero seizedAssets exercises the recovery close factor path.
-        midnight.liquidate(market, 0, 1, 0, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 1, 0, borrower, true, address(this), address(0), "");
         assertLt(midnight.debtOf(id, borrower), debtBefore, "debt should decrease after liquidation");
     }
 
     function testLiquidateNoDebtReverts() public {
         midnight.touchMarket(market);
         vm.expectRevert(IMidnight.NotLiquidatable.selector);
-        midnight.liquidate(market, 0, 0, 0, borrower, address(this), address(0), "");
+        midnight.liquidate(market, 0, 0, 0, borrower, true, address(this), address(0), "");
     }
 
     function onLiquidate(

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -573,7 +573,7 @@ contract OtherFunctionsTest is BaseTest {
         vm.warp(_market.maturity + TIME_TO_MAX_LIF);
 
         deal(address(loanToken), address(this), 1e18);
-        midnight.liquidate(_market, collateralIndex, 1e18, 0, borrower, false, address(this), address(0), "");
+        midnight.liquidate(_market, collateralIndex, 1e18, 0, borrower, true, address(this), address(0), "");
 
         uint128 collateralBitmap = midnight.collateralBitmap(_id, borrower);
         assertEq(UtilsLib.countBits(collateralBitmap), numCollaterals - 1, "one bit cleared");

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -569,11 +569,11 @@ contract OtherFunctionsTest is BaseTest {
 
         setupMarket(_market, 1e18);
 
-        // Warp to maturity + TIME_TO_MAX_LIF to bypass recovery close factor.
+        // Warp to maturity + TIME_TO_MAX_LIF and use the post-maturity path.
         vm.warp(_market.maturity + TIME_TO_MAX_LIF);
 
         deal(address(loanToken), address(this), 1e18);
-        midnight.liquidate(_market, collateralIndex, 1e18, 0, borrower, address(this), address(0), "");
+        midnight.liquidate(_market, collateralIndex, 1e18, 0, borrower, false, address(this), address(0), "");
 
         uint128 collateralBitmap = midnight.collateralBitmap(_id, borrower);
         assertEq(UtilsLib.countBits(collateralBitmap), numCollaterals - 1, "one bit cleared");

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -1612,7 +1612,7 @@ contract ReentrantLiquidateBorrowCallback is ISellCallback {
         oracle.setPrice(healthyPrice / 2);
         ERC20(market.loanToken).approve(msg.sender, repaidUnits);
         try Midnight(msg.sender)
-            .liquidate(market, collateralIndex, 0, repaidUnits, seller, true, address(this), address(0), "") returns (
+            .liquidate(market, collateralIndex, 0, repaidUnits, seller, false, address(this), address(0), "") returns (
             uint256, uint256
         ) {
             liquidateSucceeded = true;
@@ -1673,7 +1673,7 @@ contract NestedTakeReentrantLiquidateCallback is ISellCallback {
             oracle.setPrice(healthyPrice / 2);
             ERC20(market.loanToken).approve(msg.sender, storedRepaidUnits);
             try Midnight(msg.sender)
-                .liquidate(market, idx, 0, storedRepaidUnits, seller, true, address(this), address(0), "") returns (
+                .liquidate(market, idx, 0, storedRepaidUnits, seller, false, address(this), address(0), "") returns (
                 uint256, uint256
             ) {
                 liquidateSucceeded = true;

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -1612,7 +1612,7 @@ contract ReentrantLiquidateBorrowCallback is ISellCallback {
         oracle.setPrice(healthyPrice / 2);
         ERC20(market.loanToken).approve(msg.sender, repaidUnits);
         try Midnight(msg.sender)
-            .liquidate(market, collateralIndex, 0, repaidUnits, seller, address(this), address(0), "") returns (
+            .liquidate(market, collateralIndex, 0, repaidUnits, seller, true, address(this), address(0), "") returns (
             uint256, uint256
         ) {
             liquidateSucceeded = true;
@@ -1673,7 +1673,7 @@ contract NestedTakeReentrantLiquidateCallback is ISellCallback {
             oracle.setPrice(healthyPrice / 2);
             ERC20(market.loanToken).approve(msg.sender, storedRepaidUnits);
             try Midnight(msg.sender)
-                .liquidate(market, idx, 0, storedRepaidUnits, seller, address(this), address(0), "") returns (
+                .liquidate(market, idx, 0, storedRepaidUnits, seller, true, address(this), address(0), "") returns (
                 uint256, uint256
             ) {
                 liquidateSucceeded = true;


### PR DESCRIPTION
- do not deactivate the RCF at the end, as it is bad for borrowers (for no real reason), and it create a weird incentive for liquidators to leave position slightly unhealthy to try to liquidate them at maxLIF just at maturity.
- add a unhealthyPath boolean for liquidators to be able to choose if they want to liquidate in unhealthyMode (maxLIF but RCF) or not (ramped LIF but no cap). Prevents some issues were an account is just slightly unhealthy and it makes liquidating it hard.

full context: https://morpholabs.slack.com/archives/C02N7CZ088N/p1779266663065369