### PR TITLE
[Certora] Added the muldiv axioms to a separate file to facilitate the use by other specs.

### DIFF
--- a/certora/specs/Healthiness.spec
+++ b/certora/specs/Healthiness.spec
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Morpho Association
 
 import "BitmapSummaries.spec";
+import "MulDivAxioms.spec";
 
 using Havoc as havocCallback;
 
@@ -50,35 +51,6 @@ definition WAD() returns uint256 = 10 ^ 18;
 definition ORACLE_PRICE_SCALE() returns uint256 = 10 ^ 36;
 
 persistent ghost summaryPrice(address) returns uint256;
-
-persistent ghost ghostMulDivDown(mathint, mathint, mathint) returns mathint;
-
-persistent ghost ghostMulDivUp(mathint, mathint, mathint) returns mathint;
-
-/* Axioms that are proved by MulDiv.spec */
-
-/* proved in mulDivZero in MulDiv.spec */
-definition axiomDownZero(mathint b, mathint d) returns bool = d > 0 => ghostMulDivDown(0, b, d) == 0;
-
-/* proved in mulDivMonotoneA */
-definition axiomDownMonotoneA(mathint a1, mathint a2, mathint b, mathint d) returns bool = 0 <= a1 && a1 <= a2 && 0 <= b && 0 < d => ghostMulDivDown(a1, b, d) <= ghostMulDivDown(a2, b, d);
-
-definition axiomUpMonotoneA(mathint a1, mathint a2, mathint b, mathint d) returns bool = 0 <= a1 && a1 <= a2 && 0 <= b && 0 < d => ghostMulDivUp(a1, b, d) <= ghostMulDivUp(a2, b, d);
-
-/* proved in mulDivMonotoneB */
-definition axiomDownMonotoneB(mathint a, mathint b1, mathint b2, mathint d) returns bool = 0 <= a && 0 <= b1 && b1 <= b2 && 0 < d => ghostMulDivDown(a, b1, d) <= ghostMulDivDown(a, b2, d);
-
-/* proved in mulDivMonotoneD */
-definition axiomUpMonotoneD(mathint a, mathint b, mathint d1, mathint d2) returns bool = 0 <= a && 0 <= b && 0 < d1 && d1 <= d2 => ghostMulDivUp(a, b, d1) >= ghostMulDivUp(a, b, d2);
-
-/* proved in mulDivAddDownUp */
-definition axiomAddDownUp(mathint a1, mathint a2, mathint b, mathint d) returns bool = a1 >= 0 && a2 >= 0 && b >= 0 && d > 0 => ghostMulDivDown(a1, b, d) + ghostMulDivUp(a2, b, d) >= ghostMulDivDown(a1 + a2, b, d);
-
-/* proved in mulDivInverseUpDown */
-definition axiomInverseUpDown(mathint a, mathint b, mathint d) returns bool = a >= 0 && b > 0 && d > 0 => ghostMulDivUp(ghostMulDivDown(a, b, d), d, b) <= a;
-
-/* proved in ExactMath.spec (mulDivLifLLTV) */
-definition axiomLifLLTV(mathint a, mathint lif, mathint lltv) returns bool = a >= 0 && lltv * lif <= WAD() * WAD() => ghostMulDivUp(a, lltv, WAD()) <= ghostMulDivUp(a, WAD(), lif);
 
 function summaryMulDivDown(uint256 a, uint256 b, uint256 d) returns uint256 {
     bool overflow;
@@ -270,17 +242,17 @@ rule stayHealthyLiquidateSameBorrower(env e, uint256 collateralIndex, uint256 se
     mathint price = summaryPrice(globalMarket.collateralParams[collateralIndex].oracle);
 
     // require all the axioms that are needed to prove the healthiness after liquidation. These are the same axioms that are proved in the MulDiv.spec
-    require forall mathint a1. forall mathint a2. forall mathint b. forall mathint d. axiomDownMonotoneA(a1, a2, b, d), "axiom";
-    require forall mathint a1. forall mathint a2. forall mathint b. forall mathint d. axiomUpMonotoneA(a1, a2, b, d), "axiom";
-    require forall mathint a. forall mathint b1. forall mathint b2. forall mathint d. axiomDownMonotoneB(a, b1, b2, d), "axiom";
-    require forall mathint a. forall mathint b. forall mathint d1. forall mathint d2. axiomUpMonotoneD(a, b, d1, d2), "axiom";
-    require axiomDownZero(price, ORACLE_PRICE_SCALE()), "axiom";
-    require axiomDownZero(globalMarketCollateralLLTV[collateralIndex], WAD()), "axiom";
-    require axiomInverseUpDown(repaidUnitsOut, maxLifGhost(globalMarketCollateralLLTV[collateralIndex], globalMarketCollateralLiquidationCursor[collateralIndex]), WAD()), "axiom";
-    require axiomInverseUpDown(ghostMulDivDown(repaidUnitsOut, maxLifGhost(globalMarketCollateralLLTV[collateralIndex], globalMarketCollateralLiquidationCursor[collateralIndex]), WAD()), ORACLE_PRICE_SCALE(), price), "axiom";
-    require axiomLifLLTV(ghostMulDivUp(seizedAssetsOut, price, ORACLE_PRICE_SCALE()), maxLifGhost(globalMarketCollateralLLTV[collateralIndex], globalMarketCollateralLiquidationCursor[collateralIndex]), globalMarketCollateralLLTV[collateralIndex]), "axiom";
-    require axiomAddDownUp(collateralAfter, seizedAssetsOut, price, ORACLE_PRICE_SCALE()), "axiom";
-    require axiomAddDownUp(ghostMulDivDown(collateralAfter, price, ORACLE_PRICE_SCALE()), ghostMulDivUp(seizedAssetsOut, price, ORACLE_PRICE_SCALE()), globalMarketCollateralLLTV[collateralIndex], WAD()), "axiom";
+    require forall mathint a1. forall mathint a2. forall mathint b. forall mathint d. axiomMathMulDivDownMonotoneA(a1, a2, b, d), "axiom";
+    require forall mathint a1. forall mathint a2. forall mathint b. forall mathint d. axiomMathMulDivUpMonotoneA(a1, a2, b, d), "axiom";
+    require forall mathint a. forall mathint b1. forall mathint b2. forall mathint d. axiomMathMulDivDownMonotoneB(a, b1, b2, d), "axiom";
+    require forall mathint a. forall mathint b. forall mathint d1. forall mathint d2. axiomMathMulDivUpMonotoneD(a, b, d1, d2), "axiom";
+    require axiomMathMulDivDownZeroA(price, ORACLE_PRICE_SCALE()), "axiom";
+    require axiomMathMulDivDownZeroA(globalMarketCollateralLLTV[collateralIndex], WAD()), "axiom";
+    require axiomMathMulDivInverseUpDown(repaidUnitsOut, maxLifGhost(globalMarketCollateralLLTV[collateralIndex], globalMarketCollateralLiquidationCursor[collateralIndex]), WAD()), "axiom";
+    require axiomMathMulDivInverseUpDown(ghostMulDivDown(repaidUnitsOut, maxLifGhost(globalMarketCollateralLLTV[collateralIndex], globalMarketCollateralLiquidationCursor[collateralIndex]), WAD()), ORACLE_PRICE_SCALE(), price), "axiom";
+    require axiomMathMulDivUpMonotoneBD(ghostMulDivUp(seizedAssetsOut, price, ORACLE_PRICE_SCALE()), maxLifGhost(globalMarketCollateralLLTV[collateralIndex], globalMarketCollateralLiquidationCursor[collateralIndex]), WAD(), WAD(), globalMarketCollateralLLTV[collateralIndex]), "axiom";
+    require axiomMathMulDivAddDownUp(collateralAfter, seizedAssetsOut, price, ORACLE_PRICE_SCALE()), "axiom";
+    require axiomMathMulDivAddDownUp(ghostMulDivDown(collateralAfter, price, ORACLE_PRICE_SCALE()), ghostMulDivUp(seizedAssetsOut, price, ORACLE_PRICE_SCALE()), globalMarketCollateralLLTV[collateralIndex], WAD()), "axiom";
 
     // check that the user was healthy before all callbacks.  We can only assert this after we included all the needed axioms.
     assert healthyOrLockedBeforeCallbacks, "user is healthy or locked before callbacks";
@@ -315,7 +287,7 @@ rule stayHealthyOrLocked(env e, method f, calldataarg args) filtered { f -> f.se
     // This variable is set to false whenever isHealthy() is violated before a callback.  Initially we set it to true to indicate no violations detected.
     healthyOrLockedBeforeCallbacks = true;
 
-    require forall mathint a1. forall mathint a2. forall mathint b. forall mathint d. axiomDownMonotoneA(a1, a2, b, d), "axiom";
+    require forall mathint a1. forall mathint a2. forall mathint b. forall mathint d. axiomMathMulDivDownMonotoneA(a1, a2, b, d), "axiom";
 
     Midnight.Market globalMarket = getGlobalMarket();
 

--- a/certora/specs/MulDiv.spec
+++ b/certora/specs/MulDiv.spec
@@ -156,6 +156,11 @@ rule mathMulDivMonotoneD(mathint a, mathint b, mathint d1, mathint d2) {
     assert a >= 0 && b >= 0 && 0 < d1 && d1 <= d2 => mathMulDivUp(a, b, d1) >= mathMulDivUp(a, b, d2);
 }
 
+rule mathMulDivMonotoneBD(mathint a, mathint b1, mathint b2, mathint d1, mathint d2) {
+    assert a >= 0 && b1 >= 0 && b2 >= 0 && d1 > 0 && d2 > 0 && b1 * d2 <= d1 * b2 => mathMulDivDown(a, b1, d1) <= mathMulDivDown(a, b2, d2);
+    assert a >= 0 && b1 >= 0 && b2 >= 0 && d1 > 0 && d2 > 0 && b1 * d2 <= d1 * b2 => mathMulDivUp(a, b1, d1) <= mathMulDivUp(a, b2, d2);
+}
+
 // 1-Lipschitz in the first argument when b <= d: the result cannot grow faster than the numerator a.
 rule mathMulDivLipschitzA(mathint a1, mathint a2, mathint b, mathint d) {
     assert a1 >= 0 && b >= 0 && b <= d && a1 <= a2 => mathMulDivDown(a2, b, d) - mathMulDivDown(a1, b, d) <= a2 - a1;

--- a/certora/specs/MulDivAxioms.spec
+++ b/certora/specs/MulDivAxioms.spec
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (c) 2026 Morpho Association
 
-ghost ghostMulDivDown(mathint, mathint, mathint) returns mathint;
+persistent ghost ghostMulDivDown(mathint, mathint, mathint) returns mathint;
 
-ghost ghostMulDivUp(mathint, mathint, mathint) returns mathint;
+persistent ghost ghostMulDivUp(mathint, mathint, mathint) returns mathint;
 
 definition mathMulDivDown(mathint a, mathint b, mathint d) returns mathint = ghostMulDivDown(a, b, d);
 

--- a/certora/specs/MulDivAxioms.spec
+++ b/certora/specs/MulDivAxioms.spec
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2026 Morpho Association
+
+ghost ghostMulDivDown(mathint, mathint, mathint) returns mathint;
+
+ghost ghostMulDivUp(mathint, mathint, mathint) returns mathint;
+
+definition mathMulDivDown(mathint a, mathint b, mathint d) returns mathint = ghostMulDivDown(a, b, d);
+
+definition mathMulDivUp(mathint a, mathint b, mathint d) returns mathint = ghostMulDivUp(a, b, d);
+
+/* these are the axioms proved in MulDiv.spec */
+
+definition axiomMathMulDivDownZeroA(mathint b, mathint d) returns bool = d > 0 => mathMulDivDown(0, b, d) == 0;
+
+definition axiomMathMulDivUpZeroA(mathint b, mathint d) returns bool = d > 0 => mathMulDivUp(0, b, d) == 0;
+
+definition axiomMathMulDivDownZeroB(mathint a, mathint d) returns bool = d > 0 => mathMulDivDown(a, 0, d) == 0;
+
+definition axiomMathMulDivUpZeroB(mathint a, mathint d) returns bool = d > 0 => mathMulDivUp(a, 0, d) == 0;
+
+definition axiomMathMulDivDownMonotoneA(mathint a1, mathint a2, mathint b, mathint d) returns bool = a1 >= 0 && b >= 0 && d >= 0 && a1 <= a2 => mathMulDivDown(a1, b, d) <= mathMulDivDown(a2, b, d);
+
+definition axiomMathMulDivUpMonotoneA(mathint a1, mathint a2, mathint b, mathint d) returns bool = a1 >= 0 && b >= 0 && d >= 0 && a1 <= a2 => mathMulDivUp(a1, b, d) <= mathMulDivUp(a2, b, d);
+
+definition axiomMathMulDivDownMonotoneB(mathint a, mathint b1, mathint b2, mathint d) returns bool = a >= 0 && b1 >= 0 && d >= 0 && b1 <= b2 => mathMulDivDown(a, b1, d) <= mathMulDivDown(a, b2, d);
+
+definition axiomMathMulDivUpMonotoneB(mathint a, mathint b1, mathint b2, mathint d) returns bool = a >= 0 && b1 >= 0 && d >= 0 && b1 <= b2 => mathMulDivUp(a, b1, d) <= mathMulDivUp(a, b2, d);
+
+definition axiomMathMulDivDownMonotoneD(mathint a, mathint b, mathint d1, mathint d2) returns bool = a >= 0 && b >= 0 && 0 < d1 && d1 <= d2 => mathMulDivDown(a, b, d1) >= mathMulDivDown(a, b, d2);
+
+definition axiomMathMulDivUpMonotoneD(mathint a, mathint b, mathint d1, mathint d2) returns bool = a >= 0 && b >= 0 && 0 < d1 && d1 <= d2 => mathMulDivUp(a, b, d1) >= mathMulDivUp(a, b, d2);
+
+definition axiomMathMulDivDownMonotoneBD(mathint a, mathint b1, mathint b2, mathint d1, mathint d2) returns bool = a >= 0 && b1 >= 0 && b2 >= 0 && d1 > 0 && d2 > 0 && b1 * d2 <= d1 * b2 => mathMulDivDown(a, b1, d1) <= mathMulDivDown(a, b2, d2);
+
+definition axiomMathMulDivUpMonotoneBD(mathint a, mathint b1, mathint b2, mathint d1, mathint d2) returns bool = a >= 0 && b1 >= 0 && b2 >= 0 && d1 > 0 && d2 > 0 && b1 * d2 <= d1 * b2 => mathMulDivUp(a, b1, d1) <= mathMulDivUp(a, b2, d2);
+
+// 1-Lipschitz in the first argument when b <= d: the result cannot grow faster than the numerator a.
+definition axiomMathMulDivDownLipschitzA(mathint a1, mathint a2, mathint b, mathint d) returns bool = a1 >= 0 && b >= 0 && b <= d && a1 <= a2 => mathMulDivDown(a2, b, d) - mathMulDivDown(a1, b, d) <= a2 - a1;
+
+definition axiomMathMulDivUpLipschitzA(mathint a1, mathint a2, mathint b, mathint d) returns bool = a1 >= 0 && b >= 0 && b <= d && a1 <= a2 => mathMulDivUp(a2, b, d) - mathMulDivUp(a1, b, d) <= a2 - a1;
+
+// 1-Lipschitz in the second argument when a <= d: the result cannot grow faster than the numerator b.
+definition axiomMathMulDivDownLipschitzB(mathint a, mathint b1, mathint b2, mathint d) returns bool = a >= 0 && b1 >= 0 && a <= d && b1 <= b2 => mathMulDivDown(a, b2, d) - mathMulDivDown(a, b1, d) <= b2 - b1;
+
+definition axiomMathMulDivUpLipschitzB(mathint a, mathint b1, mathint b2, mathint d) returns bool = a >= 0 && b1 >= 0 && a <= d && b1 <= b2 => mathMulDivUp(a, b2, d) - mathMulDivUp(a, b1, d) <= b2 - b1;
+
+definition axiomMathMulDivAddDownDown(mathint a1, mathint a2, mathint b, mathint d) returns bool = a1 >= 0 && a2 >= 0 && b >= 0 && d > 0 => mathMulDivDown(a1, b, d) + mathMulDivDown(a2, b, d) <= mathMulDivDown(a1 + a2, b, d);
+
+// Sub-additivity upper bound for mathMulDivDown: floor((a1+a2)*b/d) <= floor(a1*b/d) + floor(a2*b/d) + 1.
+definition axiomMathMulDivAddDownDownTight(mathint a1, mathint a2, mathint b, mathint d) returns bool = a1 >= 0 && a2 >= 0 => mathMulDivDown(a1 + a2, b, d) <= mathMulDivDown(a1, b, d) + mathMulDivDown(a2, b, d) + 1;
+
+// Super-additivity upper bound for mathMulDivUp: ceil((a1+a2)*b/d) <= ceil(a1*b/d) + ceil(a2*b/d).
+definition axiomMathMulDivAddUpUp(mathint a1, mathint a2, mathint b, mathint d) returns bool = a1 >= 0 && a2 >= 0 => mathMulDivUp(a1 + a2, b, d) <= mathMulDivUp(a1, b, d) + mathMulDivUp(a2, b, d);
+
+// Super-additivity lower bound for mathMulDivUp: ceil(a1*b/d) + ceil(a2*b/d) <= ceil((a1+a2)*b/d) + 1.
+definition axiomMathMulDivAddUpUpTight(mathint a1, mathint a2, mathint b, mathint d) returns bool = a1 >= 0 && a2 >= 0 && b >= 0 && d > 0 => mathMulDivUp(a1, b, d) + mathMulDivUp(a2, b, d) <= mathMulDivUp(a1 + a2, b, d) + 1;
+
+definition axiomMathMulDivAddDownUp(mathint a1, mathint a2, mathint b, mathint d) returns bool = a1 >= 0 && a2 >= 0 => mathMulDivDown(a1, b, d) + mathMulDivUp(a2, b, d) >= mathMulDivDown(a1 + a2, b, d);
+
+definition axiomMathMulDivInverseDownUp(mathint a, mathint b, mathint d) returns bool = b > 0 && d > 0 => a <= mathMulDivDown(mathMulDivUp(a, b, d), d, b);
+
+definition axiomMathMulDivInverseUpDown(mathint a, mathint b, mathint d) returns bool = a >= 0 && b >= 0 && d > 0 => mathMulDivUp(mathMulDivDown(a, b, d), d, b) <= a;
+
+definition axiomMathMulDivDownArgumentLesserThanDenominatorA(mathint a, mathint b, mathint d) returns bool = a >= 0 && b >= 0 && a <= d => mathMulDivDown(a, b, d) <= b;
+
+definition axiomMathMulDivUpArgumentLesserThanDenominatorA(mathint a, mathint b, mathint d) returns bool = a >= 0 && b >= 0 && a <= d => mathMulDivUp(a, b, d) <= b;
+
+definition axiomMathMulDivDownArgumentLesserThanDenominatorB(mathint a, mathint b, mathint d) returns bool = a >= 0 && b >= 0 && b <= d => mathMulDivDown(a, b, d) <= a;
+
+definition axiomMathMulDivUpArgumentLesserThanDenominatorB(mathint a, mathint b, mathint d) returns bool = a >= 0 && b >= 0 && b <= d => mathMulDivUp(a, b, d) <= a;
+
+// Identity (b = d = x): floor(a*x/x) = ceil(a*x/x) = a.
+definition axiomMathMulDivDownIdentity(mathint a, mathint x) returns bool = a >= 0 && x > 0 => mathMulDivDown(a, x, x) == a;
+
+definition axiomMathMulDivUpIdentity(mathint a, mathint x) returns bool = a >= 0 && x > 0 => mathMulDivUp(a, x, x) == a;
+
+definition axiomMathMulDivDownRoundsDown(mathint a, mathint b, mathint d) returns bool = a >= 0 && b >= 0 => mathMulDivDown(a, b, d) * d <= a * b;
+
+definition axiomMathMulDivDownTightBound(mathint a, mathint b, mathint d) returns bool = a >= 0 && b >= 0 && d > 0 => (mathMulDivDown(a, b, d) + 1) * d > a * b;
+
+definition axiomMathMulDivUpRoundsUp(mathint a, mathint b, mathint d) returns bool = a >= 0 && b >= 0 && d > 0 => mathMulDivUp(a, b, d) * d >= a * b;
+
+definition axiomMathMulDivUpGeqMulDivDown(mathint a, mathint b, mathint d) returns bool = mathMulDivUp(a, b, d) >= mathMulDivDown(a, b, d);
+
+definition axiomMathMulDivUpTightBound(mathint a, mathint b, mathint d) returns bool = a >= 0 && b >= 0 && d > 0 && mathMulDivUp(a, b, d) > 0 => (mathMulDivUp(a, b, d) - 1) * d < a * b;
+
+definition axiomMathMulDivUpUpperBound(mathint a, mathint b, mathint d) returns bool = a >= 0 && b >= 0 && d > 0 => mathMulDivUp(a, b, d) * d <= a * b + d - 1;
+
+definition axiomMathMulDivDownResidualBound(mathint a, mathint b, mathint d) returns bool = a >= 0 && b >= 0 && a <= d && b <= d => a - mathMulDivDown(a, b, d) <= d - b;
+
+definition axiomMathMulDivUpResidualBound(mathint a, mathint b, mathint d) returns bool = a >= 0 && b >= 0 && a <= d && b <= d => a - mathMulDivUp(a, b, d) <= d - b;

--- a/certora/specs/TakeAmountsLibInvertibility.spec
+++ b/certora/specs/TakeAmountsLibInvertibility.spec
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (c) 2026 Morpho Association
 
+import "MulDivAxioms.spec";
+
 using Utils as Utils;
 using TakeAmountsLibHarness as TakeAmountsLibHarness;
 
@@ -45,29 +47,15 @@ persistent ghost summaryTickToPrice(uint256) returns uint256 {
 
 definition WAD() returns uint256 = 10 ^ 18;
 
-/// MULDIV GHOST SUMMARIES (mirrors AccrualRounding.spec) ///
+// MulDiv rounding axioms
+function mathMulDivAxioms() {
+    require forall mathint b. forall mathint d. axiomMathMulDivDownZeroA(b, d), "axiom";
+    require forall mathint a. forall mathint b. forall mathint d. axiomMathMulDivDownRoundsDown(a, b, d), "axiom";
+    require forall mathint a. forall mathint b. forall mathint d. axiomMathMulDivDownTightBound(a, b, d), "axiom";
 
-// MulDiv rounding axioms (each proved in MulDiv.spec); inlined on ghosts instead of requireMulDivAxioms().
-persistent ghost ghostMulDivDown(mathint, mathint, mathint) returns mathint {
-    // proved in mulDivUpRoundsUp
-    axiom forall uint256 b. forall uint256 d. d > 0 => ghostMulDivDown(0, b, d) == 0;
-
-    // proved in mulDivDownRoundsDown
-    axiom forall mathint a. forall mathint b. forall mathint d. 0 <= a && 0 <= b && 0 < d => ghostMulDivDown(a, b, d) * d <= a * b;
-
-    // proved in mulDivDownTightBound
-    axiom forall mathint a. forall mathint b. forall mathint d. 0 <= a && 0 <= b && 0 < d => (ghostMulDivDown(a, b, d) + 1) * d > a * b;
-}
-
-persistent ghost ghostMulDivUp(mathint, mathint, mathint) returns mathint {
-    // proved in mulDivUpRoundsUp
-    axiom forall uint256 b. forall uint256 d. d > 0 => ghostMulDivUp(0, b, d) == 0;
-
-    // proved in mulDivUpRoundsUp
-    axiom forall mathint a. forall mathint b. forall mathint d. 0 <= a && 0 <= b && 0 < d => ghostMulDivUp(a, b, d) * d >= a * b;
-
-    // proved in mulDivUpUpperBound
-    axiom forall mathint a. forall mathint b. forall mathint d. 0 <= a && 0 <= b && 0 < d => ghostMulDivUp(a, b, d) * d <= a * b + d - 1;
+    require forall mathint b. forall mathint d. axiomMathMulDivUpZeroA(b, d), "axiom";
+    require forall mathint a. forall mathint b. forall mathint d. axiomMathMulDivUpRoundsUp(a, b, d), "axiom";
+    require forall mathint a. forall mathint b. forall mathint d. axiomMathMulDivUpTightBound(a, b, d), "axiom";
 }
 
 function summaryMulDivDown(uint256 a, uint256 b, uint256 d) returns uint256 {
@@ -90,6 +78,8 @@ function summaryMulDivUp(uint256 a, uint256 b, uint256 d) returns uint256 {
 //
 // If buyerAssetsToUnits(midnight, id, offer, T) returns u, then take(u, ...) produces buyerAssets == T.
 rule buyerAssetsReachable(env e, Midnight.Offer offer, uint256 targetBuyerAssets, address taker, address takerCallback, bytes takerCallbackData, address receiverIfTakerIsSeller, bytes ratifierData) {
+    mathMulDivAxioms();
+
     bytes32 id = summaryToId(offer.market);
 
     uint256 units = TakeAmountsLibHarness.buyerAssetsToUnits(e, currentContract, id, offer, targetBuyerAssets);
@@ -105,6 +95,8 @@ rule buyerAssetsReachable(env e, Midnight.Offer offer, uint256 targetBuyerAssets
 //
 // If sellerAssetsToUnits(midnight, id, offer, T) returns u, then take(u, ...) produces sellerAssets == T.
 rule sellerAssetsReachable(env e, Midnight.Offer offer, uint256 targetSellerAssets, address taker, address takerCallback, bytes takerCallbackData, address receiverIfTakerIsSeller, bytes ratifierData) {
+    mathMulDivAxioms();
+
     bytes32 id = summaryToId(offer.market);
 
     uint256 units = TakeAmountsLibHarness.sellerAssetsToUnits(e, currentContract, id, offer, targetSellerAssets);

--- a/certora/specs/TakeAmountsLibInvertibility.spec
+++ b/certora/specs/TakeAmountsLibInvertibility.spec
@@ -62,14 +62,14 @@ function summaryMulDivDown(uint256 a, uint256 b, uint256 d) returns uint256 {
     if (d == 0 || a * b >= 2 ^ 256) {
         revert();
     }
-    return assert_uint256(ghostMulDivDown(a, b, d));
+    return require_uint256(ghostMulDivDown(a, b, d));
 }
 
 function summaryMulDivUp(uint256 a, uint256 b, uint256 d) returns uint256 {
     if (d == 0 || a * b + d - 1 >= 2 ^ 256) {
         revert();
     }
-    return assert_uint256(ghostMulDivUp(a, b, d));
+    return require_uint256(ghostMulDivUp(a, b, d));
 }
 
 /// TAKE AMOUNTS LIB INVERTIBILITY ///


### PR DESCRIPTION
This adds a new spec file just containing the mathint variants of the muldiv axioms as definition plus a summary for mulDiv based on these axioms.

Other spec files can use them by `require axiom...(...), "axiom";`  and as long as there is no typo in this file, we can be sure that they are sound.
