### PR TITLE
uint128 offer caps and consumed

### DIFF
--- a/.github/workflows/forge.yml
+++ b/.github/workflows/forge.yml
@@ -33,7 +33,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1
 
       - name: Run forge lint
-        run: forge lint src certora
+        run: forge lint src test script certora --deny notes
 
   sizes:
     runs-on: ubuntu-latest

--- a/.github/workflows/forge.yml
+++ b/.github/workflows/forge.yml
@@ -33,7 +33,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1
 
       - name: Run forge lint
-        run: forge lint src test script certora --deny notes
+        run: forge lint src certora
 
   sizes:
     runs-on: ubuntu-latest

--- a/certora/specs/Consume.spec
+++ b/certora/specs/Consume.spec
@@ -3,7 +3,7 @@
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;
 
-    function consumed(address user, bytes32 group) external returns (uint256) envfree;
+    function consumed(address user, bytes32 group) external returns (uint128) envfree;
     function totalUnits(bytes32 id) external returns (uint128) envfree;
 
     // Summaries for complex internals irrelevant to consumed-mapping properties.
@@ -18,7 +18,7 @@ methods {
 }
 
 ///  Only setConsumed and take can modify the consumed mapping.
-rule onlySetConsumedAndTakeChangeConsumed(env e, method f, calldataarg args, address user, bytes32 group) filtered { f -> f.selector != sig:setConsumed(bytes32, uint256, address).selector && f.selector != sig:take(Midnight.Offer, bytes, uint256, address, address, address, bytes).selector } {
+rule onlySetConsumedAndTakeChangeConsumed(env e, method f, calldataarg args, address user, bytes32 group) filtered { f -> f.selector != sig:setConsumed(bytes32, uint128, address).selector && f.selector != sig:take(Midnight.Offer, bytes, uint256, address, address, address, bytes).selector } {
     uint256 consumedBefore = consumed(user, group);
 
     f(e, args);
@@ -27,7 +27,7 @@ rule onlySetConsumedAndTakeChangeConsumed(env e, method f, calldataarg args, add
 }
 
 /// Calling setConsumed only affects onBehalf's consumed value for the given group. No other (user, group) pair is modified.
-rule setConsumedOnlyAffectsOnBehalf(env e, bytes32 group, uint256 amount, address onBehalf, address otherUser, bytes32 otherGroup) {
+rule setConsumedOnlyAffectsOnBehalf(env e, bytes32 group, uint128 amount, address onBehalf, address otherUser, bytes32 otherGroup) {
     uint256 otherConsumedBefore = consumed(otherUser, otherGroup);
 
     setConsumed(e, group, amount, onBehalf);

--- a/certora/specs/OnlyAuthorizedCanChange.spec
+++ b/certora/specs/OnlyAuthorizedCanChange.spec
@@ -6,7 +6,7 @@ methods {
     function credit(bytes32 id, address user) external returns (uint128) envfree;
     function debt(bytes32 id, address user) external returns (uint128) envfree;
     function collateral(bytes32 id, address user, uint256 index) external returns (uint128) envfree;
-    function consumed(address user, bytes32 group) external returns (uint256) envfree;
+    function consumed(address user, bytes32 group) external returns (uint128) envfree;
     function isAuthorized(address authorizer, address authorized) external returns (bool) envfree;
 
     // Summarize internal functions that use opcodes causing HAVOC (CREATE2, low-level calls).

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,7 +1,7 @@
 [profile.default]
 via_ir = true
 optimizer = true
-optimizer_runs = 800
+optimizer_runs = 700
 bytecode_hash = "none"
 evm_version = "osaka"
 fs_permissions = [{ access = "read", path = "test/ticks_exact.json" }]

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,7 +1,7 @@
 [profile.default]
 via_ir = true
 optimizer = true
-optimizer_runs = 700
+optimizer_runs = 800
 bytecode_hash = "none"
 evm_version = "osaka"
 fs_permissions = [{ access = "read", path = "test/ticks_exact.json" }]
@@ -16,4 +16,3 @@ exclude_lints = [
     "incorrect-shift",
     "block-timestamp",
 ]
-ignore = ['test/**/*.sol']

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,7 +1,7 @@
 [profile.default]
 via_ir = true
 optimizer = true
-optimizer_runs = 800
+optimizer_runs = 700
 bytecode_hash = "none"
 evm_version = "osaka"
 fs_permissions = [{ access = "read", path = "test/ticks_exact.json" }]
@@ -16,3 +16,4 @@ exclude_lints = [
     "incorrect-shift",
     "block-timestamp",
 ]
+ignore = ['test/**/*.sol']

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -98,6 +98,8 @@ import {IMidnight, Market, Offer, CollateralParams, MarketState, Position} from 
 /// @dev Exactly one of maxAssets or maxUnits must be nonzero per offer (take reverts otherwise).
 /// @dev maxAssets caps max buyer assets if offer.buy is true, and caps max seller assets otherwise.
 /// @dev If maxAssets > 0, assets are capped to maxAssets, otherwise units are capped to maxUnits.
+/// @dev A cap of type(uint128).max is recommended for effectively uncapped offers, as large values can create overflows
+/// during asset <-> unit conversion.
 /// @dev Midnight can call the callback of offers through a no-op take, even if those offers have consumed==max.
 /// @dev It is possible to give units to a fully consumed assets-based buy offer with price < 1.
 /// @dev consumed can be increased manually by the maker or authorized accounts.

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -98,8 +98,6 @@ import {IMidnight, Market, Offer, CollateralParams, MarketState, Position} from 
 /// @dev Exactly one of maxAssets or maxUnits must be nonzero per offer (take reverts otherwise).
 /// @dev maxAssets caps max buyer assets if offer.buy is true, and caps max seller assets otherwise.
 /// @dev If maxAssets > 0, assets are capped to maxAssets, otherwise units are capped to maxUnits.
-/// @dev A cap of type(uint128).max is recommended for effectively uncapped offers, as large values can create overflows
-/// during asset <-> unit conversion.
 /// @dev Midnight can call the callback of offers through a no-op take, even if those offers have consumed==max.
 /// @dev It is possible to give units to a fully consumed assets-based buy offer with price < 1.
 /// @dev consumed can be increased manually by the maker or authorized accounts.
@@ -197,7 +195,7 @@ contract Midnight is IMidnight {
 
     mapping(bytes32 id => mapping(address user => Position)) public position;
     mapping(bytes32 id => MarketState) public marketState;
-    mapping(address user => mapping(bytes32 group => uint256)) public consumed;
+    mapping(address user => mapping(bytes32 group => uint128)) public consumed;
     mapping(address authorizer => mapping(address authorized => bool)) public isAuthorized;
     mapping(address loanToken => uint16[7]) public defaultSettlementFeeCbp;
     mapping(address loanToken => uint32) public defaultContinuousFee;
@@ -449,7 +447,7 @@ contract Midnight is IMidnight {
             UtilsLib.toUint128(_marketState.totalUnits + buyerCreditIncrease - sellerCreditDecrease);
         claimableSettlementFee[offer.market.loanToken] += buyerAssets - sellerAssets;
 
-        consumed[offer.maker][offer.group] = newConsumed;
+        consumed[offer.maker][offer.group] = UtilsLib.toUint128(newConsumed);
 
         address buyerCallback = offer.buy ? offer.callback : takerCallback;
         address sellerCallback = offer.buy ? takerCallback : offer.callback;
@@ -756,8 +754,8 @@ contract Midnight is IMidnight {
         return (seizedAssets, repaidUnits);
     }
 
-    /// @dev Passing type(uint256).max cancels all offers in the group (and never reverts).
-    function setConsumed(bytes32 group, uint256 amount, address onBehalf) external {
+    /// @dev Passing type(uint128).max cancels all offers in the group (and never reverts).
+    function setConsumed(bytes32 group, uint128 amount, address onBehalf) external {
         require(onBehalf == msg.sender || isAuthorized[onBehalf][msg.sender], Unauthorized());
         require(amount >= consumed[onBehalf][group], AlreadyConsumed());
         consumed[onBehalf][group] = amount;

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -447,7 +447,8 @@ contract Midnight is IMidnight {
             UtilsLib.toUint128(_marketState.totalUnits + buyerCreditIncrease - sellerCreditDecrease);
         claimableSettlementFee[offer.market.loanToken] += buyerAssets - sellerAssets;
 
-        consumed[offer.maker][offer.group] = UtilsLib.toUint128(newConsumed);
+        // forge-lint: disable-next-item(unsafe-typecast) as newConsumed <= maxAssets or maxUnits.
+        consumed[offer.maker][offer.group] = uint128(newConsumed);
 
         address buyerCallback = offer.buy ? offer.callback : takerCallback;
         address sellerCallback = offer.buy ? takerCallback : offer.callback;

--- a/src/interfaces/IMidnight.sol
+++ b/src/interfaces/IMidnight.sol
@@ -33,8 +33,8 @@ struct Offer {
     address receiverIfMakerIsSeller;
     address ratifier;
     bool reduceOnly;
-    uint256 maxUnits;
-    uint256 maxAssets; // buyerAssets if offer.buy else sellerAssets
+    uint128 maxUnits;
+    uint128 maxAssets; // buyerAssets if offer.buy else sellerAssets
     uint256 continuousFeeCap;
 }
 
@@ -127,7 +127,7 @@ interface IMidnight {
     /// STORAGE GETTERS ///
     function position(bytes32 id, address user) external view returns (uint128 credit, uint128 pendingFee, uint128 lastLossFactor, uint128 lastAccrual, uint128 debt, uint128 collateralBitmap);
     function marketState(bytes32 id) external view returns (uint128 totalUnits, uint128 lossFactor, uint128 withdrawable, uint128 continuousFeeCredit, uint16 settlementFeeCbp0, uint16 settlementFeeCbp1, uint16 settlementFeeCbp2, uint16 settlementFeeCbp3, uint16 settlementFeeCbp4, uint16 settlementFeeCbp5, uint16 settlementFeeCbp6, uint32 continuousFee, uint8 tickSpacing);
-    function consumed(address user, bytes32 group) external view returns (uint256);
+    function consumed(address user, bytes32 group) external view returns (uint128);
     function isAuthorized(address authorizer, address authorized) external view returns (bool);
     function defaultSettlementFeeCbp(address loanToken, uint256 index) external view returns (uint16);
     function defaultContinuousFee(address loanToken) external view returns (uint32);
@@ -164,7 +164,7 @@ interface IMidnight {
     function supplyCollateral(Market memory market, uint256 collateralIndex, uint256 assets, address onBehalf) external;
     function withdrawCollateral(Market memory market, uint256 collateralIndex, uint256 assets, address onBehalf, address receiver) external;
     function liquidate(Market memory market, uint256 collateralIndex, uint256 seizedAssets, uint256 repaidUnits, address borrower, bool postMaturityMode, address receiver, address callback, bytes memory data) external returns (uint256 outputSeizedAssets, uint256 outputRepaidUnits);
-    function setConsumed(bytes32 group, uint256 amount, address onBehalf) external;
+    function setConsumed(bytes32 group, uint128 amount, address onBehalf) external;
     function setIsAuthorized(address authorized, bool newIsAuthorized, address onBehalf) external;
     function flashLoan(address[] memory tokens, uint256[] memory assets, address callback, bytes memory data) external;
     function touchMarket(Market memory market) external returns (bytes32);

--- a/src/periphery/ConsumableUnitsLib.sol
+++ b/src/periphery/ConsumableUnitsLib.sol
@@ -12,7 +12,7 @@ library ConsumableUnitsLib {
     /// @dev Returns a number of units such that it fully consumes the offer.
     /// @dev Assumes that `id` matches `offer.market`.
     function consumableUnits(address midnight, bytes32 id, Offer memory offer) internal view returns (uint256) {
-        uint256 consumed = IMidnight(midnight).consumed(offer.maker, offer.group);
+        uint128 consumed = IMidnight(midnight).consumed(offer.maker, offer.group);
         if (offer.maxUnits > 0) {
             return offer.maxUnits.zeroFloorSub(consumed);
         } else if (offer.buy) {

--- a/src/periphery/ConsumableUnitsLib.sol
+++ b/src/periphery/ConsumableUnitsLib.sol
@@ -7,7 +7,6 @@ import {UtilsLib} from "../libraries/UtilsLib.sol";
 import {TakeAmountsLib} from "./TakeAmountsLib.sol";
 
 library ConsumableUnitsLib {
-    using UtilsLib for uint256;
     using UtilsLib for uint128;
 
     /// @dev Returns a number of units such that it fully consumes the offer.

--- a/src/periphery/ConsumableUnitsLib.sol
+++ b/src/periphery/ConsumableUnitsLib.sol
@@ -12,7 +12,7 @@ library ConsumableUnitsLib {
     /// @dev Returns a number of units such that it fully consumes the offer.
     /// @dev Assumes that `id` matches `offer.market`.
     function consumableUnits(address midnight, bytes32 id, Offer memory offer) internal view returns (uint256) {
-        uint128 consumed = IMidnight(midnight).consumed(offer.maker, offer.group);
+        uint256 consumed = IMidnight(midnight).consumed(offer.maker, offer.group);
         if (offer.maxUnits > 0) {
             return offer.maxUnits.zeroFloorSub(consumed);
         } else if (offer.buy) {

--- a/src/periphery/ConsumableUnitsLib.sol
+++ b/src/periphery/ConsumableUnitsLib.sol
@@ -8,6 +8,7 @@ import {TakeAmountsLib} from "./TakeAmountsLib.sol";
 
 library ConsumableUnitsLib {
     using UtilsLib for uint256;
+    using UtilsLib for uint128;
 
     /// @dev Returns a number of units such that it fully consumes the offer.
     /// @dev Assumes that `id` matches `offer.market`.

--- a/src/periphery/ConsumableUnitsLib.sol
+++ b/src/periphery/ConsumableUnitsLib.sol
@@ -7,6 +7,7 @@ import {UtilsLib} from "../libraries/UtilsLib.sol";
 import {TakeAmountsLib} from "./TakeAmountsLib.sol";
 
 library ConsumableUnitsLib {
+    using UtilsLib for uint256;
     using UtilsLib for uint128;
 
     /// @dev Returns a number of units such that it fully consumes the offer.

--- a/src/ratifiers/libraries/HashLib.sol
+++ b/src/ratifiers/libraries/HashLib.sol
@@ -9,7 +9,7 @@ bytes32 constant COLLATERAL_PARAMS_TYPEHASH = 0x39ed3f928d24fd00574b1a02aba9c248
 /// @dev keccak256(bytes.concat(MARKET_TYPE, COLLATERAL_PARAMS_TYPE)).
 bytes32 constant MARKET_TYPEHASH = 0x510b3862f3816a109c9340b76972e8a30984246be06e034ae12ed2934220391a;
 /// @dev keccak256(bytes.concat(OFFER_TYPE, COLLATERAL_PARAMS_TYPE, MARKET_TYPE)).
-bytes32 constant OFFER_TYPEHASH = 0xa316348449d1749c733fbf0befac14d04d6ed14ea8993956f5eb405e6191bb81;
+bytes32 constant OFFER_TYPEHASH = 0x9905214264a9fb7b6cc1b0e33db7a04687c6e4185a84755d29914314aa9d8906;
 
 library HashLib {
     error LeafIndexOutOfRange();
@@ -21,28 +21,28 @@ library HashLib {
     /// @dev Reverts if height is greater than 20.
     function offerTreeTypeHash(uint256 height) internal pure returns (bytes32) {
         if (height <= 10) {
-            if (height == 0) return 0x004abfc3a2bdb852bd9e193d58623de158d293bff8df82b2c73762b1449a92da;
-            if (height == 1) return 0x2b907b506023b7da998b4e05205998675021a6698538b52812412353ba1b5b07;
-            if (height == 2) return 0xf3a8fa1ea464758633ee72dfd7bc109d92c69933b1d626583d37c1adc22431f4;
-            if (height == 3) return 0xc7aee773c7436e1047be687b497f42b5d2195ebcf80278aa902f65b99ea8d5f9;
-            if (height == 4) return 0x1ccd280d009a28babd35e45c7ea1bacc4abecbace69d6ca43bd297618af0d6ea;
-            if (height == 5) return 0x976e461f282292a9fc669ed6f8642da97b0853348b8d3b64caf1a63d74535062;
-            if (height == 6) return 0xa16c55d7ca5db454b6c0466c695febf8df2b4084481546a26383a48fb573f20b;
-            if (height == 7) return 0x15fa4f24cac8ee8dbbc17465043a62700395a7c75c4cc475fe241b6a3424b8bb;
-            if (height == 8) return 0x9bf198023231a1c26072e32ee84aa2ed6a1766ca348cceab9bc1065487b6dc82;
-            if (height == 9) return 0x7d723919779d24dfca798d2847418afb9d07dccc8aeed8db0f2e54a765e59630;
-            return 0xd50fde6271f599771c124dc4d2f3058693c7ef675e733ceffb870fe5f2941524;
+            if (height == 0) return 0x270da1ebafc0f24637af3612fb8c3a1d828fcb56d3637c24e86dd006b12ca7f9;
+            if (height == 1) return 0x828b9cdf8326a1cf234328e4d5229546a98fb72ef73624f5b6b31538e555b96c;
+            if (height == 2) return 0xfcb7a3ca4094246b8185620c4cf025c93032b6f0384805aa3f22afe04290e982;
+            if (height == 3) return 0xcc97cb1955496a5269b5a7afca62ba694edcab26ba838a1adbd257931249de92;
+            if (height == 4) return 0xda3feb08db360ad9e09540132ff04d2b6a596fdaa4747892217aaa4c7c9bcc31;
+            if (height == 5) return 0x15bd6e2aa1a7a61614187ac16d2cbf8610c8f2f3c3d9eaa380ae7a501ee3cf06;
+            if (height == 6) return 0xb726cb7fab1a24c28213cbd482fa5a301f127fb25feb01da341919983a72711a;
+            if (height == 7) return 0xcea9cd557c6f821868ea287304199d0e0554af630bfa8fe36c64eb3bbacca418;
+            if (height == 8) return 0xf7dbde8234e8e345cec8fc0a8ac5909ee336b214882751ecd51e7b37df4f6cdd;
+            if (height == 9) return 0x5400a5d43d39e6bfe910af8cb84ac77bf501d310413769dffd62ccecda8b00c6;
+            return 0x0754209b60d99d0822b3ecd5a970f9db09df9c8998a8441e24b81f06d6c76fee;
         } else {
-            if (height == 11) return 0xb1c8d8455bf9b0d65722bc605488eedaf3ca18e32f386c366083af360aed575c;
-            if (height == 12) return 0x62306a7da75b4151cbc5a8c2be14ebd9ef413988ceb26330c2b85ea75df64761;
-            if (height == 13) return 0x4c05f804d2f0a7edc5d767492018eae312b6f8f9649222f8e7a78745783cd45d;
-            if (height == 14) return 0x968c3e8fe32537b97318f74ff109f7e6efa365f25048fc48f474d10981e5d03a;
-            if (height == 15) return 0x9c4b06c4bc414cd5ffb0b3d71fd1450393e79bbe73405f2770ee4489175cf734;
-            if (height == 16) return 0xe225a68d5feb03db447cc58f3a0ff567cfe7446a73cad24e1781a33696066e90;
-            if (height == 17) return 0xa9ef83c85cdc9f01279a32350b39d1e350a51ee9f236a9e6d1be764ec67d2b12;
-            if (height == 18) return 0x083f794c8751fba472222de46673bb4386de88d05495f9d2f2c40d96020a95b3;
-            if (height == 19) return 0xdfc36aba879c79d4ce19d8620a560d41d19bc9b315758ec93c651e92115d238b;
-            if (height == 20) return 0x60f9befb3ea1715092407b29ec59829d55544c89bcd5bde861fef413f2072ddd;
+            if (height == 11) return 0xf5d561d88647c3b38ed6636709d3166819fc66f8ed52a0daf4ae186387b4646c;
+            if (height == 12) return 0x5801c07a6c7df039ce00a7a2b8bd92aa1cf333c30b0bc3d78768590b6063d09e;
+            if (height == 13) return 0xc9da7190eaf4b14c7cb1c14f9898256c0adb6b1dc303afe79594dea64fe199c0;
+            if (height == 14) return 0xa47534c85ac57c583568465d40fd46683d2d558d8129fe1aca01e93023afca92;
+            if (height == 15) return 0xb1e841691fb54f4ef85e2ed9de45d610e57f49e1e6eb2510ceead16e447dd519;
+            if (height == 16) return 0x4fa4f16f09f0c36c7670449a4032073380d28a60071e12ee8874bb3e5a8318fc;
+            if (height == 17) return 0x817bbaac8bb863670f488b454cdd5d0990d9d81871a68e9df381c3c13d3f2ba2;
+            if (height == 18) return 0xc447f06079bddf4b011523c4bce119e9e90fdf937de4ee88f48010406560e9c1;
+            if (height == 19) return 0x1608d5eb56943c667c34b413f9f8a1c24a84ddfe1301a9c25487e638de1f5822;
+            if (height == 20) return 0x3a677100d2e855c24a62d1e9c365bff90d02287f066a07064843ca1ee70ea113;
             revert TreeTooHigh();
         }
     }

--- a/test/AuthorizationTest.sol
+++ b/test/AuthorizationTest.sol
@@ -211,7 +211,7 @@ contract AuthorizationTest is BaseTest {
         offer.buy = true;
         offer.maker = lender;
         offer.ratifier = address(dummyRatifier);
-        offer.maxUnits = units;
+        offer.maxUnits = uint128(units);
         offer.market = market;
         offer.expiry = vm.getBlockTimestamp() + 200;
         offer.tick = MAX_TICK;
@@ -235,7 +235,7 @@ contract AuthorizationTest is BaseTest {
         offer.buy = true;
         offer.maker = lender;
         offer.ratifier = address(dummyRatifier);
-        offer.maxUnits = units;
+        offer.maxUnits = uint128(units);
         offer.market = market;
         offer.expiry = vm.getBlockTimestamp() + 200;
         offer.tick = MAX_TICK;
@@ -321,7 +321,7 @@ contract AuthorizationTest is BaseTest {
         offer.buy = true;
         offer.maker = lender;
         offer.ratifier = address(dummyRatifier);
-        offer.maxUnits = units;
+        offer.maxUnits = uint128(units);
         offer.market = market;
         offer.expiry = vm.getBlockTimestamp() + 200;
         offer.tick = MAX_TICK;

--- a/test/AuthorizationTest.sol
+++ b/test/AuthorizationTest.sol
@@ -211,7 +211,7 @@ contract AuthorizationTest is BaseTest {
         offer.buy = true;
         offer.maker = lender;
         offer.ratifier = address(dummyRatifier);
-        offer.maxUnits = uint128(units);
+        offer.maxUnits = units.toUint128();
         offer.market = market;
         offer.expiry = vm.getBlockTimestamp() + 200;
         offer.tick = MAX_TICK;
@@ -235,7 +235,7 @@ contract AuthorizationTest is BaseTest {
         offer.buy = true;
         offer.maker = lender;
         offer.ratifier = address(dummyRatifier);
-        offer.maxUnits = uint128(units);
+        offer.maxUnits = units.toUint128();
         offer.market = market;
         offer.expiry = vm.getBlockTimestamp() + 200;
         offer.tick = MAX_TICK;
@@ -321,7 +321,7 @@ contract AuthorizationTest is BaseTest {
         offer.buy = true;
         offer.maker = lender;
         offer.ratifier = address(dummyRatifier);
-        offer.maxUnits = uint128(units);
+        offer.maxUnits = units.toUint128();
         offer.market = market;
         offer.expiry = vm.getBlockTimestamp() + 200;
         offer.tick = MAX_TICK;

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -179,7 +179,7 @@ abstract contract BaseTest is Test {
         lenderOffer.market = market;
         lenderOffer.buy = true;
         lenderOffer.maker = otherLender;
-        lenderOffer.maxUnits = type(uint256).max;
+        lenderOffer.maxUnits = type(uint128).max;
         lenderOffer.continuousFeeCap = type(uint256).max;
         lenderOffer.group = keccak256(abi.encode("non zero group"));
         lenderOffer.ratifier = address(dummyRatifier);
@@ -301,7 +301,7 @@ abstract contract BaseTest is Test {
     }
 
     function _setupMarketOffer(Market memory market) internal view returns (Offer memory borrowerOffer) {
-        borrowerOffer = _setupMarketOffer(market, type(uint256).max);
+        borrowerOffer = _setupMarketOffer(market, type(uint128).max);
     }
 
     function _setupMarketOffer(Market memory market, uint256 maxUnits)
@@ -313,7 +313,7 @@ abstract contract BaseTest is Test {
         borrowerOffer.buy = false;
         borrowerOffer.maker = borrower;
         borrowerOffer.receiverIfMakerIsSeller = borrower;
-        borrowerOffer.maxUnits = maxUnits;
+        borrowerOffer.maxUnits = maxUnits.toUint128();
         borrowerOffer.ratifier = address(dummyRatifier);
         borrowerOffer.start = vm.getBlockTimestamp();
         borrowerOffer.expiry = vm.getBlockTimestamp();

--- a/test/ContinuousFeeTest.sol
+++ b/test/ContinuousFeeTest.sol
@@ -191,7 +191,7 @@ contract ContinuousFeeTest is BaseTest {
         borrowOffer.buy = false;
         borrowOffer.maker = otherBorrower;
         borrowOffer.receiverIfMakerIsSeller = otherBorrower;
-        borrowOffer.maxUnits = uint128(credit2);
+        borrowOffer.maxUnits = credit2.toUint128();
         borrowOffer.ratifier = address(dummyRatifier);
         borrowOffer.start = vm.getBlockTimestamp();
         borrowOffer.expiry = vm.getBlockTimestamp();
@@ -607,7 +607,7 @@ contract ContinuousFeeTest is BaseTest {
         deal(address(loanToken), otherLender, units);
 
         Offer memory offer = _makeBuyOffer(keccak256("buy-max-fee"));
-        offer.maxUnits = uint128(units);
+        offer.maxUnits = units.toUint128();
         offer.continuousFeeCap = continuousFeeCap;
 
         vm.expectRevert(IMidnight.ContinuousFeeAboveOfferCap.selector);
@@ -624,7 +624,7 @@ contract ContinuousFeeTest is BaseTest {
         deal(address(loanToken), otherLender, units);
 
         Offer memory offer = _makeBuyOffer(keccak256("buy-ok-fee"));
-        offer.maxUnits = uint128(units);
+        offer.maxUnits = units.toUint128();
         offer.continuousFeeCap = continuousFeeCap;
 
         take(units, borrower, offer);

--- a/test/ContinuousFeeTest.sol
+++ b/test/ContinuousFeeTest.sol
@@ -60,7 +60,7 @@ contract ContinuousFeeTest is BaseTest {
         o.market = market;
         o.buy = true;
         o.maker = otherLender;
-        o.maxUnits = type(uint256).max;
+        o.maxUnits = type(uint128).max;
         o.continuousFeeCap = type(uint256).max;
         o.ratifier = address(dummyRatifier);
         o.expiry = vm.getBlockTimestamp();
@@ -191,7 +191,7 @@ contract ContinuousFeeTest is BaseTest {
         borrowOffer.buy = false;
         borrowOffer.maker = otherBorrower;
         borrowOffer.receiverIfMakerIsSeller = otherBorrower;
-        borrowOffer.maxUnits = credit2;
+        borrowOffer.maxUnits = uint128(credit2);
         borrowOffer.ratifier = address(dummyRatifier);
         borrowOffer.start = vm.getBlockTimestamp();
         borrowOffer.expiry = vm.getBlockTimestamp();
@@ -607,7 +607,7 @@ contract ContinuousFeeTest is BaseTest {
         deal(address(loanToken), otherLender, units);
 
         Offer memory offer = _makeBuyOffer(keccak256("buy-max-fee"));
-        offer.maxUnits = units;
+        offer.maxUnits = uint128(units);
         offer.continuousFeeCap = continuousFeeCap;
 
         vm.expectRevert(IMidnight.ContinuousFeeAboveOfferCap.selector);
@@ -624,7 +624,7 @@ contract ContinuousFeeTest is BaseTest {
         deal(address(loanToken), otherLender, units);
 
         Offer memory offer = _makeBuyOffer(keccak256("buy-ok-fee"));
-        offer.maxUnits = units;
+        offer.maxUnits = uint128(units);
         offer.continuousFeeCap = continuousFeeCap;
 
         take(units, borrower, offer);

--- a/test/EcrecoverRatifierIntegrationTest.sol
+++ b/test/EcrecoverRatifierIntegrationTest.sol
@@ -54,7 +54,7 @@ contract EcrecoverRatifierIntegrationTest is BaseTest {
         lenderOffer.buy = true;
         lenderOffer.maker = lender;
         lenderOffer.ratifier = address(ecrecoverRatifier);
-        lenderOffer.maxUnits = type(uint256).max;
+        lenderOffer.maxUnits = type(uint128).max;
         lenderOffer.market = market;
         lenderOffer.expiry = vm.getBlockTimestamp() + 200;
         lenderOffer.tick = MAX_TICK;
@@ -227,7 +227,7 @@ contract EcrecoverRatifierIntegrationTest is BaseTest {
         uint256 price = TickLib.tickToPrice(lenderOffer.tick);
         deal(address(loanToken), lender, units.mulDivDown(price, WAD));
         collateralize(market, borrower, units);
-        lenderOffer.maxUnits = type(uint256).max;
+        lenderOffer.maxUnits = type(uint128).max;
 
         vm.prank(borrower);
         midnight.take(
@@ -248,7 +248,7 @@ contract EcrecoverRatifierIntegrationTest is BaseTest {
         uint256 price = TickLib.tickToPrice(lenderOffer.tick);
         deal(address(loanToken), lender, units.mulDivDown(price, WAD));
         collateralize(market, borrower, units);
-        lenderOffer.maxUnits = type(uint256).max;
+        lenderOffer.maxUnits = type(uint128).max;
 
         Offer memory offer0 = lenderOffer;
 

--- a/test/FrontendSignatureTest.sol
+++ b/test/FrontendSignatureTest.sol
@@ -9,10 +9,10 @@ import {CALLBACK_SUCCESS} from "../src/libraries/ConstantsLib.sol";
 import {HashLib} from "../src/ratifiers/libraries/HashLib.sol";
 
 // Paste from frontend output (sign-root.ts).
-address constant ACCOUNT = 0xFDa6883171208B36122229505FB2D6F30c052311;
+address constant ACCOUNT = 0x70997970C51812dc3A010C7d01b50e0d17dc79C8;
 uint8 constant SIG_V = 27;
-bytes32 constant SIG_R = 0xaec9813941f94ad315c142e361666a5e850e7a42fe416bbdb643d872798a14bc;
-bytes32 constant SIG_S = 0x7afeb8781b2146bb453b4ecfcc1631fa96c78eea2a01fc2428894a5b68525cc0;
+bytes32 constant SIG_R = 0xeb511490094f44ed91b79ebc436cc7c7e6d282e657bc39797a98ce2dd3826be0;
+bytes32 constant SIG_S = 0x58ec81dc273626bd4ea660bd5682a5860eed1e37927ee8cce469ef7261f9c183;
 
 address constant RATIFIER = 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB;
 

--- a/test/GateTest.sol
+++ b/test/GateTest.sol
@@ -78,7 +78,7 @@ contract GateTest is BaseTest {
 
         lenderOffer.buy = true;
         lenderOffer.maker = lender;
-        lenderOffer.maxUnits = type(uint256).max;
+        lenderOffer.maxUnits = type(uint128).max;
         lenderOffer.market = gatedMarket;
         lenderOffer.ratifier = address(dummyRatifier);
         lenderOffer.expiry = vm.getBlockTimestamp() + 200;
@@ -87,7 +87,7 @@ contract GateTest is BaseTest {
         borrowerOffer.buy = false;
         borrowerOffer.maker = borrower;
         borrowerOffer.receiverIfMakerIsSeller = borrower;
-        borrowerOffer.maxUnits = type(uint256).max;
+        borrowerOffer.maxUnits = type(uint128).max;
         borrowerOffer.market = gatedMarket;
         borrowerOffer.ratifier = address(dummyRatifier);
         borrowerOffer.expiry = vm.getBlockTimestamp() + 200;
@@ -176,7 +176,7 @@ contract GateTest is BaseTest {
         otherBorrowerOffer.buy = false;
         otherBorrowerOffer.maker = otherBorrower;
         otherBorrowerOffer.receiverIfMakerIsSeller = otherBorrower;
-        otherBorrowerOffer.maxUnits = type(uint256).max;
+        otherBorrowerOffer.maxUnits = type(uint128).max;
         otherBorrowerOffer.market = gatedMarket;
         otherBorrowerOffer.ratifier = address(dummyRatifier);
         otherBorrowerOffer.expiry = vm.getBlockTimestamp() + 200;
@@ -203,7 +203,7 @@ contract GateTest is BaseTest {
         Offer memory otherLenderOffer;
         otherLenderOffer.buy = true;
         otherLenderOffer.maker = otherLender;
-        otherLenderOffer.maxUnits = type(uint256).max;
+        otherLenderOffer.maxUnits = type(uint128).max;
         otherLenderOffer.market = gatedMarket;
         otherLenderOffer.ratifier = address(dummyRatifier);
         otherLenderOffer.expiry = vm.getBlockTimestamp() + 200;
@@ -219,7 +219,7 @@ contract GateTest is BaseTest {
         exitOffer.buy = false;
         exitOffer.maker = otherLender;
         exitOffer.receiverIfMakerIsSeller = otherLender;
-        exitOffer.maxUnits = type(uint256).max;
+        exitOffer.maxUnits = type(uint128).max;
         exitOffer.market = gatedMarket;
         exitOffer.ratifier = address(dummyRatifier);
         exitOffer.expiry = vm.getBlockTimestamp() + 200;
@@ -312,7 +312,7 @@ contract GateTest is BaseTest {
         Offer memory ungatedLenderOffer;
         ungatedLenderOffer.buy = true;
         ungatedLenderOffer.maker = lender;
-        ungatedLenderOffer.maxUnits = type(uint256).max;
+        ungatedLenderOffer.maxUnits = type(uint128).max;
         ungatedLenderOffer.market = market;
         ungatedLenderOffer.ratifier = address(dummyRatifier);
         ungatedLenderOffer.expiry = vm.getBlockTimestamp() + 200;

--- a/test/HashLibTest.sol
+++ b/test/HashLibTest.sol
@@ -15,7 +15,7 @@ bytes constant COLLATERAL_PARAMS_TYPE =
 bytes constant MARKET_TYPE =
     "Market(uint256 chainId,address midnight,address loanToken,CollateralParams[] collateralParams,uint256 maturity,uint256 rcfThreshold,address enterGate,address liquidatorGate)";
 bytes constant OFFER_TYPE =
-    "Offer(Market market,bool buy,address maker,uint256 start,uint256 expiry,uint256 tick,bytes32 group,address callback,bytes callbackData,address receiverIfMakerIsSeller,address ratifier,bool reduceOnly,uint256 maxUnits,uint256 maxAssets,uint256 continuousFeeCap)";
+    "Offer(Market market,bool buy,address maker,uint256 start,uint256 expiry,uint256 tick,bytes32 group,address callback,bytes callbackData,address receiverIfMakerIsSeller,address ratifier,bool reduceOnly,uint128 maxUnits,uint128 maxAssets,uint256 continuousFeeCap)";
 
 contract HashLibTest is Test {
     function testCollateralParamsTypeHash() public pure {

--- a/test/MaxAmountsTest.sol
+++ b/test/MaxAmountsTest.sol
@@ -2,7 +2,7 @@
 // Copyright (c) 2025 Morpho Association
 pragma solidity ^0.8.0;
 
-import {Market, Offer, CollateralParams} from "../src/interfaces/IMidnight.sol";
+import {IMidnight, Market, Offer, CollateralParams} from "../src/interfaces/IMidnight.sol";
 import {ORACLE_PRICE_SCALE} from "../src/libraries/ConstantsLib.sol";
 import {UtilsLib} from "../src/libraries/UtilsLib.sol";
 import {MAX_TICK} from "../src/libraries/TickLib.sol";
@@ -68,7 +68,7 @@ contract MaxAmountsTest is BaseTest {
         borrowerOffer.buy = false;
         borrowerOffer.maker = borrower;
         borrowerOffer.receiverIfMakerIsSeller = borrower;
-        borrowerOffer.maxUnits = type(uint256).max;
+        borrowerOffer.maxUnits = type(uint128).max;
         borrowerOffer.expiry = vm.getBlockTimestamp() + 200;
         borrowerOffer.ratifier = address(dummyRatifier);
         borrowerOffer.tick = MAX_TICK;
@@ -95,12 +95,12 @@ contract MaxAmountsTest is BaseTest {
         borrowerOffer.buy = false;
         borrowerOffer.maker = borrower;
         borrowerOffer.receiverIfMakerIsSeller = borrower;
-        borrowerOffer.maxUnits = type(uint256).max;
+        borrowerOffer.maxUnits = type(uint128).max;
         borrowerOffer.expiry = vm.getBlockTimestamp() + 200;
         borrowerOffer.ratifier = address(dummyRatifier);
         borrowerOffer.tick = MAX_TICK;
 
-        vm.expectRevert(UtilsLib.CastOverflow.selector);
+        vm.expectRevert(IMidnight.ConsumedUnits.selector);
         take(amount, lender, borrowerOffer);
     }
 

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -249,7 +249,7 @@ contract OtherFunctionsTest is BaseTest {
         assertEq(ERC20(collateralToken).balanceOf(receiver), withdraw, "balance of receiver");
     }
 
-    function testSetConsumed(address user, bytes32 group, uint256 amount) public {
+    function testSetConsumed(address user, bytes32 group, uint128 amount) public {
         vm.expectEmit();
         emit EventsLib.SetConsumed(user, group, amount, user);
 
@@ -258,9 +258,9 @@ contract OtherFunctionsTest is BaseTest {
         assertEq(midnight.consumed(user, group), amount, "consumed");
     }
 
-    function testSetConsumedIncreasing(address user, bytes32 group, uint256 amount0, uint256 amount1) public {
-        amount0 = bound(amount0, 0, type(uint256).max - 1);
-        amount1 = bound(amount1, amount0, type(uint256).max);
+    function testSetConsumedIncreasing(address user, bytes32 group, uint128 amount0, uint128 amount1) public {
+        amount0 = uint128(bound(amount0, 0, type(uint128).max - 1));
+        amount1 = uint128(bound(amount1, amount0, type(uint128).max));
 
         vm.prank(user);
         midnight.setConsumed(group, amount0, user);
@@ -271,9 +271,9 @@ contract OtherFunctionsTest is BaseTest {
         assertEq(midnight.consumed(user, group), amount1, "consumed 1");
     }
 
-    function testSetConsumedDecreasingReverts(address user, bytes32 group, uint256 amount0, uint256 amount1) public {
-        amount0 = bound(amount0, 1, type(uint256).max);
-        amount1 = bound(amount1, 0, amount0 - 1);
+    function testSetConsumedDecreasingReverts(address user, bytes32 group, uint128 amount0, uint128 amount1) public {
+        amount0 = uint128(bound(amount0, 1, type(uint128).max));
+        amount1 = uint128(bound(amount1, 0, amount0 - 1));
 
         vm.prank(user);
         midnight.setConsumed(group, amount0, user);

--- a/test/SetterRatifierTest.sol
+++ b/test/SetterRatifierTest.sol
@@ -36,7 +36,7 @@ contract SetterRatifierTest is BaseTest {
         offer.buy = true;
         offer.maker = maker;
         offer.ratifier = address(setterRatifier);
-        offer.maxUnits = type(uint256).max;
+        offer.maxUnits = type(uint128).max;
         offer.expiry = vm.getBlockTimestamp() + 200;
         offer.tick = MAX_TICK;
     }

--- a/test/SettlementFeeTest.sol
+++ b/test/SettlementFeeTest.sol
@@ -66,7 +66,7 @@ contract SettlementFeeTest is BaseTest {
         lenderOffer.market = market;
         lenderOffer.buy = true;
         lenderOffer.maker = lender;
-        lenderOffer.maxUnits = type(uint256).max;
+        lenderOffer.maxUnits = type(uint128).max;
         lenderOffer.ratifier = address(dummyRatifier);
         lenderOffer.start = vm.getBlockTimestamp();
         lenderOffer.expiry = vm.getBlockTimestamp() + 200;
@@ -75,7 +75,7 @@ contract SettlementFeeTest is BaseTest {
         borrowerOffer.buy = false;
         borrowerOffer.maker = borrower;
         borrowerOffer.receiverIfMakerIsSeller = borrower;
-        borrowerOffer.maxUnits = type(uint256).max;
+        borrowerOffer.maxUnits = type(uint128).max;
         borrowerOffer.ratifier = address(dummyRatifier);
         borrowerOffer.expiry = vm.getBlockTimestamp() + 200;
 

--- a/test/TakeAmountsTest.sol
+++ b/test/TakeAmountsTest.sol
@@ -49,7 +49,7 @@ contract TakeAmountsTest is BaseTest {
         id = toId(market);
 
         offer.buy = false;
-        offer.maxUnits = type(uint256).max;
+        offer.maxUnits = type(uint128).max;
         offer.market = market;
         offer.ratifier = address(dummyRatifier);
         offer.expiry = vm.getBlockTimestamp() + 200;

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -65,7 +65,7 @@ contract TakeTest is BaseTest {
         lenderOffer.buy = true;
         lenderOffer.maker = lender;
         lenderOffer.ratifier = address(dummyRatifier);
-        lenderOffer.maxUnits = type(uint256).max;
+        lenderOffer.maxUnits = type(uint128).max;
         lenderOffer.continuousFeeCap = type(uint256).max;
         lenderOffer.market = market;
         lenderOffer.expiry = vm.getBlockTimestamp() + 200;
@@ -75,7 +75,7 @@ contract TakeTest is BaseTest {
         otherLenderOffer.maker = otherLender;
         otherLenderOffer.ratifier = address(dummyRatifier);
         otherLenderOffer.receiverIfMakerIsSeller = otherLender;
-        otherLenderOffer.maxUnits = type(uint256).max;
+        otherLenderOffer.maxUnits = type(uint128).max;
         otherLenderOffer.continuousFeeCap = type(uint256).max;
         otherLenderOffer.market = market;
         otherLenderOffer.expiry = vm.getBlockTimestamp() + 200;
@@ -85,7 +85,7 @@ contract TakeTest is BaseTest {
         borrowerOffer.maker = borrower;
         borrowerOffer.ratifier = address(dummyRatifier);
         borrowerOffer.receiverIfMakerIsSeller = borrower;
-        borrowerOffer.maxUnits = type(uint256).max;
+        borrowerOffer.maxUnits = type(uint128).max;
         borrowerOffer.continuousFeeCap = type(uint256).max;
         borrowerOffer.market = market;
         borrowerOffer.expiry = vm.getBlockTimestamp() + 200;
@@ -94,7 +94,7 @@ contract TakeTest is BaseTest {
         otherBorrowerOffer.buy = true;
         otherBorrowerOffer.maker = otherBorrower;
         otherBorrowerOffer.ratifier = address(dummyRatifier);
-        otherBorrowerOffer.maxUnits = type(uint256).max;
+        otherBorrowerOffer.maxUnits = type(uint128).max;
         otherBorrowerOffer.continuousFeeCap = type(uint256).max;
         otherBorrowerOffer.market = market;
         otherBorrowerOffer.expiry = vm.getBlockTimestamp() + 200;
@@ -126,7 +126,7 @@ contract TakeTest is BaseTest {
         vm.assume(price > 0.01 ether); // keep price > settlement fee.
         existingDebt = bound(existingDebt, 1e8, units - 1e8);
         existingCredit = bound(existingCredit, 1e8, units - 1);
-        existingConsumed = bound(existingConsumed, 1, type(uint128).max);
+        existingConsumed = bound(existingConsumed, 1, type(uint128).max - units);
 
         collateralize(market, lender, existingDebt);
         Offer memory buy0 = _setupMarketOffer(market, existingDebt);
@@ -270,7 +270,7 @@ contract TakeTest is BaseTest {
         uint256 actualOtherLenderCredit = midnight.credit(id, otherLender);
         deal(address(loanToken), lender, buyerAssets + 1);
         otherLenderOffer.buy = false;
-        otherLenderOffer.maxUnits = type(uint256).max;
+        otherLenderOffer.maxUnits = type(uint128).max;
         otherLenderOffer.tick = tick;
         uint256 totalUnitsBefore = midnight.totalUnits(id);
 
@@ -293,7 +293,7 @@ contract TakeTest is BaseTest {
         setupOtherUsers(market, otherLenderUnits);
         uint256 actualOtherLenderCredit = midnight.credit(id, otherLender);
         deal(address(loanToken), lender, buyerAssets + 1);
-        lenderOffer.maxUnits = type(uint256).max;
+        lenderOffer.maxUnits = type(uint128).max;
         lenderOffer.tick = tick;
         uint256 totalUnitsBefore = midnight.totalUnits(id);
 
@@ -336,7 +336,7 @@ contract TakeTest is BaseTest {
         setupOtherUsers(market, existingUnits);
         uint256 otherBorrowerDebt = midnight.debt(id, otherBorrower);
         collateralize(market, borrower, units);
-        borrowerOffer.maxUnits = type(uint256).max;
+        borrowerOffer.maxUnits = type(uint128).max;
         borrowerOffer.tick = tick;
         uint256 price = TickLib.tickToPrice(tick);
         deal(address(loanToken), otherBorrower, units.mulDivUp(price, WAD));
@@ -356,7 +356,7 @@ contract TakeTest is BaseTest {
         setupOtherUsers(market, existingUnits);
         uint256 otherBorrowerDebt = midnight.debt(id, otherBorrower);
         collateralize(market, borrower, units);
-        otherBorrowerOffer.maxUnits = type(uint256).max;
+        otherBorrowerOffer.maxUnits = type(uint128).max;
         otherBorrowerOffer.tick = tick;
         uint256 totalUnitsBefore = midnight.totalUnits(id);
 
@@ -401,7 +401,7 @@ contract TakeTest is BaseTest {
         uint256 otherLenderCredit = midnight.credit(id, otherLender);
         uint256 otherBorrowerDebt = midnight.debt(id, otherBorrower);
 
-        otherLenderOffer.maxUnits = type(uint256).max;
+        otherLenderOffer.maxUnits = type(uint128).max;
         otherLenderOffer.tick = tick;
         deal(address(loanToken), otherBorrower, buyerAssets);
 
@@ -424,7 +424,7 @@ contract TakeTest is BaseTest {
         uint256 otherLenderCredit = midnight.credit(id, otherLender);
         uint256 otherBorrowerDebt = midnight.debt(id, otherBorrower);
 
-        otherBorrowerOffer.maxUnits = type(uint256).max;
+        otherBorrowerOffer.maxUnits = type(uint128).max;
         otherBorrowerOffer.tick = tick;
 
         take(units, otherLender, otherBorrowerOffer);
@@ -440,7 +440,7 @@ contract TakeTest is BaseTest {
         uint256 timestamp = market.maturity + 1;
         vm.warp(timestamp);
         borrowerOffer.expiry = timestamp;
-        borrowerOffer.maxUnits = units;
+        borrowerOffer.maxUnits = uint128(units);
         deal(address(loanToken), lender, units);
         collateralize(market, borrower, units);
 
@@ -453,7 +453,7 @@ contract TakeTest is BaseTest {
         uint256 timestamp = market.maturity + 1;
         vm.warp(timestamp);
         lenderOffer.expiry = timestamp;
-        lenderOffer.maxUnits = units;
+        lenderOffer.maxUnits = uint128(units);
         deal(address(loanToken), lender, units);
         collateralize(market, borrower, units);
 
@@ -472,7 +472,7 @@ contract TakeTest is BaseTest {
         uint256 timestamp = market.maturity + 1;
         vm.warp(timestamp);
         otherLenderOffer.expiry = timestamp;
-        otherLenderOffer.maxUnits = units;
+        otherLenderOffer.maxUnits = uint128(units);
         deal(address(loanToken), lender, units);
 
         take(units, lender, otherLenderOffer);
@@ -495,7 +495,7 @@ contract TakeTest is BaseTest {
         uint256 timestamp = market.maturity + 1;
         vm.warp(timestamp);
         lenderOffer.expiry = timestamp;
-        lenderOffer.maxUnits = units;
+        lenderOffer.maxUnits = uint128(units);
         deal(address(loanToken), lender, units);
 
         take(units, otherLender, lenderOffer);
@@ -514,7 +514,7 @@ contract TakeTest is BaseTest {
         uint256 timestamp = market.maturity + 1;
         vm.warp(timestamp);
         borrowerOffer.expiry = timestamp;
-        borrowerOffer.maxUnits = units;
+        borrowerOffer.maxUnits = uint128(units);
         deal(address(loanToken), otherBorrower, units);
         collateralize(market, borrower, units);
 
@@ -529,7 +529,7 @@ contract TakeTest is BaseTest {
         uint256 timestamp = market.maturity + 1;
         vm.warp(timestamp);
         otherBorrowerOffer.expiry = timestamp;
-        otherBorrowerOffer.maxUnits = units;
+        otherBorrowerOffer.maxUnits = uint128(units);
         deal(address(loanToken), otherBorrower, units);
         collateralize(market, borrower, units);
 
@@ -548,7 +548,7 @@ contract TakeTest is BaseTest {
         uint256 timestamp = market.maturity + 1;
         vm.warp(timestamp);
         otherLenderOffer.expiry = timestamp;
-        otherLenderOffer.maxUnits = units;
+        otherLenderOffer.maxUnits = uint128(units);
         deal(address(loanToken), otherBorrower, units);
 
         take(units, otherBorrower, otherLenderOffer);
@@ -569,7 +569,7 @@ contract TakeTest is BaseTest {
         uint256 timestamp = market.maturity + 1;
         vm.warp(timestamp);
         otherBorrowerOffer.expiry = timestamp;
-        otherBorrowerOffer.maxUnits = units;
+        otherBorrowerOffer.maxUnits = uint128(units);
         deal(address(loanToken), otherBorrower, units);
 
         take(units, otherLender, otherBorrowerOffer);
@@ -586,7 +586,7 @@ contract TakeTest is BaseTest {
         exitUnits = bound(exitUnits, 1, existingUnits);
         setupOtherUsers(market, existingUnits);
 
-        otherBorrowerOffer.maxUnits = exitUnits;
+        otherBorrowerOffer.maxUnits = uint128(exitUnits);
         otherBorrowerOffer.reduceOnly = true;
 
         uint256 price = TickLib.tickToPrice(MAX_TICK);
@@ -609,7 +609,7 @@ contract TakeTest is BaseTest {
         exitUnits = bound(exitUnits, existingUnits + 1, maxAssets);
         setupOtherUsers(market, existingUnits);
 
-        otherBorrowerOffer.maxUnits = exitUnits;
+        otherBorrowerOffer.maxUnits = uint128(exitUnits);
         otherBorrowerOffer.reduceOnly = true;
 
         vm.expectRevert(IMidnight.MakerCreditOrDebtIncreased.selector);
@@ -621,7 +621,7 @@ contract TakeTest is BaseTest {
         exitUnits = bound(exitUnits, 1, existingUnits);
         setupOtherUsers(market, existingUnits);
 
-        otherLenderOffer.maxUnits = exitUnits;
+        otherLenderOffer.maxUnits = uint128(exitUnits);
         otherLenderOffer.reduceOnly = true;
 
         uint256 price = TickLib.tickToPrice(MAX_TICK);
@@ -644,7 +644,7 @@ contract TakeTest is BaseTest {
         exitUnits = bound(exitUnits, existingUnits + 1, maxAssets);
         setupOtherUsers(market, existingUnits);
 
-        otherLenderOffer.maxUnits = exitUnits;
+        otherLenderOffer.maxUnits = uint128(exitUnits);
         otherLenderOffer.reduceOnly = true;
 
         vm.expectRevert(IMidnight.MakerCreditOrDebtIncreased.selector);
@@ -660,7 +660,7 @@ contract TakeTest is BaseTest {
         offerUnits = bound(offerUnits, max(units, 1), maxAssets - 1);
         secondRevertingTake = bound(secondRevertingTake, offerUnits - units + 1, maxAssets);
         secondPassingTake = bound(secondPassingTake, 0, offerUnits - units);
-        borrowerOffer.maxUnits = offerUnits;
+        borrowerOffer.maxUnits = uint128(offerUnits);
         borrowerOffer.tick = MAX_TICK;
         deal(address(loanToken), lender, offerUnits);
         collateralize(market, borrower, offerUnits);
@@ -680,7 +680,7 @@ contract TakeTest is BaseTest {
         offerUnits = bound(offerUnits, max(units, 1), maxAssets - 1);
         secondRevertingTake = bound(secondRevertingTake, offerUnits - units + 1, maxAssets);
         secondPassingTake = bound(secondPassingTake, 0, offerUnits - units);
-        lenderOffer.maxUnits = offerUnits;
+        lenderOffer.maxUnits = uint128(offerUnits);
         lenderOffer.tick = MAX_TICK;
         deal(address(loanToken), lender, offerUnits);
         collateralize(market, borrower, offerUnits);
@@ -697,7 +697,7 @@ contract TakeTest is BaseTest {
         firstFill = bound(firstFill, 0, maxAssets);
         secondFill = bound(secondFill, 0, maxAssets);
         vm.assume(firstFill + secondFill > 0); // an offer must have a nonzero cap
-        borrowerOffer.maxUnits = firstFill + secondFill;
+        borrowerOffer.maxUnits = uint128(firstFill + secondFill);
         borrowerOffer.tick = MAX_TICK;
         Offer memory borrowerOffer2 = borrowerOffer;
         borrowerOffer2.market.maturity = market.maturity + 100;
@@ -717,7 +717,7 @@ contract TakeTest is BaseTest {
         firstFill = bound(firstFill, 0, maxAssets);
         secondFill = bound(secondFill, 0, maxAssets);
         vm.assume(firstFill + secondFill > 0); // an offer must have a nonzero cap
-        lenderOffer.maxUnits = firstFill + secondFill;
+        lenderOffer.maxUnits = uint128(firstFill + secondFill);
         lenderOffer.tick = MAX_TICK;
         Offer memory lenderOffer2 = lenderOffer;
         lenderOffer2.market.maturity = market.maturity + 100;
@@ -745,9 +745,9 @@ contract TakeTest is BaseTest {
         vm.assume(price1 > price2);
         vm.assume(price1 > 0.5 ether);
         vm.assume(price2 > 0.5 ether);
-        borrowerOffer.maxUnits = units;
+        borrowerOffer.maxUnits = uint128(units);
         borrowerOffer.tick = tick1;
-        lenderOffer.maxUnits = units;
+        lenderOffer.maxUnits = uint128(units);
         lenderOffer.tick = tick2;
 
         deal(address(loanToken), lender, units.mulDivDown(price2, WAD));
@@ -771,9 +771,9 @@ contract TakeTest is BaseTest {
         vm.assume(price2 > price1);
         vm.assume(price1 > 0.5 ether);
         vm.assume(price2 > 0.5 ether);
-        borrowerOffer.maxUnits = units;
+        borrowerOffer.maxUnits = uint128(units);
         borrowerOffer.tick = tick1;
-        lenderOffer.maxUnits = units;
+        lenderOffer.maxUnits = uint128(units);
         lenderOffer.tick = tick2;
 
         deal(address(loanToken), lender, units.mulDivDown(price2, WAD));
@@ -818,7 +818,7 @@ contract TakeTest is BaseTest {
         units = bound(units, 1, maxAssets);
         collateralized = bound(collateralized, 0, units / 2);
         tick = bound(tick, 0, MAX_TICK);
-        borrowerOffer.maxUnits = units;
+        borrowerOffer.maxUnits = uint128(units);
         borrowerOffer.tick = tick;
         uint256 price = TickLib.tickToPrice(tick);
         deal(address(loanToken), lender, units.mulDivUp(price, WAD));
@@ -832,7 +832,7 @@ contract TakeTest is BaseTest {
         units = bound(units, 1, maxAssets);
         collateralized = bound(collateralized, 0, units / 2);
         tick = bound(tick, 0, MAX_TICK);
-        lenderOffer.maxUnits = units;
+        lenderOffer.maxUnits = uint128(units);
         lenderOffer.tick = tick;
         uint256 price = TickLib.tickToPrice(tick);
         deal(address(loanToken), lender, units.mulDivDown(price, WAD));
@@ -927,7 +927,7 @@ contract TakeTest is BaseTest {
         uint256 expectedSellerAssets = units.mulDivUp(price, WAD);
 
         borrowerOffer.maxUnits = 0;
-        borrowerOffer.maxAssets = expectedSellerAssets;
+        borrowerOffer.maxAssets = uint128(expectedSellerAssets);
 
         (, uint256 sellerAssets) = take(units, lender, borrowerOffer);
         assertEq(sellerAssets, expectedSellerAssets);
@@ -941,7 +941,7 @@ contract TakeTest is BaseTest {
         uint256 expectedBuyerAssets = units.mulDivDown(price, WAD);
 
         lenderOffer.maxUnits = 0;
-        lenderOffer.maxAssets = expectedBuyerAssets;
+        lenderOffer.maxAssets = uint128(expectedBuyerAssets);
 
         (uint256 buyerAssets,) = take(units, borrower, lenderOffer);
         assertEq(buyerAssets, expectedBuyerAssets);
@@ -1203,7 +1203,7 @@ contract TakeTest is BaseTest {
         uint256 collateral = units.mulDivUp(WAD, market.collateralParams[0].lltv);
         borrowerOffer.callback = address(new BorrowCallback());
         borrowerOffer.callbackData = abi.encode(0, collateral, data);
-        borrowerOffer.maxUnits = type(uint256).max;
+        borrowerOffer.maxUnits = type(uint128).max;
         borrowerOffer.tick = MAX_TICK;
         uint256 price = TickLib.tickToPrice(MAX_TICK);
         deal(address(loanToken), lender, units.mulDivUp(price, WAD));
@@ -1240,7 +1240,7 @@ contract TakeTest is BaseTest {
         uint256 collateral = units.mulDivUp(WAD, market.collateralParams[0].lltv);
         addCredit(borrower, units);
 
-        lenderOffer.maxUnits = type(uint256).max;
+        lenderOffer.maxUnits = type(uint128).max;
         lenderOffer.tick = MAX_TICK;
         uint256 price = TickLib.tickToPrice(MAX_TICK);
         address callback = address(new BorrowCallback());
@@ -1272,7 +1272,7 @@ contract TakeTest is BaseTest {
         uint256 units = 100e18;
         uint256 repaidUnits = 1e18;
         uint256 collateral = units.mulDivUp(WAD, market.collateralParams[0].lltv);
-        lenderOffer.maxUnits = units;
+        lenderOffer.maxUnits = uint128(units);
         lenderOffer.tick = MAX_TICK;
         uint256 price = TickLib.tickToPrice(MAX_TICK);
         ReentrantLiquidateBorrowCallback callback = new ReentrantLiquidateBorrowCallback();
@@ -1303,7 +1303,7 @@ contract TakeTest is BaseTest {
         uint256 repaidUnits = 1e18;
         uint256 collateral = units.mulDivUp(WAD, market.collateralParams[0].lltv);
         uint256 price = TickLib.tickToPrice(MAX_TICK);
-        lenderOffer.maxUnits = 2 * units;
+        lenderOffer.maxUnits = uint128(2 * units);
         lenderOffer.tick = MAX_TICK;
 
         NestedTakeReentrantLiquidateCallback callback = new NestedTakeReentrantLiquidateCallback();
@@ -1330,7 +1330,7 @@ contract TakeTest is BaseTest {
 
     function testSellSellerCallbackRevertsOnInvalidReturn(uint256 units) public {
         units = bound(units, 1, maxAssets);
-        lenderOffer.maxUnits = units;
+        lenderOffer.maxUnits = uint128(units);
         lenderOffer.tick = MAX_TICK;
         uint256 price = TickLib.tickToPrice(MAX_TICK);
         deal(address(loanToken), lender, units.mulDivDown(price, WAD));
@@ -1351,7 +1351,7 @@ contract TakeTest is BaseTest {
         lenderOffer.callback = address(new LendCallback());
         lenderOffer.callbackData = data;
         lenderOffer.maker = address(otherLender);
-        lenderOffer.maxUnits = type(uint256).max;
+        lenderOffer.maxUnits = type(uint128).max;
         lenderOffer.tick = MAX_TICK;
         deal(address(loanToken), lenderOffer.callback, assets);
         collateralize(market, borrower, units);
@@ -1378,7 +1378,7 @@ contract TakeTest is BaseTest {
         uint256 price = TickLib.tickToPrice(MAX_TICK);
         uint256 assets = units.mulDivUp(price, WAD);
         address callback = address(new LendCallback());
-        borrowerOffer.maxUnits = type(uint256).max;
+        borrowerOffer.maxUnits = type(uint128).max;
         borrowerOffer.tick = MAX_TICK;
         deal(address(loanToken), callback, assets);
         collateralize(market, borrower, units);
@@ -1411,7 +1411,7 @@ contract TakeTest is BaseTest {
     function testPriceZeroNoSettlementFeeSell() public {
         uint256 units = 1e18;
         borrowerOffer.tick = 0;
-        borrowerOffer.maxUnits = units;
+        borrowerOffer.maxUnits = uint128(units);
         collateralize(market, borrower, units);
         (uint256 buyerAssets, uint256 sellerAssets) = take(units, lender, borrowerOffer);
         assertEq(buyerAssets, 0, "buyerAssets");
@@ -1426,7 +1426,7 @@ contract TakeTest is BaseTest {
         midnight.setMarketSettlementFee(id, 1, 1e12);
         uint256 units = 1e18;
         lenderOffer.tick = 0;
-        lenderOffer.maxUnits = units;
+        lenderOffer.maxUnits = uint128(units);
         collateralize(market, borrower, units);
         vm.expectRevert();
         take(units, borrower, lenderOffer);
@@ -1439,7 +1439,7 @@ contract TakeTest is BaseTest {
         uint256 fee = midnight.settlementFee(id, market.maturity - vm.getBlockTimestamp());
         uint256 units = 1e18;
         borrowerOffer.tick = 0;
-        borrowerOffer.maxUnits = units;
+        borrowerOffer.maxUnits = uint128(units);
         uint256 expectedBuyerAssets = units.mulDivUp(fee, WAD);
         deal(address(loanToken), lender, expectedBuyerAssets);
         collateralize(market, borrower, units);
@@ -1458,7 +1458,7 @@ contract TakeTest is BaseTest {
         zeroOffer.buy = true;
         zeroOffer.maker = address(0);
         zeroOffer.ratifier = address(dummyRatifier);
-        zeroOffer.maxUnits = units;
+        zeroOffer.maxUnits = uint128(units);
         zeroOffer.market = market;
         zeroOffer.expiry = vm.getBlockTimestamp() + 200;
         zeroOffer.tick = 0; // 0 price so any units transfer 0 assets
@@ -1473,7 +1473,7 @@ contract TakeTest is BaseTest {
 
     function testBuyBuyerCallbackRevertsOnInvalidReturn(uint256 units) public {
         units = bound(units, 1, maxAssets);
-        borrowerOffer.maxUnits = units;
+        borrowerOffer.maxUnits = uint128(units);
         borrowerOffer.tick = MAX_TICK;
         uint256 price = TickLib.tickToPrice(MAX_TICK);
         uint256 assets = units.mulDivUp(price, WAD);

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -440,7 +440,7 @@ contract TakeTest is BaseTest {
         uint256 timestamp = market.maturity + 1;
         vm.warp(timestamp);
         borrowerOffer.expiry = timestamp;
-        borrowerOffer.maxUnits = uint128(units);
+        borrowerOffer.maxUnits = units.toUint128();
         deal(address(loanToken), lender, units);
         collateralize(market, borrower, units);
 
@@ -453,7 +453,7 @@ contract TakeTest is BaseTest {
         uint256 timestamp = market.maturity + 1;
         vm.warp(timestamp);
         lenderOffer.expiry = timestamp;
-        lenderOffer.maxUnits = uint128(units);
+        lenderOffer.maxUnits = units.toUint128();
         deal(address(loanToken), lender, units);
         collateralize(market, borrower, units);
 
@@ -472,7 +472,7 @@ contract TakeTest is BaseTest {
         uint256 timestamp = market.maturity + 1;
         vm.warp(timestamp);
         otherLenderOffer.expiry = timestamp;
-        otherLenderOffer.maxUnits = uint128(units);
+        otherLenderOffer.maxUnits = units.toUint128();
         deal(address(loanToken), lender, units);
 
         take(units, lender, otherLenderOffer);
@@ -495,7 +495,7 @@ contract TakeTest is BaseTest {
         uint256 timestamp = market.maturity + 1;
         vm.warp(timestamp);
         lenderOffer.expiry = timestamp;
-        lenderOffer.maxUnits = uint128(units);
+        lenderOffer.maxUnits = units.toUint128();
         deal(address(loanToken), lender, units);
 
         take(units, otherLender, lenderOffer);
@@ -514,7 +514,7 @@ contract TakeTest is BaseTest {
         uint256 timestamp = market.maturity + 1;
         vm.warp(timestamp);
         borrowerOffer.expiry = timestamp;
-        borrowerOffer.maxUnits = uint128(units);
+        borrowerOffer.maxUnits = units.toUint128();
         deal(address(loanToken), otherBorrower, units);
         collateralize(market, borrower, units);
 
@@ -529,7 +529,7 @@ contract TakeTest is BaseTest {
         uint256 timestamp = market.maturity + 1;
         vm.warp(timestamp);
         otherBorrowerOffer.expiry = timestamp;
-        otherBorrowerOffer.maxUnits = uint128(units);
+        otherBorrowerOffer.maxUnits = units.toUint128();
         deal(address(loanToken), otherBorrower, units);
         collateralize(market, borrower, units);
 
@@ -548,7 +548,7 @@ contract TakeTest is BaseTest {
         uint256 timestamp = market.maturity + 1;
         vm.warp(timestamp);
         otherLenderOffer.expiry = timestamp;
-        otherLenderOffer.maxUnits = uint128(units);
+        otherLenderOffer.maxUnits = units.toUint128();
         deal(address(loanToken), otherBorrower, units);
 
         take(units, otherBorrower, otherLenderOffer);
@@ -569,7 +569,7 @@ contract TakeTest is BaseTest {
         uint256 timestamp = market.maturity + 1;
         vm.warp(timestamp);
         otherBorrowerOffer.expiry = timestamp;
-        otherBorrowerOffer.maxUnits = uint128(units);
+        otherBorrowerOffer.maxUnits = units.toUint128();
         deal(address(loanToken), otherBorrower, units);
 
         take(units, otherLender, otherBorrowerOffer);
@@ -586,7 +586,7 @@ contract TakeTest is BaseTest {
         exitUnits = bound(exitUnits, 1, existingUnits);
         setupOtherUsers(market, existingUnits);
 
-        otherBorrowerOffer.maxUnits = uint128(exitUnits);
+        otherBorrowerOffer.maxUnits = exitUnits.toUint128();
         otherBorrowerOffer.reduceOnly = true;
 
         uint256 price = TickLib.tickToPrice(MAX_TICK);
@@ -609,7 +609,7 @@ contract TakeTest is BaseTest {
         exitUnits = bound(exitUnits, existingUnits + 1, maxAssets);
         setupOtherUsers(market, existingUnits);
 
-        otherBorrowerOffer.maxUnits = uint128(exitUnits);
+        otherBorrowerOffer.maxUnits = exitUnits.toUint128();
         otherBorrowerOffer.reduceOnly = true;
 
         vm.expectRevert(IMidnight.MakerCreditOrDebtIncreased.selector);
@@ -621,7 +621,7 @@ contract TakeTest is BaseTest {
         exitUnits = bound(exitUnits, 1, existingUnits);
         setupOtherUsers(market, existingUnits);
 
-        otherLenderOffer.maxUnits = uint128(exitUnits);
+        otherLenderOffer.maxUnits = exitUnits.toUint128();
         otherLenderOffer.reduceOnly = true;
 
         uint256 price = TickLib.tickToPrice(MAX_TICK);
@@ -644,7 +644,7 @@ contract TakeTest is BaseTest {
         exitUnits = bound(exitUnits, existingUnits + 1, maxAssets);
         setupOtherUsers(market, existingUnits);
 
-        otherLenderOffer.maxUnits = uint128(exitUnits);
+        otherLenderOffer.maxUnits = exitUnits.toUint128();
         otherLenderOffer.reduceOnly = true;
 
         vm.expectRevert(IMidnight.MakerCreditOrDebtIncreased.selector);
@@ -660,7 +660,7 @@ contract TakeTest is BaseTest {
         offerUnits = bound(offerUnits, max(units, 1), maxAssets - 1);
         secondRevertingTake = bound(secondRevertingTake, offerUnits - units + 1, maxAssets);
         secondPassingTake = bound(secondPassingTake, 0, offerUnits - units);
-        borrowerOffer.maxUnits = uint128(offerUnits);
+        borrowerOffer.maxUnits = offerUnits.toUint128();
         borrowerOffer.tick = MAX_TICK;
         deal(address(loanToken), lender, offerUnits);
         collateralize(market, borrower, offerUnits);
@@ -680,7 +680,7 @@ contract TakeTest is BaseTest {
         offerUnits = bound(offerUnits, max(units, 1), maxAssets - 1);
         secondRevertingTake = bound(secondRevertingTake, offerUnits - units + 1, maxAssets);
         secondPassingTake = bound(secondPassingTake, 0, offerUnits - units);
-        lenderOffer.maxUnits = uint128(offerUnits);
+        lenderOffer.maxUnits = offerUnits.toUint128();
         lenderOffer.tick = MAX_TICK;
         deal(address(loanToken), lender, offerUnits);
         collateralize(market, borrower, offerUnits);
@@ -697,7 +697,7 @@ contract TakeTest is BaseTest {
         firstFill = bound(firstFill, 0, maxAssets);
         secondFill = bound(secondFill, 0, maxAssets);
         vm.assume(firstFill + secondFill > 0); // an offer must have a nonzero cap
-        borrowerOffer.maxUnits = uint128(firstFill + secondFill);
+        borrowerOffer.maxUnits = (firstFill + secondFill).toUint128();
         borrowerOffer.tick = MAX_TICK;
         Offer memory borrowerOffer2 = borrowerOffer;
         borrowerOffer2.market.maturity = market.maturity + 100;
@@ -717,7 +717,7 @@ contract TakeTest is BaseTest {
         firstFill = bound(firstFill, 0, maxAssets);
         secondFill = bound(secondFill, 0, maxAssets);
         vm.assume(firstFill + secondFill > 0); // an offer must have a nonzero cap
-        lenderOffer.maxUnits = uint128(firstFill + secondFill);
+        lenderOffer.maxUnits = (firstFill + secondFill).toUint128();
         lenderOffer.tick = MAX_TICK;
         Offer memory lenderOffer2 = lenderOffer;
         lenderOffer2.market.maturity = market.maturity + 100;
@@ -745,9 +745,9 @@ contract TakeTest is BaseTest {
         vm.assume(price1 > price2);
         vm.assume(price1 > 0.5 ether);
         vm.assume(price2 > 0.5 ether);
-        borrowerOffer.maxUnits = uint128(units);
+        borrowerOffer.maxUnits = units.toUint128();
         borrowerOffer.tick = tick1;
-        lenderOffer.maxUnits = uint128(units);
+        lenderOffer.maxUnits = units.toUint128();
         lenderOffer.tick = tick2;
 
         deal(address(loanToken), lender, units.mulDivDown(price2, WAD));
@@ -771,9 +771,9 @@ contract TakeTest is BaseTest {
         vm.assume(price2 > price1);
         vm.assume(price1 > 0.5 ether);
         vm.assume(price2 > 0.5 ether);
-        borrowerOffer.maxUnits = uint128(units);
+        borrowerOffer.maxUnits = units.toUint128();
         borrowerOffer.tick = tick1;
-        lenderOffer.maxUnits = uint128(units);
+        lenderOffer.maxUnits = units.toUint128();
         lenderOffer.tick = tick2;
 
         deal(address(loanToken), lender, units.mulDivDown(price2, WAD));
@@ -818,7 +818,7 @@ contract TakeTest is BaseTest {
         units = bound(units, 1, maxAssets);
         collateralized = bound(collateralized, 0, units / 2);
         tick = bound(tick, 0, MAX_TICK);
-        borrowerOffer.maxUnits = uint128(units);
+        borrowerOffer.maxUnits = units.toUint128();
         borrowerOffer.tick = tick;
         uint256 price = TickLib.tickToPrice(tick);
         deal(address(loanToken), lender, units.mulDivUp(price, WAD));
@@ -832,7 +832,7 @@ contract TakeTest is BaseTest {
         units = bound(units, 1, maxAssets);
         collateralized = bound(collateralized, 0, units / 2);
         tick = bound(tick, 0, MAX_TICK);
-        lenderOffer.maxUnits = uint128(units);
+        lenderOffer.maxUnits = units.toUint128();
         lenderOffer.tick = tick;
         uint256 price = TickLib.tickToPrice(tick);
         deal(address(loanToken), lender, units.mulDivDown(price, WAD));
@@ -927,7 +927,7 @@ contract TakeTest is BaseTest {
         uint256 expectedSellerAssets = units.mulDivUp(price, WAD);
 
         borrowerOffer.maxUnits = 0;
-        borrowerOffer.maxAssets = uint128(expectedSellerAssets);
+        borrowerOffer.maxAssets = expectedSellerAssets.toUint128();
 
         (, uint256 sellerAssets) = take(units, lender, borrowerOffer);
         assertEq(sellerAssets, expectedSellerAssets);
@@ -941,7 +941,7 @@ contract TakeTest is BaseTest {
         uint256 expectedBuyerAssets = units.mulDivDown(price, WAD);
 
         lenderOffer.maxUnits = 0;
-        lenderOffer.maxAssets = uint128(expectedBuyerAssets);
+        lenderOffer.maxAssets = expectedBuyerAssets.toUint128();
 
         (uint256 buyerAssets,) = take(units, borrower, lenderOffer);
         assertEq(buyerAssets, expectedBuyerAssets);
@@ -1306,7 +1306,7 @@ contract TakeTest is BaseTest {
         uint256 units = 100e18;
         uint256 repaidUnits = 1e18;
         uint256 collateral = units.mulDivUp(WAD, market.collateralParams[0].lltv);
-        lenderOffer.maxUnits = uint128(units);
+        lenderOffer.maxUnits = units.toUint128();
         lenderOffer.tick = MAX_TICK;
         uint256 price = TickLib.tickToPrice(MAX_TICK);
         ReentrantLiquidateBorrowCallback callback = new ReentrantLiquidateBorrowCallback();
@@ -1337,7 +1337,7 @@ contract TakeTest is BaseTest {
         uint256 repaidUnits = 1e18;
         uint256 collateral = units.mulDivUp(WAD, market.collateralParams[0].lltv);
         uint256 price = TickLib.tickToPrice(MAX_TICK);
-        lenderOffer.maxUnits = uint128(2 * units);
+        lenderOffer.maxUnits = (2 * units).toUint128();
         lenderOffer.tick = MAX_TICK;
 
         NestedTakeReentrantLiquidateCallback callback = new NestedTakeReentrantLiquidateCallback();
@@ -1364,7 +1364,7 @@ contract TakeTest is BaseTest {
 
     function testSellSellerCallbackRevertsOnInvalidReturn(uint256 units) public {
         units = bound(units, 1, maxAssets);
-        lenderOffer.maxUnits = uint128(units);
+        lenderOffer.maxUnits = units.toUint128();
         lenderOffer.tick = MAX_TICK;
         uint256 price = TickLib.tickToPrice(MAX_TICK);
         deal(address(loanToken), lender, units.mulDivDown(price, WAD));
@@ -1445,7 +1445,7 @@ contract TakeTest is BaseTest {
     function testPriceZeroNoSettlementFeeSell() public {
         uint256 units = 1e18;
         borrowerOffer.tick = 0;
-        borrowerOffer.maxUnits = uint128(units);
+        borrowerOffer.maxUnits = units.toUint128();
         collateralize(market, borrower, units);
         (uint256 buyerAssets, uint256 sellerAssets) = take(units, lender, borrowerOffer);
         assertEq(buyerAssets, 0, "buyerAssets");
@@ -1460,7 +1460,7 @@ contract TakeTest is BaseTest {
         midnight.setMarketSettlementFee(id, 1, 1e12);
         uint256 units = 1e18;
         lenderOffer.tick = 0;
-        lenderOffer.maxUnits = uint128(units);
+        lenderOffer.maxUnits = units.toUint128();
         collateralize(market, borrower, units);
         vm.expectRevert();
         take(units, borrower, lenderOffer);
@@ -1473,7 +1473,7 @@ contract TakeTest is BaseTest {
         uint256 fee = midnight.settlementFee(id, market.maturity - vm.getBlockTimestamp());
         uint256 units = 1e18;
         borrowerOffer.tick = 0;
-        borrowerOffer.maxUnits = uint128(units);
+        borrowerOffer.maxUnits = units.toUint128();
         uint256 expectedBuyerAssets = units.mulDivUp(fee, WAD);
         deal(address(loanToken), lender, expectedBuyerAssets);
         collateralize(market, borrower, units);
@@ -1492,7 +1492,7 @@ contract TakeTest is BaseTest {
         zeroOffer.buy = true;
         zeroOffer.maker = address(0);
         zeroOffer.ratifier = address(dummyRatifier);
-        zeroOffer.maxUnits = uint128(units);
+        zeroOffer.maxUnits = units.toUint128();
         zeroOffer.market = market;
         zeroOffer.expiry = vm.getBlockTimestamp() + 200;
         zeroOffer.tick = 0; // 0 price so any units transfer 0 assets
@@ -1507,7 +1507,7 @@ contract TakeTest is BaseTest {
 
     function testBuyBuyerCallbackRevertsOnInvalidReturn(uint256 units) public {
         units = bound(units, 1, maxAssets);
-        borrowerOffer.maxUnits = uint128(units);
+        borrowerOffer.maxUnits = units.toUint128();
         borrowerOffer.tick = MAX_TICK;
         uint256 price = TickLib.tickToPrice(MAX_TICK);
         uint256 assets = units.mulDivUp(price, WAD);

--- a/test/TickGatingTest.sol
+++ b/test/TickGatingTest.sol
@@ -52,7 +52,7 @@ contract TickGatingTest is BaseTest {
         offer.buy = true;
         offer.maker = lender;
         offer.ratifier = address(dummyRatifier);
-        offer.maxUnits = type(uint256).max;
+        offer.maxUnits = type(uint128).max;
         offer.expiry = vm.getBlockTimestamp() + 200;
         offer.tick = tick;
     }

--- a/test/frontend/sign-root.ts
+++ b/test/frontend/sign-root.ts
@@ -54,8 +54,8 @@ function buildTypes(height: number) {
       { name: "receiverIfMakerIsSeller", type: "address" },
       { name: "ratifier", type: "address" },
       { name: "reduceOnly", type: "bool" },
-      { name: "maxUnits", type: "uint256" },
-      { name: "maxAssets", type: "uint256" },
+      { name: "maxUnits", type: "uint128" },
+      { name: "maxAssets", type: "uint128" },
       { name: "continuousFeeCap", type: "uint256" },
     ],
   };


### PR DESCRIPTION
[TRST-R-15](https://app.notion.com/p/morpho-labs/Trusted-Midnight-Bundles-audit-answer-38ed69939e6d808692b7eb2cf0930e04?source=copy_link#38ed69939e6d808f84bae3c3d27b0a64)

an offer with maxAssets or maxUnits = type(uint256).max is very annoying because multiplying this amount will overflow. we needed to document this, as it created edge-cases in TakeAmountsLib and ConsumableUnitsLib. Then we thought that we would rather constrain more maxAssets and maxUnits such that it's always multipliable by an other uint128. And then for consistency changed consumed to uint128.