### PR TITLE
License header

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -10,7 +10,7 @@ Parameters
 Licensor:             Morpho Association
 
 Licensed Work:        Morpho Midnight
-                      The Licensed Work is (c) 2025 Morpho Association
+                      The Licensed Work is (c) 2026 Morpho Association
 
 Additional Use Grant: Any uses listed and defined at
                       morpho-midnight-license-grants.morpho.eth

--- a/certora/helpers/FlashLiquidateCallback.sol
+++ b/certora/helpers/FlashLiquidateCallback.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {Market} from "../../src/interfaces/IMidnight.sol";

--- a/certora/helpers/Havoc.sol
+++ b/certora/helpers/Havoc.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 interface IHavoc {

--- a/certora/helpers/MidnightWrapper.sol
+++ b/certora/helpers/MidnightWrapper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {Midnight} from "../../src/Midnight.sol";

--- a/certora/helpers/MulDiv.sol
+++ b/certora/helpers/MulDiv.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {UtilsLib} from "../../src/libraries/UtilsLib.sol";

--- a/certora/helpers/TakeAmountsLibHarness.sol
+++ b/certora/helpers/TakeAmountsLibHarness.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {Offer} from "../../src/interfaces/IMidnight.sol";

--- a/certora/helpers/TickLibWrapper.sol
+++ b/certora/helpers/TickLibWrapper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {TickLib, MAX_TICK, LN_ONE_PLUS_DELTA, PRICE_ROUNDING_STEP} from "../../src/libraries/TickLib.sol";

--- a/certora/helpers/Utils.sol
+++ b/certora/helpers/Utils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {Offer, Market} from "../../src/interfaces/IMidnight.sol";

--- a/certora/specs/BalanceEffects.spec
+++ b/certora/specs/BalanceEffects.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/BalanceEffects.spec
+++ b/certora/specs/BalanceEffects.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/Bitmap.spec
+++ b/certora/specs/Bitmap.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 methods {
     function getBit(uint128 bitmap, uint256 bit) external returns (bool) envfree;

--- a/certora/specs/Bitmap.spec
+++ b/certora/specs/Bitmap.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 methods {
     function getBit(uint128 bitmap, uint256 bit) external returns (bool) envfree;

--- a/certora/specs/BitmapSummaries.spec
+++ b/certora/specs/BitmapSummaries.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 methods {
     function UtilsLib.setBit(uint128 bitmap, uint256 bit) internal returns (uint128) => summarySetBit(bitmap, bit);

--- a/certora/specs/BitmapSummaries.spec
+++ b/certora/specs/BitmapSummaries.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 methods {
     function UtilsLib.setBit(uint128 bitmap, uint256 bit) internal returns (uint128) => summarySetBit(bitmap, bit);

--- a/certora/specs/CollateralBitmap.spec
+++ b/certora/specs/CollateralBitmap.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 import "BitmapSummaries.spec";
 

--- a/certora/specs/CollateralBitmap.spec
+++ b/certora/specs/CollateralBitmap.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 import "BitmapSummaries.spec";
 

--- a/certora/specs/Consume.spec
+++ b/certora/specs/Consume.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;

--- a/certora/specs/Consume.spec
+++ b/certora/specs/Consume.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;

--- a/certora/specs/ContinuousFee.spec
+++ b/certora/specs/ContinuousFee.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;

--- a/certora/specs/ContinuousFee.spec
+++ b/certora/specs/ContinuousFee.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;

--- a/certora/specs/CreatedMarkets.spec
+++ b/certora/specs/CreatedMarkets.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/CreatedMarkets.spec
+++ b/certora/specs/CreatedMarkets.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/EcrecoverAuthorizer.spec
+++ b/certora/specs/EcrecoverAuthorizer.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 // Signature verification is verified in tests.
 

--- a/certora/specs/EcrecoverAuthorizer.spec
+++ b/certora/specs/EcrecoverAuthorizer.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 // Signature verification is verified in tests.
 

--- a/certora/specs/EmptyOffer.spec
+++ b/certora/specs/EmptyOffer.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/ExactMath.spec
+++ b/certora/specs/ExactMath.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 using MulDiv as MulDiv;
 

--- a/certora/specs/ExactMath.spec
+++ b/certora/specs/ExactMath.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 using MulDiv as MulDiv;
 

--- a/certora/specs/Healthiness.spec
+++ b/certora/specs/Healthiness.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 import "BitmapSummaries.spec";
 

--- a/certora/specs/Healthiness.spec
+++ b/certora/specs/Healthiness.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 import "BitmapSummaries.spec";
 

--- a/certora/specs/Liquidate.spec
+++ b/certora/specs/Liquidate.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;

--- a/certora/specs/Liquidate.spec
+++ b/certora/specs/Liquidate.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;

--- a/certora/specs/LiquidationBoundedByLIF.spec
+++ b/certora/specs/LiquidationBoundedByLIF.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 import "BitmapSummaries.spec";
 

--- a/certora/specs/LiquidationBoundedByLIF.spec
+++ b/certora/specs/LiquidationBoundedByLIF.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 import "BitmapSummaries.spec";
 

--- a/certora/specs/LiquidationProfitability.spec
+++ b/certora/specs/LiquidationProfitability.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/LiquidationProfitability.spec
+++ b/certora/specs/LiquidationProfitability.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/LossFactor.spec
+++ b/certora/specs/LossFactor.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/LossFactor.spec
+++ b/certora/specs/LossFactor.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/Midnight.spec
+++ b/certora/specs/Midnight.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/Midnight.spec
+++ b/certora/specs/Midnight.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/MulDiv.spec
+++ b/certora/specs/MulDiv.spec
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
+
 methods {
     function mulDivDown(uint256 a, uint256 b, uint256 d) external returns (uint256) envfree;
     function mulDivUp(uint256 a, uint256 b, uint256 d) external returns (uint256) envfree;

--- a/certora/specs/MulDiv.spec
+++ b/certora/specs/MulDiv.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 methods {
     function mulDivDown(uint256 a, uint256 b, uint256 d) external returns (uint256) envfree;

--- a/certora/specs/NoDebtWithoutCollateral.spec
+++ b/certora/specs/NoDebtWithoutCollateral.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 /* Proves: a position can never carry debt while having no active collateral bit, i.e.:
  *   position[id][user].collateralBitmap == 0  =>  position[id][user].debt == 0

--- a/certora/specs/NoDebtWithoutCollateral.spec
+++ b/certora/specs/NoDebtWithoutCollateral.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 /* Proves: a position can never carry debt while having no active collateral bit, i.e.:
  *   position[id][user].collateralBitmap == 0  =>  position[id][user].debt == 0

--- a/certora/specs/NoDivisionByZero.spec
+++ b/certora/specs/NoDivisionByZero.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 // Proves that no division by zero occurs in mulDivDown or mulDivUp.
 //

--- a/certora/specs/NoDivisionByZero.spec
+++ b/certora/specs/NoDivisionByZero.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 // Proves that no division by zero occurs in mulDivDown or mulDivUp.
 //

--- a/certora/specs/NoMultiplicationOverflow.spec
+++ b/certora/specs/NoMultiplicationOverflow.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 // Proves that successful calls do not overflow in mulDivDown or mulDivUp, given the oracle price is bounded.
 

--- a/certora/specs/NoMultiplicationOverflow.spec
+++ b/certora/specs/NoMultiplicationOverflow.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 // Proves that successful calls do not overflow in mulDivDown or mulDivUp, given the oracle price is bounded.
 

--- a/certora/specs/NotCreatedMarket.spec
+++ b/certora/specs/NotCreatedMarket.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;

--- a/certora/specs/NotCreatedMarket.spec
+++ b/certora/specs/NotCreatedMarket.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;

--- a/certora/specs/OnlyAuthorizedCanChange.spec
+++ b/certora/specs/OnlyAuthorizedCanChange.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;

--- a/certora/specs/OnlyAuthorizedCanChange.spec
+++ b/certora/specs/OnlyAuthorizedCanChange.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;

--- a/certora/specs/OnlyAuthorizedCanChangeUpdatedValues.spec
+++ b/certora/specs/OnlyAuthorizedCanChangeUpdatedValues.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/OnlyAuthorizedCanChangeUpdatedValues.spec
+++ b/certora/specs/OnlyAuthorizedCanChangeUpdatedValues.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/OnlyExplicitPayerCanLoseTokens.spec
+++ b/certora/specs/OnlyExplicitPayerCanLoseTokens.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 using Utils as Utils;
 using Havoc as callbackHavoc;

--- a/certora/specs/OnlyExplicitPayerCanLoseTokens.spec
+++ b/certora/specs/OnlyExplicitPayerCanLoseTokens.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 using Utils as Utils;
 using Havoc as callbackHavoc;

--- a/certora/specs/PostMaturityDebt.spec
+++ b/certora/specs/PostMaturityDebt.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/PostMaturityDebt.spec
+++ b/certora/specs/PostMaturityDebt.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/PriceToTick.spec
+++ b/certora/specs/PriceToTick.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 import "TickToPrice.spec";
 

--- a/certora/specs/PriceToTick.spec
+++ b/certora/specs/PriceToTick.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 import "TickToPrice.spec";
 

--- a/certora/specs/Ratification.spec
+++ b/certora/specs/Ratification.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;

--- a/certora/specs/Ratification.spec
+++ b/certora/specs/Ratification.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;

--- a/certora/specs/Reentrancy.spec
+++ b/certora/specs/Reentrancy.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;

--- a/certora/specs/ReentrancyView.spec
+++ b/certora/specs/ReentrancyView.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;

--- a/certora/specs/Reverts.spec
+++ b/certora/specs/Reverts.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 import "BitmapSummaries.spec";
 

--- a/certora/specs/Reverts.spec
+++ b/certora/specs/Reverts.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 import "BitmapSummaries.spec";
 

--- a/certora/specs/Role.spec
+++ b/certora/specs/Role.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/Role.spec
+++ b/certora/specs/Role.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/SettlementFeeBoundaries.spec
+++ b/certora/specs/SettlementFeeBoundaries.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/SettlementFeeBoundaries.spec
+++ b/certora/specs/SettlementFeeBoundaries.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/SettlementFeeSpread.spec
+++ b/certora/specs/SettlementFeeSpread.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/SettlementFeeSpread.spec
+++ b/certora/specs/SettlementFeeSpread.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/Solvency.spec
+++ b/certora/specs/Solvency.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/Solvency.spec
+++ b/certora/specs/Solvency.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/SplitDoesNotPunishMakerOrFavorTaker.spec
+++ b/certora/specs/SplitDoesNotPunishMakerOrFavorTaker.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/SplitDoesNotPunishMakerOrFavorTaker.spec
+++ b/certora/specs/SplitDoesNotPunishMakerOrFavorTaker.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/SplitPreservesAccounting.spec
+++ b/certora/specs/SplitPreservesAccounting.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/SplitPreservesAccounting.spec
+++ b/certora/specs/SplitPreservesAccounting.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/TakeAmountsLibInvertibility.spec
+++ b/certora/specs/TakeAmountsLibInvertibility.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 using Utils as Utils;
 using TakeAmountsLibHarness as TakeAmountsLibHarness;

--- a/certora/specs/TakeAmountsLibInvertibility.spec
+++ b/certora/specs/TakeAmountsLibInvertibility.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 using Utils as Utils;
 using TakeAmountsLibHarness as TakeAmountsLibHarness;

--- a/certora/specs/TickToPrice.spec
+++ b/certora/specs/TickToPrice.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 methods {
     function lnOnePlusDelta() external returns (int256) envfree;

--- a/certora/specs/TickToPrice.spec
+++ b/certora/specs/TickToPrice.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 methods {
     function lnOnePlusDelta() external returns (int256) envfree;

--- a/certora/specs/TickToPriceIsMonotonic.spec
+++ b/certora/specs/TickToPriceIsMonotonic.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 import "TickToPrice.spec";
 

--- a/certora/specs/TickToPriceIsMonotonic.spec
+++ b/certora/specs/TickToPriceIsMonotonic.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 import "TickToPrice.spec";
 

--- a/certora/specs/UpdateBeforeCredit.spec
+++ b/certora/specs/UpdateBeforeCredit.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;

--- a/certora/specs/UpdateBeforeCredit.spec
+++ b/certora/specs/UpdateBeforeCredit.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 methods {
     function multicall(bytes[]) external => HAVOC_ALL DELETE;

--- a/certora/specs/WithdrawableMonotonicity.spec
+++ b/certora/specs/WithdrawableMonotonicity.spec
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 
 using Utils as Utils;
 

--- a/certora/specs/WithdrawableMonotonicity.spec
+++ b/certora/specs/WithdrawableMonotonicity.spec
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 
 using Utils as Utils;
 

--- a/src/Midnight.sol
+++ b/src/Midnight.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity 0.8.34;
 
 import {UtilsLib} from "./libraries/UtilsLib.sol";

--- a/src/interfaces/ICallbacks.sol
+++ b/src/interfaces/ICallbacks.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity >=0.5.0;
 
 import {Market} from "./IMidnight.sol";

--- a/src/interfaces/IERC20.sol
+++ b/src/interfaces/IERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity >=0.5.0;
 
 interface IERC20 {

--- a/src/interfaces/IGate.sol
+++ b/src/interfaces/IGate.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity >=0.5.0;
 
 interface IEnterGate {

--- a/src/interfaces/IMidnight.sol
+++ b/src/interfaces/IMidnight.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity >=0.5.0;
 
 struct Market {

--- a/src/interfaces/IOracle.sol
+++ b/src/interfaces/IOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity >=0.5.0;
 
 interface IOracle {

--- a/src/interfaces/IRatifier.sol
+++ b/src/interfaces/IRatifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity >=0.5.0;
 
 import {Offer} from "./IMidnight.sol";

--- a/src/libraries/ConstantsLib.sol
+++ b/src/libraries/ConstantsLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {UtilsLib} from "./UtilsLib.sol";

--- a/src/libraries/EventsLib.sol
+++ b/src/libraries/EventsLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {Market} from "../interfaces/IMidnight.sol";

--- a/src/libraries/IdLib.sol
+++ b/src/libraries/IdLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {Market} from "../interfaces/IMidnight.sol";

--- a/src/libraries/SafeTransferLib.sol
+++ b/src/libraries/SafeTransferLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {IERC20} from "../interfaces/IERC20.sol";

--- a/src/libraries/TickLib.sol
+++ b/src/libraries/TickLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 int256 constant LN_ONE_PLUS_DELTA = 0.004987541511039073e18; // floor(ln(1.005) * 1e18)

--- a/src/libraries/UtilsLib.sol
+++ b/src/libraries/UtilsLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 library UtilsLib {

--- a/src/periphery/ConsumableUnitsLib.sol
+++ b/src/periphery/ConsumableUnitsLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {IMidnight, Offer} from "../interfaces/IMidnight.sol";

--- a/src/periphery/EcrecoverAuthorizer.sol
+++ b/src/periphery/EcrecoverAuthorizer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity 0.8.34;
 
 import {IMidnight} from "../interfaces/IMidnight.sol";

--- a/src/periphery/TakeAmountsLib.sol
+++ b/src/periphery/TakeAmountsLib.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Morpho Association
 pragma solidity ^0.8.0;
 
 import {IMidnight, Offer} from "../interfaces/IMidnight.sol";

--- a/src/periphery/TakeAmountsLib.sol
+++ b/src/periphery/TakeAmountsLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {IMidnight, Offer} from "../interfaces/IMidnight.sol";

--- a/src/periphery/interfaces/IEcrecoverAuthorizer.sol
+++ b/src/periphery/interfaces/IEcrecoverAuthorizer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity >=0.5.0;
 
 struct Signature {

--- a/src/ratifiers/EcrecoverRatifier.sol
+++ b/src/ratifiers/EcrecoverRatifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity 0.8.34;
 
 import {IEcrecoverRatifier, Signature, EIP712_DOMAIN_TYPEHASH} from "./interfaces/IEcrecoverRatifier.sol";

--- a/src/ratifiers/SetterRatifier.sol
+++ b/src/ratifiers/SetterRatifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity 0.8.34;
 
 import {ISetterRatifier} from "./interfaces/ISetterRatifier.sol";

--- a/src/ratifiers/interfaces/IEcrecoverRatifier.sol
+++ b/src/ratifiers/interfaces/IEcrecoverRatifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity >=0.5.0;
 
 import {IRatifier} from "../../interfaces/IRatifier.sol";

--- a/src/ratifiers/interfaces/ISetterRatifier.sol
+++ b/src/ratifiers/interfaces/ISetterRatifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity >=0.5.0;
 
 import {IRatifier} from "../../interfaces/IRatifier.sol";

--- a/src/ratifiers/libraries/HashLib.sol
+++ b/src/ratifiers/libraries/HashLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {Offer, Market, CollateralParams} from "../../interfaces/IMidnight.sol";

--- a/test/AuthorizationTest.sol
+++ b/test/AuthorizationTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {IMidnight, Market, CollateralParams, Offer} from "../src/interfaces/IMidnight.sol";

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {Test} from "../lib/forge-std/src/Test.sol";

--- a/test/ContinuousFeeTest.sol
+++ b/test/ContinuousFeeTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {WAD, MAX_CONTINUOUS_FEE} from "../src/libraries/ConstantsLib.sol";

--- a/test/EcrecoverAuthorizerTest.sol
+++ b/test/EcrecoverAuthorizerTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {

--- a/test/EcrecoverRatifierIntegrationTest.sol
+++ b/test/EcrecoverRatifierIntegrationTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {Market, Offer, CollateralParams} from "../src/interfaces/IMidnight.sol";

--- a/test/EcrecoverRatifierTest.sol
+++ b/test/EcrecoverRatifierTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {Offer} from "../src/interfaces/IMidnight.sol";

--- a/test/FlashLoanTest.sol
+++ b/test/FlashLoanTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {BaseTest} from "./BaseTest.sol";

--- a/test/GateTest.sol
+++ b/test/GateTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {IMidnight, Market, Offer, CollateralParams} from "../src/interfaces/IMidnight.sol";

--- a/test/LiquidationTest.sol
+++ b/test/LiquidationTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {

--- a/test/MaxAmountsTest.sol
+++ b/test/MaxAmountsTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {IMidnight, Market, Offer, CollateralParams} from "../src/interfaces/IMidnight.sol";

--- a/test/MulticallTest.sol
+++ b/test/MulticallTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {BaseTest} from "./BaseTest.sol";

--- a/test/OtherFunctionsTest.sol
+++ b/test/OtherFunctionsTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {IMidnight, Market, CollateralParams} from "../src/interfaces/IMidnight.sol";

--- a/test/SafeTransferLibTest.sol
+++ b/test/SafeTransferLibTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {Test} from "../lib/forge-std/src/Test.sol";

--- a/test/SetterRatifierTest.sol
+++ b/test/SetterRatifierTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {CollateralParams, Market, Offer} from "../src/interfaces/IMidnight.sol";

--- a/test/SettersTest.sol
+++ b/test/SettersTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {

--- a/test/SettlementFeeTest.sol
+++ b/test/SettlementFeeTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {WAD, DEFAULT_TICK_SPACING} from "../src/libraries/ConstantsLib.sol";

--- a/test/TakeAmountsTest.sol
+++ b/test/TakeAmountsTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {Market, Offer, CollateralParams} from "../src/interfaces/IMidnight.sol";

--- a/test/TakeTest.sol
+++ b/test/TakeTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {IMidnight, Market, Offer, CollateralParams} from "../src/interfaces/IMidnight.sol";

--- a/test/erc20s/ERC20.sol
+++ b/test/erc20s/ERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 contract ERC20 {

--- a/test/erc20s/ERC20NoReturn.sol
+++ b/test/erc20s/ERC20NoReturn.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {PermitExt} from "./PermitExt.sol";

--- a/test/erc20s/ERC20NoRevert.sol
+++ b/test/erc20s/ERC20NoRevert.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {PermitExt} from "./PermitExt.sol";

--- a/test/erc20s/ERC20Permit.sol
+++ b/test/erc20s/ERC20Permit.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {ERC20} from "./ERC20.sol";

--- a/test/erc20s/ERC20RevertToZero.sol
+++ b/test/erc20s/ERC20RevertToZero.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {PermitExt} from "./PermitExt.sol";

--- a/test/erc20s/ERC20USDT.sol
+++ b/test/erc20s/ERC20USDT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {PermitExt} from "./PermitExt.sol";

--- a/test/erc20s/PermitExt.sol
+++ b/test/erc20s/PermitExt.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 abstract contract PermitExt {

--- a/test/helpers/DummyRatifier.sol
+++ b/test/helpers/DummyRatifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {IRatifier} from "../../src/interfaces/IRatifier.sol";

--- a/test/helpers/ERC20Test.sol
+++ b/test/helpers/ERC20Test.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 import {ERC20} from "../erc20s/ERC20.sol";

--- a/test/helpers/Oracle.sol
+++ b/test/helpers/Oracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 contract Oracle {

--- a/test/helpers/RevertingOracle.sol
+++ b/test/helpers/RevertingOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2025 Morpho Association
+// Copyright (c) 2026 Morpho Association
 pragma solidity ^0.8.0;
 
 contract RevertingOracle {


### PR DESCRIPTION
- adding the copyright to all the files (it was missing TakeAmountsLib, and certora files)
- 2025 → 2026

verify with [check_license_header.sh](https://github.com/user-attachments/files/29558988/check_license_header.sh)
`for file in $(find certora -name "*.spec") $(find src -name "*.sol"); do bash check_license_header.sh $file; done`
