### PR TITLE
correct offset and unit test

### DIFF
--- a/src/libraries/TickLib.sol
+++ b/src/libraries/TickLib.sol
@@ -26,7 +26,7 @@ library TickLib {
                 return 1e36 / wExp(-x);
             } else {
                 int256 ln2 = 0.693147180559945309e18; // floor(ln(2) * 1e18)
-                // offset is chosen such that expR(-offset) == expR(ln2 - offset - 1), so wExp is non-decreasing.
+                // offset is chosen such that 2 * expR(-offset) == expR(ln2 - offset - 1), so wExp is non-decreasing.
                 int256 offset = 0.32261121498945987e18;
                 int256 q = (x + offset) / ln2;
                 int256 r = x - q * ln2;

--- a/test/TickLibTest.sol
+++ b/test/TickLibTest.sol
@@ -19,6 +19,18 @@ contract TickLibTest is BaseTest {
         assertEq(TickLib.tickToPrice(MAX_TICK), 1e18, "tick max");
     }
 
+    function expR(int256 r) internal pure returns (int256) {
+        int256 secondTerm = r * r / (2 * 1e18);
+        int256 thirdTerm = secondTerm * r / (3 * 1e18);
+        return 1e18 + r + secondTerm + thirdTerm;
+    }
+
+    function testWExpOffsetProperty() public pure {
+        int256 ln2 = 0.693147180559945309e18;
+        int256 offset = 0.32261121498945987e18;
+        assertEq(2 * expR(-offset), expR(ln2 - offset - 1));
+    }
+
     function testTickMonotonicity() public pure {
         for (uint256 i = 0; i < MAX_TICK; i++) {
             assertGe(TickLib.tickToPrice(i + 1), TickLib.tickToPrice(i));


### PR DESCRIPTION
Credit @jhoenicke for this.

See #882 for why this is the correct bound:
<img width="590" height="74" alt="Screenshot 2026-05-26 at 11 55 43" src="https://github.com/user-attachments/assets/9ec90dfc-bb00-4712-a17f-80d340e32b9a" />
