### PR TITLE
[Certora] Add rule UpdatePositionViewDoesNotRevert

### DIFF
--- a/certora/specs/LossFactor.spec
+++ b/certora/specs/LossFactor.spec
@@ -87,12 +87,9 @@ rule updatePositionDoesNotRevert(env e, Midnight.Market market, address user) {
 }
 
 /// The loss factor computation in updatePositionView does not revert.
-/// With the current implementation this follows from updatePositionDoesNotRevert (updatePosition calls it),
-/// but proving it directly guards against future implementation changes. It uses the same preconditions.
 rule updatePositionViewDoesNotRevert(env e, Midnight.Market market, address user) {
     bytes32 id = summaryToId(market);
 
-    // No marketIsCreated require: updatePositionView has no MarketNotCreated check.
     require lastLossFactor(id, user) <= currentContract.marketState[id].lossFactor, "lastLossFactor bounded by market lossFactor, already proved in Midnight.spec";
     require pendingFee(id, user) <= creditOf(id, user), "pending fee bounded by credit, already proved in Midnight.spec";
     require currentContract.position[id][user].lastAccrual <= e.block.timestamp, "lastAccrual <= block.timestamp by timestamp monotonicity";

--- a/certora/specs/LossFactor.spec
+++ b/certora/specs/LossFactor.spec
@@ -80,10 +80,29 @@ rule updatePositionDoesNotRevert(env e, Midnight.Market market, address user) {
     require e.block.timestamp < 2 ^ 128, "reasonable timestamp";
     require currentContract.marketState[id].continuousFeeCredit + pendingFee(id, user) <= max_uint128, "Total credit should be bounded by 2^128 and an increase of continuous fee credit should corresponds to a similar decrease of credit";
 
-    require e.msg.value == 0, "setup the call";
+    require e.msg.value == 0, "Midnight is not payable";
     updatePosition@withrevert(e, market, user);
 
     assert !lastReverted, "updatePosition should not revert under valid state";
+}
+
+/// The loss factor computation in updatePositionView does not revert.
+/// With the current implementation this follows from updatePositionDoesNotRevert (updatePosition calls it),
+/// but proving it directly guards against future implementation changes. It uses the same preconditions.
+rule updatePositionViewDoesNotRevert(env e, Midnight.Market market, address user) {
+    bytes32 id = summaryToId(market);
+
+    // No marketIsCreated require: updatePositionView has no MarketNotCreated check.
+    require lastLossFactor(id, user) <= currentContract.marketState[id].lossFactor, "lastLossFactor bounded by market lossFactor, already proved in Midnight.spec";
+    require pendingFee(id, user) <= creditOf(id, user), "pending fee bounded by credit, already proved in Midnight.spec";
+    require currentContract.position[id][user].lastAccrual <= e.block.timestamp, "lastAccrual <= block.timestamp by timestamp monotonicity";
+    require e.block.timestamp < 2 ^ 128, "reasonable timestamp";
+    require currentContract.marketState[id].continuousFeeCredit + pendingFee(id, user) <= max_uint128, "Total credit should be bounded by 2^128 and an increase of continuous fee credit should corresponds to a similar decrease of credit";
+
+    require e.msg.value == 0, "Midnight is not payable";
+    updatePositionView@withrevert(e, market, id, user);
+
+    assert !lastReverted, "updatePositionView should not revert under valid state";
 }
 
 /// updatePosition is idempotent: a second call in the same env leaves the relevant position state unchanged and accrues no new fee.


### PR DESCRIPTION
This is just a copy of the existing rule to also handle updatePositionView's revert behavior.

For completeness and because spec generally want to call updatePositionView without worrying about hiding valid paths.
