### PR TITLE
[fallback rolling] max LTV

### DIFF
--- a/src/periphery/blue-fallback-rolling/BlueFallbackRolling.sol
+++ b/src/periphery/blue-fallback-rolling/BlueFallbackRolling.sol
@@ -58,7 +58,7 @@ contract BlueFallbackRolling is IBlueFallbackRolling {
         uint256 maxLtv,
         uint256 assets
     ) external override {
-        require(maxLtv < blueMarketParams.lltv, InvalidMaxLtv());
+        require(maxLtv <= blueMarketParams.lltv, InvalidMaxLtv());
         bytes32 midnightId = IdLib.toId(midnightMarket);
         bytes32 blueId = Id.unwrap(blueMarketParams.id());
         require(isConfig[user][keccak256(abi.encode(midnightId, blueId, start, incentive, maxLtv))], NotConfigured());

--- a/src/periphery/blue-fallback-rolling/BlueFallbackRolling.sol
+++ b/src/periphery/blue-fallback-rolling/BlueFallbackRolling.sol
@@ -52,6 +52,7 @@ contract BlueFallbackRolling is IBlueFallbackRolling {
         uint256 maxLtv,
         uint256 assets
     ) external override {
+        require(maxLtv < blueMarketParams.lltv, InvalidMaxLtv());
         bytes32 midnightId = IdLib.toId(midnightMarket);
         bytes32 blueId = Id.unwrap(blueMarketParams.id());
         require(isConfig[user][keccak256(abi.encode(midnightId, blueId, start, incentive, maxLtv))], NotConfigured());
@@ -100,7 +101,6 @@ contract BlueFallbackRolling is IBlueFallbackRolling {
     }
 
     function requireMaxLtv(MarketParams memory marketParams, address sender, uint256 maxLtv) internal view {
-        if (maxLtv >= marketParams.lltv) return;
         Position memory position = IMorpho(BLUE).position(marketParams.id(), sender);
         if (position.borrowShares == 0) return;
         BlueMarket memory market = IMorpho(BLUE).market(marketParams.id());

--- a/src/periphery/blue-fallback-rolling/BlueFallbackRolling.sol
+++ b/src/periphery/blue-fallback-rolling/BlueFallbackRolling.sol
@@ -2,10 +2,12 @@
 // Copyright (c) 2026 Morpho Association
 pragma solidity 0.8.34;
 
-import {IMorpho, Id, MarketParams} from "../../../lib/morpho-blue/src/interfaces/IMorpho.sol";
+import {IMorpho, Id, MarketParams, Market as BlueMarket, Position} from "../../../lib/morpho-blue/src/interfaces/IMorpho.sol";
 import {MarketParamsLib} from "../../../lib/morpho-blue/src/libraries/MarketParamsLib.sol";
+import {SharesMathLib} from "../../../lib/morpho-blue/src/libraries/SharesMathLib.sol";
 import {IMidnight, Market} from "../../interfaces/IMidnight.sol";
-import {WAD} from "../../libraries/ConstantsLib.sol";
+import {IOracle} from "../../interfaces/IOracle.sol";
+import {WAD, ORACLE_PRICE_SCALE} from "../../libraries/ConstantsLib.sol";
 import {IdLib} from "../../libraries/IdLib.sol";
 import {SafeTransferLib} from "../../libraries/SafeTransferLib.sol";
 import {UtilsLib} from "../../libraries/UtilsLib.sol";
@@ -15,7 +17,9 @@ import {SafeApproveLib} from "../libraries/SafeApproveLib.sol";
 /// @dev Users must authorize this contract on both Midnight and Blue before their debt can be rolled.
 contract BlueFallbackRolling is IBlueFallbackRolling {
     using MarketParamsLib for MarketParams;
+    using SharesMathLib for uint256;
     using UtilsLib for uint128;
+    using UtilsLib for uint256;
 
     address public immutable override MIDNIGHT;
     address public immutable override BLUE;
@@ -28,15 +32,15 @@ contract BlueFallbackRolling is IBlueFallbackRolling {
     }
 
     /// @param incentive The caller incentive as a WAD-scaled percentage of the debt rolled.
-    function setConfig(bytes32 midnightId, bytes32 blueId, uint64 start, uint64 incentive, bool enabled)
+    function setConfig(bytes32 midnightId, bytes32 blueId, uint64 start, uint64 incentive, uint256 maxLtv, bool enabled)
         external
         override
     {
         require(incentive <= WAD, IncentiveTooHigh());
 
-        isConfig[msg.sender][keccak256(abi.encode(midnightId, blueId, start, incentive))] = enabled;
+        isConfig[msg.sender][keccak256(abi.encode(midnightId, blueId, start, incentive, maxLtv))] = enabled;
 
-        emit SetConfig(msg.sender, midnightId, blueId, start, incentive, enabled);
+        emit SetConfig(msg.sender, midnightId, blueId, start, incentive, maxLtv, enabled);
     }
 
     function roll(
@@ -45,11 +49,12 @@ contract BlueFallbackRolling is IBlueFallbackRolling {
         address user,
         uint64 start,
         uint64 incentive,
+        uint256 maxLtv,
         uint256 assets
     ) external override {
         bytes32 midnightId = IdLib.toId(midnightMarket);
         bytes32 blueId = Id.unwrap(blueMarketParams.id());
-        require(isConfig[user][keccak256(abi.encode(midnightId, blueId, start, incentive))], NotConfigured());
+        require(isConfig[user][keccak256(abi.encode(midnightId, blueId, start, incentive, maxLtv))], NotConfigured());
         require(blueMarketParams.loanToken == midnightMarket.loanToken, InconsistentLoanToken());
         require(block.timestamp >= start, NotStarted());
         uint128 collateralBitmap = IMidnight(MIDNIGHT).collateralBitmap(midnightId, user);
@@ -71,6 +76,8 @@ contract BlueFallbackRolling is IBlueFallbackRolling {
         bytes memory data = abi.encode(midnightMarket, blueMarketParams, collateralIndex, assets, incentiveAssets, user);
         IMorpho(BLUE).supplyCollateral(blueMarketParams, collateralAssets, user, data);
         if (incentiveAssets > 0) SafeTransferLib.safeTransfer(midnightMarket.loanToken, msg.sender, incentiveAssets);
+
+        requireMaxLtv(blueMarketParams, user, maxLtv);
     }
 
     function onMorphoSupplyCollateral(uint256 collateralAssets, bytes calldata data) external {
@@ -90,5 +97,16 @@ contract BlueFallbackRolling is IBlueFallbackRolling {
         IMidnight(MIDNIGHT).repay(midnightMarket, assets, user, address(0), hex"");
         IMidnight(MIDNIGHT).withdrawCollateral(midnightMarket, collateralIndex, collateralAssets, user, address(this));
         SafeApproveLib.forceApproveMax(blueMarketParams.collateralToken, BLUE);
+    }
+
+    function requireMaxLtv(MarketParams memory marketParams, address sender, uint256 maxLtv) internal view {
+        if (maxLtv >= marketParams.lltv) return;
+        Position memory position = IMorpho(BLUE).position(marketParams.id(), sender);
+        if (position.borrowShares == 0) return;
+        BlueMarket memory market = IMorpho(BLUE).market(marketParams.id());
+        uint256 borrowed = uint256(position.borrowShares).toAssetsUp(market.totalBorrowAssets, market.totalBorrowShares);
+        uint256 price = IOracle(marketParams.oracle).price();
+        uint256 maxBorrow = uint256(position.collateral).mulDivDown(price, ORACLE_PRICE_SCALE).mulDivDown(maxLtv, WAD);
+        require(borrowed <= maxBorrow, LtvExceeded());
     }
 }

--- a/src/periphery/blue-fallback-rolling/BlueFallbackRolling.sol
+++ b/src/periphery/blue-fallback-rolling/BlueFallbackRolling.sol
@@ -37,7 +37,9 @@ contract BlueFallbackRolling is IBlueFallbackRolling {
         BLUE = _blue;
     }
 
+    /// @param start The start time of the rolling window.
     /// @param incentive The caller incentive as a WAD-scaled percentage of the debt rolled.
+    /// @param maxLtv The maximum LTV allowed for the Blue position after the roll.
     function setConfig(bytes32 midnightId, bytes32 blueId, uint64 start, uint64 incentive, uint256 maxLtv, bool enabled)
         external
         override

--- a/src/periphery/blue-fallback-rolling/BlueFallbackRolling.sol
+++ b/src/periphery/blue-fallback-rolling/BlueFallbackRolling.sol
@@ -2,7 +2,13 @@
 // Copyright (c) 2026 Morpho Association
 pragma solidity 0.8.34;
 
-import {IMorpho, Id, MarketParams, Market as BlueMarket, Position} from "../../../lib/morpho-blue/src/interfaces/IMorpho.sol";
+import {
+    IMorpho,
+    Id,
+    MarketParams,
+    Market as BlueMarket,
+    Position
+} from "../../../lib/morpho-blue/src/interfaces/IMorpho.sol";
 import {MarketParamsLib} from "../../../lib/morpho-blue/src/libraries/MarketParamsLib.sol";
 import {SharesMathLib} from "../../../lib/morpho-blue/src/libraries/SharesMathLib.sol";
 import {IMidnight, Market} from "../../interfaces/IMidnight.sol";

--- a/src/periphery/blue-fallback-rolling/IBlueFallbackRolling.sol
+++ b/src/periphery/blue-fallback-rolling/IBlueFallbackRolling.sol
@@ -10,6 +10,7 @@ interface IBlueFallbackRolling is IMorphoSupplyCollateralCallback {
     /// ERRORS ///
     error IncentiveTooHigh();
     error IncorrectActivatedCollateral();
+    error InvalidMaxLtv();
     error InconsistentCollateralToken();
     error InconsistentLoanToken();
     error LtvExceeded();

--- a/src/periphery/blue-fallback-rolling/IBlueFallbackRolling.sol
+++ b/src/periphery/blue-fallback-rolling/IBlueFallbackRolling.sol
@@ -12,6 +12,7 @@ interface IBlueFallbackRolling is IMorphoSupplyCollateralCallback {
     error IncorrectActivatedCollateral();
     error InconsistentCollateralToken();
     error InconsistentLoanToken();
+    error LtvExceeded();
     error NotBlue();
     error NotConfigured();
     error NotStarted();
@@ -23,6 +24,7 @@ interface IBlueFallbackRolling is IMorphoSupplyCollateralCallback {
         bytes32 indexed blueId,
         uint256 start,
         uint256 incentive,
+        uint256 maxLtv,
         bool enabled
     );
     event Roll(
@@ -41,13 +43,15 @@ interface IBlueFallbackRolling is IMorphoSupplyCollateralCallback {
     function isConfig(address user, bytes32 configId) external view returns (bool);
 
     /// FUNCTIONS ///
-    function setConfig(bytes32 midnightId, bytes32 blueId, uint64 start, uint64 incentive, bool enabled) external;
+    function setConfig(bytes32 midnightId, bytes32 blueId, uint64 start, uint64 incentive, uint256 maxLtv, bool enabled)
+        external;
     function roll(
         Market memory midnightMarket,
         MarketParams memory blueMarketParams,
         address user,
         uint64 start,
         uint64 incentive,
+        uint256 maxLtv,
         uint256 assets
     ) external;
 }

--- a/test/BlueFallbackRollingTest.sol
+++ b/test/BlueFallbackRollingTest.sol
@@ -83,7 +83,9 @@ contract BlueFallbackRollingTest is BaseTest {
         vm.prank(borrower);
         blue.setAuthorization(address(fallbackContract), true);
         vm.prank(borrower);
-        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, INCENTIVE, MAX_LTV, true);
+        fallbackContract.setConfig(
+            toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, INCENTIVE, MAX_LTV, true
+        );
     }
 
     function testAnyoneCanRollBorrowerToBlue() public {
@@ -124,7 +126,9 @@ contract BlueFallbackRollingTest is BaseTest {
     function testCannotRollBeforeStart() public {
         uint64 futureStart = uint64(vm.getBlockTimestamp() + 1);
         vm.prank(borrower);
-        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), futureStart, INCENTIVE, MAX_LTV, true);
+        fallbackContract.setConfig(
+            toId(midnightMarket), Id.unwrap(blueMarketParams.id()), futureStart, INCENTIVE, MAX_LTV, true
+        );
 
         vm.expectRevert(IBlueFallbackRolling.NotStarted.selector);
         vm.prank(keeper);
@@ -142,7 +146,9 @@ contract BlueFallbackRollingTest is BaseTest {
     function testRollRevertsForInconsistentLoanToken() public {
         blueMarketParams.loanToken = makeAddr("otherLoanToken");
         vm.prank(borrower);
-        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, INCENTIVE, MAX_LTV, true);
+        fallbackContract.setConfig(
+            toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, INCENTIVE, MAX_LTV, true
+        );
 
         vm.expectRevert(IBlueFallbackRolling.InconsistentLoanToken.selector);
         vm.prank(keeper);
@@ -186,19 +192,25 @@ contract BlueFallbackRollingTest is BaseTest {
         uint64 incentive = MAX_INCENTIVE + 1;
 
         vm.expectRevert(IBlueFallbackRolling.IncentiveTooHigh.selector);
-        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, incentive, MAX_LTV, true);
+        fallbackContract.setConfig(
+            toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, incentive, MAX_LTV, true
+        );
     }
 
     function testSetConfigAllowsOneIncentive() public {
         vm.prank(borrower);
-        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, MAX_INCENTIVE, MAX_LTV, true);
+        fallbackContract.setConfig(
+            toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, MAX_INCENTIVE, MAX_LTV, true
+        );
 
         assertTrue(fallbackContract.isConfig(borrower, configId(start, MAX_INCENTIVE, MAX_LTV)));
     }
 
     function testSetConfigCanDisable() public {
         vm.prank(borrower);
-        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, INCENTIVE, MAX_LTV, false);
+        fallbackContract.setConfig(
+            toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, INCENTIVE, MAX_LTV, false
+        );
 
         assertFalse(fallbackContract.isConfig(borrower, configId(start, INCENTIVE, MAX_LTV)));
 
@@ -220,7 +232,9 @@ contract BlueFallbackRollingTest is BaseTest {
     function testRollRevertsWhenMaxLtvExceeded() public {
         uint256 tightMaxLtv = BLUE_LLTV / 2;
         vm.prank(borrower);
-        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, INCENTIVE, tightMaxLtv, true);
+        fallbackContract.setConfig(
+            toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, INCENTIVE, tightMaxLtv, true
+        );
 
         vm.expectRevert(IBlueFallbackRolling.LtvExceeded.selector);
         vm.prank(keeper);
@@ -230,7 +244,9 @@ contract BlueFallbackRollingTest is BaseTest {
     function testRollRevertsWhenMaxLtvIsAboveLltv() public {
         uint256 invalidMaxLtv = BLUE_LLTV;
         vm.prank(borrower);
-        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, INCENTIVE, invalidMaxLtv, true);
+        fallbackContract.setConfig(
+            toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, INCENTIVE, invalidMaxLtv, true
+        );
 
         vm.expectRevert(IBlueFallbackRolling.InvalidMaxLtv.selector);
         vm.prank(keeper);

--- a/test/BlueFallbackRollingTest.sol
+++ b/test/BlueFallbackRollingTest.sol
@@ -16,7 +16,7 @@ contract BlueFallbackRollingTest is BaseTest {
     uint256 internal constant BLUE_LLTV = 0.86e18;
     uint64 internal constant INCENTIVE = 0.001e18;
     uint64 internal constant MAX_INCENTIVE = 1e18;
-    uint256 internal constant MAX_LTV = type(uint256).max;
+    uint256 internal constant MAX_LTV = 0.8e18;
     uint256 internal constant DEBT = 10_000e18;
 
     address internal keeper = makeAddr("keeper");
@@ -225,6 +225,16 @@ contract BlueFallbackRollingTest is BaseTest {
         vm.expectRevert(IBlueFallbackRolling.LtvExceeded.selector);
         vm.prank(keeper);
         fallbackContract.roll(midnightMarket, blueMarketParams, borrower, start, INCENTIVE, tightMaxLtv, DEBT);
+    }
+
+    function testRollRevertsWhenMaxLtvIsAboveLltv() public {
+        uint256 invalidMaxLtv = BLUE_LLTV;
+        vm.prank(borrower);
+        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, INCENTIVE, invalidMaxLtv, true);
+
+        vm.expectRevert(IBlueFallbackRolling.InvalidMaxLtv.selector);
+        vm.prank(keeper);
+        fallbackContract.roll(midnightMarket, blueMarketParams, borrower, start, INCENTIVE, invalidMaxLtv, DEBT);
     }
 
     function configId(uint64 _start, uint64 incentive, uint256 _maxLtv) internal view returns (bytes32) {

--- a/test/BlueFallbackRollingTest.sol
+++ b/test/BlueFallbackRollingTest.sol
@@ -16,6 +16,7 @@ contract BlueFallbackRollingTest is BaseTest {
     uint256 internal constant BLUE_LLTV = 0.86e18;
     uint64 internal constant INCENTIVE = 0.001e18;
     uint64 internal constant MAX_INCENTIVE = 1e18;
+    uint256 internal constant MAX_LTV = type(uint256).max;
     uint256 internal constant DEBT = 10_000e18;
 
     address internal keeper = makeAddr("keeper");
@@ -82,14 +83,14 @@ contract BlueFallbackRollingTest is BaseTest {
         vm.prank(borrower);
         blue.setAuthorization(address(fallbackContract), true);
         vm.prank(borrower);
-        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, INCENTIVE, true);
+        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, INCENTIVE, MAX_LTV, true);
     }
 
     function testAnyoneCanRollBorrowerToBlue() public {
         uint256 midnightCollateral = midnight.collateral(toId(midnightMarket), borrower, blueCollateralIndex);
 
         vm.prank(keeper);
-        fallbackContract.roll(midnightMarket, blueMarketParams, borrower, start, INCENTIVE, DEBT);
+        fallbackContract.roll(midnightMarket, blueMarketParams, borrower, start, INCENTIVE, MAX_LTV, DEBT);
 
         uint256 incentiveAssets = DEBT * INCENTIVE / WAD;
         assertEq(midnight.debt(toId(midnightMarket), borrower), 0);
@@ -106,7 +107,7 @@ contract BlueFallbackRollingTest is BaseTest {
         uint256 collateralAssets = totalCollateralAssets * debtAssets / DEBT;
 
         vm.prank(keeper);
-        fallbackContract.roll(midnightMarket, blueMarketParams, borrower, start, INCENTIVE, debtAssets);
+        fallbackContract.roll(midnightMarket, blueMarketParams, borrower, start, INCENTIVE, MAX_LTV, debtAssets);
 
         uint256 incentiveAssets = debtAssets * INCENTIVE / WAD;
         assertEq(midnight.debt(toId(midnightMarket), borrower), DEBT - debtAssets);
@@ -123,11 +124,11 @@ contract BlueFallbackRollingTest is BaseTest {
     function testCannotRollBeforeStart() public {
         uint64 futureStart = uint64(vm.getBlockTimestamp() + 1);
         vm.prank(borrower);
-        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), futureStart, INCENTIVE, true);
+        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), futureStart, INCENTIVE, MAX_LTV, true);
 
         vm.expectRevert(IBlueFallbackRolling.NotStarted.selector);
         vm.prank(keeper);
-        fallbackContract.roll(midnightMarket, blueMarketParams, borrower, futureStart, INCENTIVE, DEBT);
+        fallbackContract.roll(midnightMarket, blueMarketParams, borrower, futureStart, INCENTIVE, MAX_LTV, DEBT);
     }
 
     function testRollRevertsForUnconfiguredBlueMarket() public {
@@ -135,17 +136,17 @@ contract BlueFallbackRollingTest is BaseTest {
 
         vm.expectRevert(IBlueFallbackRolling.NotConfigured.selector);
         vm.prank(keeper);
-        fallbackContract.roll(midnightMarket, blueMarketParams, borrower, start, INCENTIVE, DEBT);
+        fallbackContract.roll(midnightMarket, blueMarketParams, borrower, start, INCENTIVE, MAX_LTV, DEBT);
     }
 
     function testRollRevertsForInconsistentLoanToken() public {
         blueMarketParams.loanToken = makeAddr("otherLoanToken");
         vm.prank(borrower);
-        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, INCENTIVE, true);
+        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, INCENTIVE, MAX_LTV, true);
 
         vm.expectRevert(IBlueFallbackRolling.InconsistentLoanToken.selector);
         vm.prank(keeper);
-        fallbackContract.roll(midnightMarket, blueMarketParams, borrower, start, INCENTIVE, DEBT);
+        fallbackContract.roll(midnightMarket, blueMarketParams, borrower, start, INCENTIVE, MAX_LTV, DEBT);
     }
 
     function testRollRevertsForMultipleActivatedCollaterals() public {
@@ -153,7 +154,7 @@ contract BlueFallbackRollingTest is BaseTest {
 
         vm.expectRevert(IBlueFallbackRolling.IncorrectActivatedCollateral.selector);
         vm.prank(keeper);
-        fallbackContract.roll(midnightMarket, blueMarketParams, borrower, start, INCENTIVE, DEBT);
+        fallbackContract.roll(midnightMarket, blueMarketParams, borrower, start, INCENTIVE, MAX_LTV, DEBT);
     }
 
     function testRollRevertsWhenActivatedCollateralDoesNotMatchBlue() public {
@@ -165,7 +166,7 @@ contract BlueFallbackRollingTest is BaseTest {
 
         vm.expectRevert(IBlueFallbackRolling.InconsistentCollateralToken.selector);
         vm.prank(keeper);
-        fallbackContract.roll(midnightMarket, blueMarketParams, borrower, start, INCENTIVE, DEBT);
+        fallbackContract.roll(midnightMarket, blueMarketParams, borrower, start, INCENTIVE, MAX_LTV, DEBT);
     }
 
     function testSupplyCollateralCallbackRevertsIfCallerIsNotBlue() public {
@@ -178,45 +179,55 @@ contract BlueFallbackRollingTest is BaseTest {
     }
 
     function testSetConfig() public view {
-        assertTrue(fallbackContract.isConfig(borrower, configId(start, INCENTIVE)));
+        assertTrue(fallbackContract.isConfig(borrower, configId(start, INCENTIVE, MAX_LTV)));
     }
 
     function testSetConfigRevertsForTooLargeIncentive() public {
         uint64 incentive = MAX_INCENTIVE + 1;
 
         vm.expectRevert(IBlueFallbackRolling.IncentiveTooHigh.selector);
-        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, incentive, true);
+        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, incentive, MAX_LTV, true);
     }
 
     function testSetConfigAllowsOneIncentive() public {
         vm.prank(borrower);
-        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, MAX_INCENTIVE, true);
+        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, MAX_INCENTIVE, MAX_LTV, true);
 
-        assertTrue(fallbackContract.isConfig(borrower, configId(start, MAX_INCENTIVE)));
+        assertTrue(fallbackContract.isConfig(borrower, configId(start, MAX_INCENTIVE, MAX_LTV)));
     }
 
     function testSetConfigCanDisable() public {
         vm.prank(borrower);
-        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, INCENTIVE, false);
+        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, INCENTIVE, MAX_LTV, false);
 
-        assertFalse(fallbackContract.isConfig(borrower, configId(start, INCENTIVE)));
+        assertFalse(fallbackContract.isConfig(borrower, configId(start, INCENTIVE, MAX_LTV)));
 
         vm.expectRevert(IBlueFallbackRolling.NotConfigured.selector);
-        fallbackContract.roll(midnightMarket, blueMarketParams, borrower, start, INCENTIVE, DEBT);
+        fallbackContract.roll(midnightMarket, blueMarketParams, borrower, start, INCENTIVE, MAX_LTV, DEBT);
     }
 
     function testSetConfigDoesNotReplaceOtherConfig() public {
         uint64 otherStart = start + 1;
         vm.prank(borrower);
         fallbackContract.setConfig(
-            toId(midnightMarket), Id.unwrap(blueMarketParams.id()), otherStart, MAX_INCENTIVE, true
+            toId(midnightMarket), Id.unwrap(blueMarketParams.id()), otherStart, MAX_INCENTIVE, MAX_LTV, true
         );
 
-        assertTrue(fallbackContract.isConfig(borrower, configId(start, INCENTIVE)));
-        assertTrue(fallbackContract.isConfig(borrower, configId(otherStart, MAX_INCENTIVE)));
+        assertTrue(fallbackContract.isConfig(borrower, configId(start, INCENTIVE, MAX_LTV)));
+        assertTrue(fallbackContract.isConfig(borrower, configId(otherStart, MAX_INCENTIVE, MAX_LTV)));
     }
 
-    function configId(uint64 _start, uint64 incentive) internal view returns (bytes32) {
-        return keccak256(abi.encode(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), _start, incentive));
+    function testRollRevertsWhenMaxLtvExceeded() public {
+        uint256 tightMaxLtv = BLUE_LLTV / 2;
+        vm.prank(borrower);
+        fallbackContract.setConfig(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), start, INCENTIVE, tightMaxLtv, true);
+
+        vm.expectRevert(IBlueFallbackRolling.LtvExceeded.selector);
+        vm.prank(keeper);
+        fallbackContract.roll(midnightMarket, blueMarketParams, borrower, start, INCENTIVE, tightMaxLtv, DEBT);
+    }
+
+    function configId(uint64 _start, uint64 incentive, uint256 _maxLtv) internal view returns (bytes32) {
+        return keccak256(abi.encode(toId(midnightMarket), Id.unwrap(blueMarketParams.id()), _start, incentive, _maxLtv));
     }
 }


### PR DESCRIPTION
Similarly as for Bundles, implement a max LTV. Rationale being

- the incentive is taken as additional debt for the borrower so the rolling deteriorates the LTV of the position
- liquidation is much harsher on blue than on midnight so a borrower close to insolvency would prefer staying on midnight instead of rolling

