### PR TITLE
nit: remove functions from IERC20 interface

### DIFF
--- a/src/interfaces/IERC20.sol
+++ b/src/interfaces/IERC20.sol
@@ -3,9 +3,6 @@
 pragma solidity >=0.5.0;
 
 interface IERC20 {
-    function approve(address spender, uint256 amount) external returns (bool);
     function transfer(address receiver, uint256 amount) external returns (bool);
     function transferFrom(address sender, address receiver, uint256 amount) external returns (bool);
-    function balanceOf(address account) external view returns (uint256);
-    function allowance(address owner, address spender) external view returns (uint256);
 }


### PR DESCRIPTION
Removed approve, balanceOf, and allowance functions from IERC20 interface.