### PR TITLE
move consumed update down and remove += result assignment

### DIFF
--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -368,6 +368,15 @@ contract Midnight is IMidnight {
         uint256 buyerAssets = offer.buy ? units.mulDivDown(buyerPrice, WAD) : units.mulDivUp(buyerPrice, WAD);
         uint256 sellerAssets = offer.buy ? units.mulDivDown(sellerPrice, WAD) : units.mulDivUp(sellerPrice, WAD);
 
+        uint256 newConsumed;
+        if (offer.maxAssets > 0) {
+            newConsumed = consumed[offer.maker][offer.group] + (offer.buy ? buyerAssets : sellerAssets);
+            require(newConsumed <= offer.maxAssets, ConsumedAssets());
+        } else {
+            newConsumed = consumed[offer.maker][offer.group] + units;
+            require(newConsumed <= offer.maxUnits, ConsumedUnits());
+        }
+
         (address buyer, address seller) = offer.buy ? (offer.maker, taker) : (taker, offer.maker);
         Position storage buyerPos = position[id][buyer];
         Position storage sellerPos = position[id][seller];
@@ -412,14 +421,6 @@ contract Midnight is IMidnight {
             UtilsLib.toUint128(_marketState.totalUnits + buyerCreditIncrease - sellerCreditDecrease);
         claimableSettlementFee[offer.market.loanToken] += buyerAssets - sellerAssets;
 
-        uint256 newConsumed;
-        if (offer.maxAssets > 0) {
-            newConsumed = consumed[offer.maker][offer.group] + offer.buy ? buyerAssets : sellerAssets;
-            require(newConsumed <= offer.maxAssets, ConsumedAssets());
-        } else {
-            newConsumed = consumed[offer.maker][offer.group] + units;
-            require(newConsumed <= offer.maxUnits, ConsumedUnits());
-        }
         consumed[offer.maker][offer.group] = newConsumed;
 
         address buyerCallback = offer.buy ? offer.callback : takerCallback;

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -368,15 +368,6 @@ contract Midnight is IMidnight {
         uint256 buyerAssets = offer.buy ? units.mulDivDown(buyerPrice, WAD) : units.mulDivUp(buyerPrice, WAD);
         uint256 sellerAssets = offer.buy ? units.mulDivDown(sellerPrice, WAD) : units.mulDivUp(sellerPrice, WAD);
 
-        uint256 newConsumed;
-        if (offer.maxAssets > 0) {
-            newConsumed = consumed[offer.maker][offer.group] += offer.buy ? buyerAssets : sellerAssets;
-            require(newConsumed <= offer.maxAssets, ConsumedAssets());
-        } else {
-            newConsumed = consumed[offer.maker][offer.group] += units;
-            require(newConsumed <= offer.maxUnits, ConsumedUnits());
-        }
-
         (address buyer, address seller) = offer.buy ? (offer.maker, taker) : (taker, offer.maker);
         Position storage buyerPos = position[id][buyer];
         Position storage sellerPos = position[id][seller];
@@ -421,6 +412,15 @@ contract Midnight is IMidnight {
         _marketState.totalUnits =
             UtilsLib.toUint128(_marketState.totalUnits + buyerCreditIncrease - sellerCreditDecrease);
         claimableSettlementFee[offer.market.loanToken] += buyerAssets - sellerAssets;
+
+        uint256 newConsumed;
+        if (offer.maxAssets > 0) {
+            newConsumed = consumed[offer.maker][offer.group] += offer.buy ? buyerAssets : sellerAssets;
+            require(newConsumed <= offer.maxAssets, ConsumedAssets());
+        } else {
+            newConsumed = consumed[offer.maker][offer.group] += units;
+            require(newConsumed <= offer.maxUnits, ConsumedUnits());
+        }
 
         address buyerCallback = offer.buy ? offer.callback : takerCallback;
         address sellerCallback = offer.buy ? takerCallback : offer.callback;

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -389,7 +389,6 @@ contract Midnight is IMidnight {
             !offer.reduceOnly || (offer.buy ? buyerCreditIncrease == 0 : sellerDebtIncrease == 0),
             MakerCreditOrDebtIncreased()
         );
-
         require(
             offer.market.enterGate == address(0) || buyerCreditIncrease == 0
                 || IEnterGate(offer.market.enterGate).canIncreaseCredit(buyer),

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -415,12 +415,13 @@ contract Midnight is IMidnight {
 
         uint256 newConsumed;
         if (offer.maxAssets > 0) {
-            newConsumed = consumed[offer.maker][offer.group] += offer.buy ? buyerAssets : sellerAssets;
+            newConsumed = consumed[offer.maker][offer.group] + offer.buy ? buyerAssets : sellerAssets;
             require(newConsumed <= offer.maxAssets, ConsumedAssets());
         } else {
-            newConsumed = consumed[offer.maker][offer.group] += units;
+            newConsumed = consumed[offer.maker][offer.group] + units;
             require(newConsumed <= offer.maxUnits, ConsumedUnits());
         }
+        consumed[offer.maker][offer.group] = newConsumed;
 
         address buyerCallback = offer.buy ? offer.callback : takerCallback;
         address sellerCallback = offer.buy ? takerCallback : offer.callback;


### PR DESCRIPTION
motivation: entry gate calls done before state updates (touchMarket and updatePosition excluded)