### PR TITLE
More precise `maxRepaid` computation

### DIFF
--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -657,8 +657,9 @@ contract Midnight is IMidnight {
                 uint256 lltv = market.collateralParams[collateralIndex].lltv;
                 // Note that debt >= maxDebt in this branch.
                 // The imprecision in this computation is at most a few hundreds WEI of collateral or loan token.
-                uint256 maxRepaid =
-                    lltv < WAD ? (_position.debt - maxDebt).mulDivUp(WAD * WAD, WAD - lif * lltv) : type(uint256).max;
+                uint256 maxRepaid = lltv < WAD
+                    ? (_position.debt - maxDebt).mulDivUp(WAD * WAD, WAD * WAD - lif * lltv)
+                    : type(uint256).max;
                 require(
                     repaidUnits <= maxRepaid
                         || _position.collateral[collateralIndex].mulDivDown(liquidatedCollatPrice, ORACLE_PRICE_SCALE)

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -656,7 +656,7 @@ contract Midnight is IMidnight {
             if (!healthyPath) {
                 uint256 lltv = market.collateralParams[collateralIndex].lltv;
                 // Note that debt >= maxDebt in this branch.
-                // The imprecision in this computation is at most a few hundreds WEI of collateral or loan token.
+                // The imprecision in this computation is at most a few hundreds collateral or loan token assets.
                 uint256 maxRepaid = lltv < WAD
                     ? (_position.debt - maxDebt).mulDivUp(WAD * WAD, WAD * WAD - lif * lltv)
                     : type(uint256).max;

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -656,9 +656,9 @@ contract Midnight is IMidnight {
             if (!healthyPath) {
                 uint256 lltv = market.collateralParams[collateralIndex].lltv;
                 // Note that debt >= maxDebt in this branch.
-                uint256 maxRepaid = lltv < WAD
-                    ? (_position.debt - maxDebt).mulDivUp(WAD, WAD - lif.mulDivUp(lltv, WAD))
-                    : type(uint256).max;
+                // The imprecision in this computation is at most a few hundreds WEI of collateral or loan token.
+                uint256 maxRepaid =
+                    lltv < WAD ? (_position.debt - maxDebt).mulDivUp(WAD * WAD, WAD - lif * lltv) : type(uint256).max;
                 require(
                     repaidUnits <= maxRepaid
                         || _position.collateral[collateralIndex].mulDivDown(liquidatedCollatPrice, ORACLE_PRICE_SCALE)

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -754,7 +754,7 @@ contract LiquidationTest is BaseTest {
         + otherCollat.mulDivDown(market.collateralParams[otherIdx].lltv, WAD);
 
         uint256 maxR = (units - _maxDebt)
-        .mulDivUp(WAD, WAD - market.collateralParams[liqIdx].maxLif.mulDivUp(market.collateralParams[liqIdx].lltv, WAD));
+        .mulDivUp(WAD * WAD, WAD * WAD - market.collateralParams[liqIdx].maxLif * market.collateralParams[liqIdx].lltv);
 
         midnight.liquidate(market, liqIdx, 0, maxR, borrower, false, address(this), address(0), "");
     }
@@ -932,7 +932,7 @@ contract LiquidationTest is BaseTest {
         uint256 lltv = market.collateralParams[0].lltv;
         uint256 collatAmount = units.mulDivUp(WAD, lltv);
         uint256 _maxDebt = collatAmount.mulDivDown(oraclePrice, ORACLE_PRICE_SCALE).mulDivDown(lltv, WAD);
-        return (debt - _maxDebt).mulDivUp(WAD, WAD - market.collateralParams[0].maxLif.mulDivUp(lltv, WAD));
+        return (debt - _maxDebt).mulDivUp(WAD * WAD, WAD * WAD - market.collateralParams[0].maxLif * lltv);
     }
 
     function _setupUnhealthy(uint256 units, uint256 liquidationOraclePrice)

--- a/test/UtilsLibTest.sol
+++ b/test/UtilsLibTest.sol
@@ -4,6 +4,20 @@ pragma solidity ^0.8.0;
 import {Test, stdError} from "../lib/forge-std/src/Test.sol";
 import {UtilsLib} from "../src/libraries/UtilsLib.sol";
 import {LN_ONE_PLUS_DELTA, MAX_TICK, TickLib} from "../src/libraries/TickLib.sol";
+import {
+    WAD,
+    LIQUIDATION_CURSOR_LOW,
+    LIQUIDATION_CURSOR_HIGH,
+    LLTV_0,
+    LLTV_1,
+    LLTV_2,
+    LLTV_3,
+    LLTV_4,
+    LLTV_5,
+    LLTV_6,
+    LLTV_7,
+    maxLif
+} from "../src/libraries/ConstantsLib.sol";
 
 contract UtilsLibTest is Test {
     int256 internal constant WEXP_LN2 = 0.693147180559945309e18;
@@ -183,5 +197,22 @@ contract UtilsLibTest is Test {
         assertApproxEqRel(TickLib.wExp(18 ether), 65659969.137330511139838976 ether, 0.001 ether, "exp(18)");
         assertApproxEqRel(TickLib.wExp(19 ether), 178482300.96318726092869632 ether, 0.001 ether, "exp(19)");
         assertApproxEqRel(TickLib.wExp(20 ether), 485165195.409790277969936384 ether, 0.001 ether, "exp(20)");
+    }
+
+    // This test makes sure that the computation of maxRepaid (for RCF) is not too imprecise.
+    function testRcfBound() public pure {
+        uint256[8] memory lltvs = [LLTV_0, LLTV_1, LLTV_2, LLTV_3, LLTV_4, LLTV_5, LLTV_6, LLTV_7];
+        uint256[2] memory cursors = [LIQUIDATION_CURSOR_LOW, LIQUIDATION_CURSOR_HIGH];
+        for (uint256 i = 0; i < lltvs.length; i++) {
+            uint256 lltv = lltvs[i];
+            for (uint256 j = 0; j < cursors.length; j++) {
+                uint256 lif = maxLif(lltv, cursors[j]);
+                assertLt(lif * lltv, WAD * WAD);
+                assertLt(WAD * WAD / (WAD * WAD - lif * lltv), 100);
+            }
+        }
+        // Also ensure that the bound is close to the max bound.
+        uint256 lifHigh7 = maxLif(LLTV_7, LIQUIDATION_CURSOR_HIGH);
+        assertGt(WAD * WAD / (WAD * WAD - lifHigh7 * LLTV_7), 90);
     }
 }


### PR DESCRIPTION
Resources:
- [Cantina finding](https://cantina.xyz/code/6b7e5600-4961-4cad-a9bd-4f952789d07f/findings/11)
- [Corresponding thread](https://morpholabs.slack.com/archives/C08A40KKN9W/p1779347911234319)

Goals (borrowed from [this message](https://morpholabs.slack.com/archives/C08A40KKN9W/p1779873776746999?thread_ts=1779347911.234319&cid=C08A40KKN9W)):
> maxRepaid has to satisfy two properties:
> - Don't restore borrower too much into health: the position after liquidation should be only slightly healthy and not too far from health boundary.
> - Avoid consecutive maxLiquidations: its deliberately rounded up so that there is no immediate consecutive liquidation.

Call R the perfect computation of the bound of the code. `R = (debt - maxDebt) / (1 - lif * lltv)`

From the goals above, we want the max repaid to be as close to the bound of the finding:
<img width="1055" height="120" alt="Screenshot 2026-05-28 at 18 28 12" src="https://github.com/user-attachments/assets/1aac85c5-2116-4282-a7b5-d8e590d180d5" />
This bound is different from `R` by the rounding term `X`.

This means that option 2 (adding 200) and option 3 (adding `(WAD + lltv).mulDivUp(WAD, WAD * WAD - lif * lltv)`) are not really helping: they help with one property wanted, at the expense of the other.

The current code (before this PR), has the additional error term `Y` compared to `R`, defined as:
<img width="730" height="106" alt="Screenshot 2026-05-28 at 18 31 11" src="https://github.com/user-attachments/assets/38b57ce5-d601-4f88-917f-7dbf6ea45d7a" />
This can be mitigated with option 1 (what this PR does), where `Y` becomes 1 at most.

We still would be off from the bound of the finding by `X`. In absolute value, `X` is less than `A / (1 - lif * lltv) + B * price / (1 - lif * lltv)` with `A` and `B` small integers constants (could be negative). Note that I didn't add a term of the form `C * lltv / (1 - lif * lltv)`  nor of the form `D * lif * lltv / (1 - lif * lltv)` because you can bound `lltv` and `lif * lltv` by 1.
Then we conclude by the following interpretation: we are at most hundreds of WEI of debt (the term `A / (1 - lif * lltv)`) and of collateral (the term `B * price / (1 - lif * lltv)`) off from being exactly at the healthy threshold. See the corresponding added test

Finally: this change cannot overflow, because we multiply `debt - maxDebt <= debt` with `1e36`, and both are below `type(uint128).max`. It cannot do a division by 0 either (there is a spec verifying that)