### PR TITLE
Add Kairos Lab Security Research audit draft (Midnight)

### DIFF
--- a/audits/2026-06-05-kairoslab-DRAFT.pdf
+++ b/audits/2026-06-05-kairoslab-DRAFT.pdf
@@ -1,0 +1,112 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 12 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (Kairos Lab Security Research) /CreationDate (D:20260605124705-04'00') /Creator (Kairos Lab Security Research) /Keywords (Kairos Lab, Morpho, Midnight, security review, smart contract audit) /ModDate (D:20260605124705-04'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (Smart Contract Security Review) /Title (Morpho - Midnight - Security Review Summary) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 3 /Kids [ 4 0 R 5 0 R 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3279
+>>
+stream
+Gatm>8TPi['#)\qkbF?!@%adf'O%5BPpO&"@f.^ZI%a%TBjPe!;3[X4f=q@kgC+li2KNgA+#1If6_i$R"r&I>s)5RNGVb'*D](6^kq+ST"ACIW4KSl(S8f!k8ms.MU"Tdt@!u*.rQEV]Jm'WXJe;LoJTV((^K*`08Z`";%HS@V-tX2Om_u,_H<h@E]pT(G(n^msK='kE?<s\a?gh'8!a"d6ZG!m-quY@I_=UfIi(rR!9G?L4p/2ipYGli-'NM,eEVCOdVMmhN"?SK)o84C[?7h_qg'08>O@j_*8_>#c/&J5A#([n3+W1hDPu6=.6%Vj*`<@WHCBH$mbF!GW>@E(--WH`Bc#krQXU]Cr;HKfZ+@f_]P&)6i+\?$HAP=NsN6mY3.3Srm&lMfQWe=r%U82Z+lH09"0W#QrlkYe#Pet#AYV*FW>7U23"YRa*kAm_^ck;Quc^h)(G\ZMebR_p_RM\ZIZfK-:4`^oRQY:s6/i^eZO@d2%.o&*%X:3+C`%5=4"`R(j'i]dJN#:)L`e`+Z>!Y-7XIR7cP,4rU8]tIK8>OWAZ6X=EV*05=WN0i8`!X\?Ui$.sb%2G+GCA+?kT<,b"=HMOMn[8o`Xi_JM:Pj]d\?=j;'c9d`OR*b,;1E!,&A\U!`>;2.mc#dOMiOUIO85&TWYRdBi8srar1'+Ku*t=.#?!F(PTf>*!OU2+:9$$57.]FU/4PK4NqgY+GNb?N")MSWTcnr!C[^nUh"P21\<1cU"^8qZ\8AQ2bD`,`?rua%5s%YI'?0T;J_M*<hOr*P`[.;B1r^lM<8WY8J4p;P(XS,"A.AIFYWDV3!UWI75tkEO)c<T<1IW#VPQ_<Kloi'#c#%7qOGhd5u7n4X=5MO@^%4.,AG[8/1bWN'GiuLb7r&VV-2L>-tpf9/g/;7Aeh,Wlj?:G2)5rVHW$Fj6I+7EDaZgI8\rq.-m<jl(Kf>[8PmV;`<hY^8%'kkb.^80>MaK'fmgC(+pn>siNA.!P]4%2@P^DM+[Htk.TTI9b6#hAS,om."[aD5\qa1;YL?>7ONo-a55@""la6D]Moj"T\/`12eNDds"7*!R9$@c.BS^-?J@$Zh\V;i/_OiN5$^ee<!&/sY3-59:3/)Q0o29fdbqAsR\Rgp.A?;W@rl&]eJ^`.iZ_#\d\8LTPFh@GS-I'$.q>RZtR!IjTfhi/6Y)&3tK4O[@kmbDFD>SNuF0_BSRbu!R@^bebr<E9[ld\S?HMk?X_Rs%.[*-)0_K^uH8nb5T:b*CS(@F9+;h84/.D)Z0'TY=SE'(ktPn8OD758:=KR>86-:2ED+?EMr))F1oMO7&b$k]de)ffc'+X2&;CW,?MPDgWJ,%GF^3nps6Y1T&Bo)agkAa.V.m<I13IJ)`1d1f-oV!#k&/]*SlPoPJ>`K^a)-Pt6ie'THA^kqrD_Rk`tQYd2o1CTIXB7^/8`MOLPh:.LTp0.XNO,LtnrQd9?J@eMe))#cW`BkH0Uj;/sD5rgumag\VHP-TO-C(bYT"G>0>QF&nHAdZ%ben_F\Kot,R"THs!"BR?H$IX/.;j[ViB.N#6)kVE5s4!CS>J,^,ubr1.o(pVjTI,Fq<)#&(H0LL;6V[oaJKcF#&]-k*%'@VW@9GT=4n(Uq3l5]9.S!8Q3g1oVGC9_fmNO!A?8#ij4@nRB;u>W3H`b$R[\K/BijC8#C*IpJ`2Feh81EE3-lSp;ME<>>bu0dN0UF^)$i^=dbMga&F.^Tc-LOONOu)=Rk^8\oD;s\bO]Vq#t'qR]Zn#tge/1(F]E+9^N\7_p\VCCV8X,&rnr>Y47-`2:=nm1XbVhIMf;%TPZ$_'cHJZKJn*>;aTo.gO):_LYNs`Jp85AL-1/7rFjUu)cP0fB9T_.f,sIYhM-.fPpjO'Z5#[+S1<&p-U@e4c1*unU=Vor`gO:->\;OGtj1G$QroG[[,oi6tHR1nK-)HEg/EojX+c<YjKQPUb7;'^VQd>P&iL$#GT1c%LXQ)Wp^DfW+OX[5a9L5)7&t_goUu+7L_u"l:O2DY_ded$cdloBjcBV934"=>*8q&s*8eJ\FEi>8U"l.d4P(hkV/50T[`93:7&aSWlh[^sc-O[=LZ;@+6&t_h&Uu/k.nbp2h`uti@3L6#4mk8<G.6nu?.=3@*T.-Um>tipi@pfXIlnQJeZhd?]WtJ@ZF2=)oGqPoe_[(T_EUC(r;pa18Pk837-3)h)(Z+W8IMAY=9duAEbM1QniN's?W)n;>Qoud1%Z#QlCO.aB`gU;2+l*lsmV52#4,5:@(`Jdlrj$_LB]7q?bG*g/RN"3e#2e1[rQTZ^I0lNQ[ED9ckAC^#IsKVe\F8a\^F=?`j+I]q2n@sUi-E1Ur0C7f@>WQ9B1ti^:ml2:=-A,rY-qdZ\E/C=''Vm"59Kp(M-I"BQ-b+:A$!H?.D[SAUPVD$D^Utk$,T:YWH=U_h$57f6l>4s8L.7qWk3GEdJaV*,mo`u'#WN;:C0XMafkY*pd)['1sIOZd7r)`h9NTd#IfQmC>hJeJdXoIEI]?9CR6-AE#hpGn%+rd(DWQeUd(oed/pfcO)S)P]'cFk6C&8#h4hJ6U?EL^bVpndZ1(uiLuI"D<`iBhCVkh,QnTtFUfr=G8;uZYhsYYo>=@aKTQ[L%@M\!WpE_+2l>oNQ@a#J7bX.U`"gNK(&ZMgI<LT1(:Qi0aHWJQ`hhJ]GA@pP^JkL\f4/#)cN94]^aN:p'`Oh14bS=*r(%&I&IEdORA+Sk%7]of/)6R'Xhh96)W<A@OF$[[kh\Rt\HugV:nMXNO$,bCkSsPi2\j&bGMGO[+','<Z8SOFD8I9Dd3stW+q2YhU2T`FlU;]u!nu7Scdg7;(6[&clh6D2=&.;O/Ni(k.O-@=bd$$S:Qob&Jde"pd_eMAVVc)`*_rk+3;\&gjIFCEFI_mmO"4p"lSm>%1BCPWSEdW9ds1FZG5u[iV?TkLVf15FcRt2rNnY_<8J&[[^3T1^;:;!4,ldZ)BcG#NM;BD:[\h4p+5=mtLMR%R+iI#`2^)DKg*g(cmI8`fi6W'CNH%O7?8:KL:8#0A8U!o'(<u4AJ`euL`d?9u&E9#SOYEk[?@0>u<UU-`$Y341)FS+O.1c[WElZt13]GdE'i0.B:e(Jcj/n\"a(13P*4)?E3GoRl_V#*^23Rln;I=6Jg\fWsYh:Dbo[Jo]12K'ZqpWX+Ai/^Y+jm:0qDD/jFpP3f>3dEX<1r"CK'<4TqmQ4XMcT(ANZ*$%n%\6<`Dl7OUokJd,hDEDM4.F.JEmr=mVL>E+X,"`<;lGE8s$VXD8c~>endstream
+endobj
+11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2300
+>>
+stream
+Gb!#]?#SIW(4Gq\\A2PY8N16LM3OsQ[7NG9fX<Tj)"Zf)7\Xa;-.,B-DUVt-+@V0PdHM>^4X<8o+!S;jgr"KW%qA-Q!Gqd:/\pZ]gqLaX;qUF:'1?7"%c2#&-m9JR$:"nDAWd*e$:ZcZHGAb3_mH3f/SGWQ@)Q0h5RZ5X=J7LdAW?eVBh<7NW2/R.H-k\G!E5JG\P01cNXgf.5uHcSZqUp0&!]0_p^,f8iLjr9W;Y1&D#Og3(RAO!Ai)(?'h(_d$&E"pj:jfW]Y]KAk>c-sZ>pB+!bP#S%6XQ&KSV.e>VhUnRr+/fgQ1?mH9!AoPB?Ye.'nIY_RWbC]0aJ.#Rs?`>joZ$&mD,m#IRTYJ(r,WPP`5tYQh%*gWBO(R^%`\%(96&l3>WHnB7;&pY0I?k8'u;dL5/D6EdFo=MoKXTi,(L5U.@.f2D6"T_T^S;X")aN^CqL60P3cOPM&ON`Vs1m8]Um:,\i=kPkA,-Y8qi2$g;B\+afiIKb5ZAZ$\)Z]K,8GPoN43BXFE".(%8WYS;R]05XUX1jAJ+J@imP8N4*:qN:F0^)G"5V;e<oCgKX,%jK;kah(YqXJ:UaA.7$]EYb_-g&s7Hf.U#=U'(:%ncHJ]0G/g;(K%1b+!,/C/M/V`IXYX3b_EZ=,lu])ru8VB7Gh*G%[s(mfo_u4:D*#qLK/dGA:N0qYJahWDqIWIHH/]h/0?aZfnEen6ccB+?)lTQsZe:e+>T]rM*,b;8a:-*ZNLVLD(sgVdI&>*)1##!5(K'h4$51S9Z>pb5qSG*,8I_g5=M'Y(kYLhj\8e<sPG<+KOleBQ9?to64+0\(d;Hbus6XfZC9S;_?^ueC)k<"D=Ef'5H0+M(bSa%AJU7eK$&$:<<,IGZR6Y#Kq'l*CTQle5.0q?LO+:IA@[%8<-iGIP:!8Z'!Qbch?Y&V:)OCIXAc4<KcQGnob_JLO,[;C>aFk]7,9cUYtuGRRn[4@O.Z&.:ioEZJ6;S4GX>^iSbo$UT.,ZaEq>9Z+\9fQ9CN;qd*?&s4TDj5)<Y'M9i&+:'+C-;jl74Is]>@C60J77nEunr6%TMjO-e([hlh%HdbJHX]e5WT5$CYMbYA=,8'rsif3>qZ[c*tDk;:.a3"<idD\r9>RC8HWgaTn=g[JNWER+;Cr4kGRuehf-(lO0oA&[@8sX"aaanDCIK8>sj_4`D`FYVpZP"Kp(?/=d1SC._J[R(t'EL*BRP9t)7`$"]$.+X*1rI64a08a,cnFE(,T'Cq;@&D@;pV?3TGiZ3fW7u.;+>LG`_m_/ZbWIo%nB%3_\(!%ak&5I\QU"SY@"@B2O^Imo!BMR"%qqc]</XYM(fp-6s+aY'!]76+2K5N#Ub`coMpT9^1a#$H&-">OHe+fA:UTpCM]oqbm]SYaQ-R^Teo&L?Jp*1QcVIY1^oDgH*=5H/%Y8i%_(qY%hD0-/a=@kgMu*?0_UMKZ\H7Tnr>*`]S#Im41MfmNaFb^.M#cgGSmoD+1$%U_i92lg;4MCD;e'@8A9g]c/(Num#&YS?#jYMTFo9O1'NC2cR<6YPt4rCJ+448S<WRHP?*.JPntY@l<Vj$U">GcML3$-Qa@?5d2$;':+;Gh$dJET8b3K_A+NAJ1=%dh*'m[=bVN*9bsP)CRtm6]Km?5Rp8U$9#@fP`0PZ>VbfoPjD?Mq:L5F"($kp_oak&5Iq*u6m80h)0ACcF\qF,tV9I<Xkq_*t^LQb\T+Gf+a>^[ci0Ae((*eH!-Slpt-[]"QDkZIIXl.2AUlnN&)k.>]nCkMc^rT%l[S=_p&rT)##8b+G'P:,bqjH#eU:O.6MVo#!ZD(6'$H[$C:LEEjDm_b$WR'h\sinD;6%$>oHZ^QBr:I-7hZWJJ?C+^,RIH'jZ?kR1,P=Qp?<J<uXBUe:4LpWt5i^RR&;%JfQZK5ClU)Pq-jB$,i788s\1XgRcS&ULl-Y-e!)UHj"L4l=cL%NeM`9hqh.M#cKGSp1-+1%0t_i8'XRu]7<VMJc=jD1.5r55B<+q[FWOU02b6m@kLr"]Et7Mq.\(:pM4,[[oQofPWGdPPrVZUIYS"@i]t?eb92n4.2q$Xe>3.6&@BRb%VJlp!)7o&/19_?=?^q(_1D**j^]XIY4;ljA<>QWFG<NNNg>i;1@/\3KnYSTGt!!h[X.LF;*X_ikLkHk!ENJ(R.T,Z7*`1b2JP$^!to<:j5t(5+1@$c<S!5[RNIjGUIGSqfj0RL$r8#kO>EY>^ek-1]ZcoBSQ&fU2^$;QCkqnOIg8eO^\nI2'BQ\iQ3s?L69+d8r"0&[7U[Bp!`\BbV@ars'_$7o0~>endstream
+endobj
+12 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2255
+>>
+stream
+Gatn'9lo&K&r,lQ'n+c(ABI7.rK4d0igD'poh;5&mI%q0R"R"a-rLFNnmm4J(+9fK/DK47g/XHXf49*#qZ.TX!=Tgdn6'W/hCmj4#6KRqEWq+@%a.N?H!)96).<j`(>N:)#V4.;JT+gM_o'=s7$Wk,3C-gf%DfmG`r[,PN$No^24RK.7`6tM_8-ok+pMD#o^mSmL-pK+:duM-/N<1aK5W6sgii0u\(TF'm56GELZORaI$?BP%3VLGi!,8i6qID\*t*Z'g_J(A9q-dC%1n6Vb8S)/#YQUX*2/Zt#sa.V+\`Ae17"GhJ$2$O84VD<P9A+0mS-!'6!=OLCNVok7oUolCP8_P/qLN34BKP<as(OlZIr:,1h),98Cj&pXA:PrV2S9KX1D[A$)KC+->5.oHljAp"k@Zbp#0WoGqtOPQ"QgBf#@OL+@'L+J.Y1F+]'"I@tY!(aG^2GC]?qNB)<Je(rHkE&/nuPYQTY9f$:HOQ5A`Q/os6Q&Mgq`J-_&t)'"<fHT5gK8e"Z$di8tB3$O;n$)C6hGE)FDP_;TU1.3m7Wp!uAY4iVtL.I1Z",1]G327sUMk'i-.uB^jAaEs]"T;kZSerjNH4c6p`^gB<Sc\/PMU,gh.#!IRlBn8@(EYk)QQLd<#,K6>@S%:N)+.AZHb=/%`XEJXn=1ZA))>C[CdN/"h)3I1=\0#J/Rp3X`[WA%M1cR1`__OM@u(JDkg>TYT+F%6o?&k'q>/!)B#S;/SiJ1oH4bn1_2--(*AKsB(j`ELcfBoIBV-AVoZPQF?2X#TB7fc#+&&e/gnSI[E,H5b3,;93_$*2p;_r2oW9LH>n!T>08m4\^VN%uYee8QCL80J\`gX@g8J'i36Vs:\3\(N4Uh(Z[g,(ZVj&nIUT</pgLguCBjQ;gSoo'@)1I5J>`Q!:D6+[!lT4_UYp]4lu0f'N*,Xu76@DnG@LWlV,_Ar9")+HqJ,Y^0QKiHMqA(!.Z;3\GHU.cL64W.$HU^/`3;PY0u>[_0%cIs8)-]$&?U*s^n7@?&.MokfXF\]78+rCV[OZ)jgC1QlR5>oScmZ"G;`,L-`dD`:25(=BKKFBKc_b2%ASf,:`?!HcDh_rjS[bl4qVt"k<&0'sJ7-&GRGqtGk08:S>e\O/NgU;1RgN_>>p]9!M#f_A+ILQ[([Tp`8E;kB*mC+*<=LGcFke.?8gr<@N7S@Z\j3:jC27j%mn=.<o%T`Q>=?tJn?.n[uX[f(*/(\l\iL<9t[f%*[&DV,A>o1u]#50s"g[rk)Y4'`tN\R.HJ)7bK(aB$.n:/@Wj7rRYq6ar*C004<l2&pg\4,MkZ>R9[E.8+>B71k#Yd(q,X`%Hp5'VG?Y$[rj6p`;cmA$2RC>ZOf,p=l^o/70*KC=5&CNopu55Es#m'7(o]kN,d>m31E^c(,?b&(E_\Y]U\L,"_'Mpg06P\nm[YTG9DeaCaJTjQOqeul1$*j(D5)35O_^N\Wp)IL,7H=+P?Frai&_U.\ehX=tF=2Ae0i[-Y^[C^m9#.CM(?b;-`n#l#,kb,V)J2'$-Tl5RCs(GJ0!$^F*Hj\jRXDOn@j/On;[:*S2qV,KJJmWe)Ja_;RVINK8_dqC(^[]"p];,4dC&=[0cl*Hj8$XM'8k];QpnXN-D=/cC8mR!@I]oA_WDE?s2u9>B#gA>+M3q>U'L>WO;foU>:XMakl(%*;4o60nd4(gK'V-G>N2/c$H'gY3;hl$<a&SWRq9X!]\CP_TIrf$QX_!d`Xfjgj_82]2f9'*9Km!Rsg39dWh:0/lmdS*TW5O25\HnS-YNU`d;KRq4l201WB2H%%K=WXi3RjV9Ds_g/i12I(LKM$Zh>8Z'faR5NG'+81D;3DZ7>^'uS&E"bYRZ*5:-$mVc7k9c,V9WsOiAs$&lVIR`$EHiBtu`g,dWamNAsf*ajE/IPP$AZUm*UVFB'-9,-L.27*6j'_tWdCeT4+\N@El77N,3sLC(u8?JciQX%/OHRRN"\e/7'0c1Q\m&56JIDd<SUY^>\OHW*">)[PlH44j-Y`?AY0YosmB+*c,A2upHZ$Ye;^?*LdJ2Kg$,l[)ib?'K-j)]2ak(g;#j'tULto,Z%2?AIOX7"4oR-pG;6C7F(GrHIW"T$5'u$jX]MZp(i;>hU.lilYQrrAV6,S[5"p`uVu?If/6`[e="AG'9/]%pmtZmts]WR*7oj<b-=mCN,R-hni<c+b62fhL/K9/\>0]fU]^X@Ft.cL3WlBZnhP$d1%mq`Wc5N,KoF?nNZ[.6c&~>endstream
+endobj
+xref
+0 13
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000525 00000 n 
+0000000729 00000 n 
+0000000933 00000 n 
+0000001001 00000 n 
+0000001421 00000 n 
+0000001492 00000 n 
+0000004863 00000 n 
+0000007255 00000 n 
+trailer
+<<
+/ID 
+[<cec728d3c00957d1b2a1c4bd02e4a28e><cec728d3c00957d1b2a1c4bd02e4a28e>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 13
+>>
+startxref
+9602
+%%EOF


### PR DESCRIPTION
## Add Kairos Lab Security Research — Midnight security review (summary)

Adds `audits/2026-06-05-kairoslab-DRAFT.pdf`, a security-review **summary** of Midnight by **Kairos Lab Security Research**, in the same `audits/` location as the existing Spearbit / Blackthorn / TrustSec drafts.

- **Reviewed commit:** `7538c438` (contest HEAD — includes the `#944` maxRepaid change).
- **Verdict:** **0 Critical · 0 High.**
- **Methodology (OMEGA):** capacity-chain modelling; line-by-line read of `src/` **and** all 33 Certora/CVL proofs; an invariant driver running a 4,000,000-call stateful conservation/solvency fuzz (0 counterexamples); independent adversarial validation; and a doctrine-blind divergent review.
- **Deduplication:** findings deduplicated against Spearbit (`41c8405a`) and Blackthorn / TrustSec (`6783b978`).

This PDF is a **public summary** (severity counts + remediation status, no per-finding detail). The full report (101 pages — findings, PoCs, Certora coverage map, attack-chain ledger, remediation specs) is **available on request**.

Credit: Kairos Lab Security Research (`@Valisthea` / `@KairosLab`). Opened as a **draft** for maintainer consideration — happy to adjust placement or provide the full report.
