### PR TITLE
split fmt of Certora

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -8,6 +8,25 @@ on:
   workflow_dispatch:
 
 jobs:
+  format-specs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ">=3.11"
+
+      - name: Install certora
+        run: pip install certora-cli
+
+      - name: Run Certora Specs Linter
+        run: |
+          for file in certora/specs/*.spec; do
+            echo "Fix lint errors by applying the following diff to $file:"
+            diff -u "$file" <(certoraCVLFormatter "$file")
+          done
+
   matrix:
     runs-on: ubuntu-latest
     outputs:
@@ -46,12 +65,6 @@ jobs:
 
       - name: Install certora
         run: pip install certora-cli
-
-      - name: Run Certora Specs Linter
-        run: |
-          file="certora/specs/${{ matrix.conf }}.spec"
-          echo "Fix lint errors by applying the following diff to $file:"
-          diff -u "$file" <(certoraCVLFormatter "$file")
 
       - name: Install solc (0.8.34)
         env:

--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ">=3.11"

--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  format-specs:
+  format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -43,7 +43,7 @@ jobs:
         run: echo "confs=$(ls certora/confs/*.conf | xargs -I{} basename {} .conf | jq -nRc '[inputs]')" >> "$GITHUB_OUTPUT"
 
   verify:
-    needs: matrix
+    needs: [matrix, format]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
motivation:
- a spec file can have 2 confs, which used to break because each conf will try to format the corresponding spec file (see #891)
- a spec file can have no conf, which will not ensure that this spec file is formatted. For example `BitmapSummaries.spec` has no corresponding conf