### PR TITLE
reduce mempool optimizer-runs

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -6,19 +6,6 @@ bytecode_hash = "none"
 evm_version = "osaka"
 fs_permissions = [{ access = "read", path = "test/ticks_exact.json" }]
 
-# Compile the Log periphery contract with the maximum optimizer_runs.
-[[profile.default.additional_compiler_profiles]]
-name = "log"
-via_ir = true
-optimizer = true
-optimizer_runs = 4294967295
-bytecode_hash = "None"
-evm_version = "osaka"
-
-[[profile.default.compilation_restrictions]]
-paths = "src/periphery/Log.sol"
-optimizer_runs = 4294967295
-
 [profile.default.fmt]
 wrap_comments = true
 


### PR DESCRIPTION
ir optimized with 400 runs and 4294967295 runs. not worth imo
<img width="2277" height="1088" alt="image" src="https://github.com/user-attachments/assets/7e12fa7a-3e31-4aa0-a2dd-09f734cbde1f" />