### PR TITLE
[Certora] MaxRepaidHealthy - support more than two collaterals

### DIFF
--- a/certora/confs/MaxRepaidHealthy.conf
+++ b/certora/confs/MaxRepaidHealthy.conf
@@ -11,7 +11,7 @@
   "solc_via_ir": true,
   "solc_evm_version": "osaka",
   "optimistic_loop": true,
-  "loop_iter": 2,
+  "loop_iter": 3,
   "optimistic_hashing": true,
   "hashing_length_bound": 2048,
   "prover_args": [

--- a/certora/helpers/MidnightWrapper.sol
+++ b/certora/helpers/MidnightWrapper.sol
@@ -24,8 +24,7 @@ contract MidnightWrapper is Midnight {
                 i--;
                 CollateralParams memory collateralParam = market.collateralParams[i];
                 uint256 price = IOracle(collateralParam.oracle).price();
-                maxDebt += _position.collateral[i]
-                    .mulDivDown(price, ORACLE_PRICE_SCALE)
+                maxDebt += _position.collateral[i].mulDivDown(price, ORACLE_PRICE_SCALE)
                     .mulDivDown(collateralParam.lltv, WAD);
             }
         }
@@ -49,8 +48,7 @@ contract MidnightWrapper is Midnight {
             i--;
             CollateralParams memory collateralParam = market.collateralParams[i];
             uint256 price = IOracle(collateralParam.oracle).price();
-            maxDebt += _position.collateral[i]
-                .mulDivDown(price, ORACLE_PRICE_SCALE)
+            maxDebt += _position.collateral[i].mulDivDown(price, ORACLE_PRICE_SCALE)
                 .mulDivDown(collateralParam.lltv, WAD);
         }
         CollateralParams memory liquidatedParam = market.collateralParams[collateralIndex];
@@ -59,6 +57,9 @@ contract MidnightWrapper is Midnight {
         return (debt - maxDebt).mulDivUp(WAD * WAD, WAD * WAD - lif * lltv);
     }
 
+    /* Compute the maxDebt a user can have to be still considered healthy.  This uses the same math as
+     * isHealthyNoBitmap.
+     */
     function maxDebtFor(Market memory market, bytes32 id, address borrower) public view returns (uint256) {
         Position storage _position = position[id][borrower];
         uint256 maxDebt;

--- a/certora/helpers/MidnightWrapper.sol
+++ b/certora/helpers/MidnightWrapper.sol
@@ -24,7 +24,8 @@ contract MidnightWrapper is Midnight {
                 i--;
                 CollateralParams memory collateralParam = market.collateralParams[i];
                 uint256 price = IOracle(collateralParam.oracle).price();
-                maxDebt += _position.collateral[i].mulDivDown(price, ORACLE_PRICE_SCALE)
+                maxDebt += _position.collateral[i]
+                    .mulDivDown(price, ORACLE_PRICE_SCALE)
                     .mulDivDown(collateralParam.lltv, WAD);
             }
         }
@@ -48,7 +49,8 @@ contract MidnightWrapper is Midnight {
             i--;
             CollateralParams memory collateralParam = market.collateralParams[i];
             uint256 price = IOracle(collateralParam.oracle).price();
-            maxDebt += _position.collateral[i].mulDivDown(price, ORACLE_PRICE_SCALE)
+            maxDebt += _position.collateral[i]
+                .mulDivDown(price, ORACLE_PRICE_SCALE)
                 .mulDivDown(collateralParam.lltv, WAD);
         }
         CollateralParams memory liquidatedParam = market.collateralParams[collateralIndex];
@@ -68,7 +70,8 @@ contract MidnightWrapper is Midnight {
             i--;
             CollateralParams memory collateralParam = market.collateralParams[i];
             uint256 price = IOracle(collateralParam.oracle).price();
-            maxDebt += _position.collateral[i].mulDivDown(price, ORACLE_PRICE_SCALE)
+            maxDebt += _position.collateral[i]
+                .mulDivDown(price, ORACLE_PRICE_SCALE)
                 .mulDivDown(collateralParam.lltv, WAD);
         }
         return maxDebt;

--- a/certora/helpers/MidnightWrapper.sol
+++ b/certora/helpers/MidnightWrapper.sol
@@ -59,6 +59,20 @@ contract MidnightWrapper is Midnight {
         return (debt - maxDebt).mulDivUp(WAD * WAD, WAD * WAD - lif * lltv);
     }
 
+    function maxDebtFor(Market memory market, bytes32 id, address borrower) public view returns (uint256) {
+        Position storage _position = position[id][borrower];
+        uint256 maxDebt;
+        uint256 len = market.collateralParams.length;
+        for (uint256 i = len; i > 0;) {
+            i--;
+            CollateralParams memory collateralParam = market.collateralParams[i];
+            uint256 price = IOracle(collateralParam.oracle).price();
+            maxDebt += _position.collateral[i].mulDivDown(price, ORACLE_PRICE_SCALE)
+                .mulDivDown(collateralParam.lltv, WAD);
+        }
+        return maxDebt;
+    }
+
     // This realizableBadDebt function recomputes, verbatim, the badDebt local that
     // liquidate() computes at src/Midnight.sol:643-657, so that the prover can equate this
     // getter's result with liquidate's inlined bad-debt computation.

--- a/certora/specs/MaxRepaidHealthy.spec
+++ b/certora/specs/MaxRepaidHealthy.spec
@@ -74,14 +74,7 @@ persistent ghost address globalMarketLoanToken;
 
 persistent ghost uint256 globalMarketChainId;
 
-// Exactly two collaterals is not a restriction on the result. Liquidating touches a single collateral, so the
-// whole contribution of every other collateral to maxDebt enters the reasoning as one arbitrary non-negative
-// value, and one extra collateral with an arbitrary amount, price and LLTV already realizes every such value.
-// The second collateral therefore plays the role of the arbitrary otherCollatContribution of the Rocq proof,
-// and a market with more collaterals is covered by the same argument.
-persistent ghost uint256 globalMarketCollateralLength {
-    axiom globalMarketCollateralLength == 2;
-}
+persistent ghost uint256 globalMarketCollateralLength;
 
 persistent ghost mapping(uint256 => address) globalMarketCollateralOracle;
 
@@ -106,7 +99,7 @@ persistent ghost bytes32 globalId;
 definition collateralMatches(Midnight.Market market, uint256 index) returns bool = (index < globalMarketCollateralLength => market.collateralParams[index].oracle == globalMarketCollateralOracle[index] && market.collateralParams[index].token == globalMarketCollateralToken[index] && market.collateralParams[index].lltv == globalMarketCollateralLLTV[index] && market.collateralParams[index].liquidationCursor == globalMarketCollateralLiquidationCursor[index]);
 
 function equalsGlobalMarket(Midnight.Market market) returns (bool) {
-    return market.chainId == globalMarketChainId && market.midnight == currentContract && market.loanToken == globalMarketLoanToken && market.collateralParams.length == globalMarketCollateralLength && collateralMatches(market, 0) && collateralMatches(market, 1) && market.maturity == globalMarketMaturity && market.rcfThreshold == globalMarketRcfThreshold && market.enterGate == globalMarketEnterGate && market.liquidatorGate == globalMarketLiquidatorGate;
+    return market.chainId == globalMarketChainId && market.midnight == currentContract && market.loanToken == globalMarketLoanToken && market.collateralParams.length == globalMarketCollateralLength && collateralMatches(market, 0) && collateralMatches(market, 1) && collateralMatches(market, 2) && globalMarketCollateralLength <= 3 && market.maturity == globalMarketMaturity && market.rcfThreshold == globalMarketRcfThreshold && market.enterGate == globalMarketEnterGate && market.liquidatorGate == globalMarketLiquidatorGate;
 }
 
 function getGlobalMarket() returns (Midnight.Market) {
@@ -127,9 +120,8 @@ function summaryToId(Midnight.Market market) returns (bytes32) {
 
 /// RULE ///
 
-// In a two-collateral market, liquidating at the amount computed by maxRepaidFor leaves the position healthy.
-// The call uses normal mode and covers the strictly unhealthy and health-boundary cases. See the
-// globalMarketCollateralLength axiom for why two collaterals is general enough.
+// In a market, liquidating at the amount computed by maxRepaidFor leaves the position healthy.
+// The call uses normal mode and covers the strictly unhealthy and health-boundary cases.
 rule liquidateAtCapRestoresHealth(env e, uint256 collateralIndex, address borrower, address receiver, address callback, bytes data) {
     Midnight.Market globalMarket = getGlobalMarket();
 

--- a/certora/specs/MaxRepaidHealthy.spec
+++ b/certora/specs/MaxRepaidHealthy.spec
@@ -11,6 +11,7 @@ methods {
     function debt(bytes32 id, address user) external returns (uint128) envfree;
     function isHealthyNoBitmap(Midnight.Market, bytes32, address) external returns (bool) envfree;
     function maxRepaidFor(Midnight.Market, bytes32, uint256, address) external returns (uint256) envfree;
+    function maxDebtFor(Midnight.Market, bytes32, address) external returns (uint256) envfree;
 
     // Assumption: price does not change during the rule (same value in maxRepaidFor, in liquidate and in the
     // post-state isHealthyNoBitmap). Deterministic per oracle address, as in Healthiness.spec.
@@ -137,12 +138,7 @@ rule liquidateAtCapRestoresHealth(env e, uint256 collateralIndex, address borrow
 
     // This rule checks that using `repaidUnits == maxRepaid` is enough to put the account healthy. This means that the RCF doesn't prevent to put the position back to health.
     uint256 repaidUnits = maxRepaidFor(globalMarket, globalId, collateralIndex, borrower);
-
-    // maxRepaidFor's non-reverting collateral lookup establishes collateralIndex < 2.
-    uint256 otherIndex = assert_uint256(1 - collateralIndex);
-    uint256 otherCollatBefore = collateral(globalId, borrower, otherIndex);
-    uint256 otherLltv = globalMarketCollateralLLTV[otherIndex];
-    uint256 otherPrice = summaryPrice(globalMarket.collateralParams[otherIndex].oracle);
+    uint256 maxDebtBefore = maxDebtFor(globalMarket, globalId, borrower);
 
     uint256 seizedOut;
     uint256 repaidOut;
@@ -191,9 +187,6 @@ rule liquidateAtCapRestoresHealth(env e, uint256 collateralIndex, address borrow
     // repaidUnits is ceil(gap * WAD^2 / (WAD^2 - lif * lltv)). The two rounding facts below imply
     // maxDebtDropBound <= repaidUnits - gap. Therefore the new max debt falls by no more than the amount
     // repaid in excess of the old health gap.
-    mathint otherCollatValue = ghostMulDivDown(otherCollatBefore, otherPrice, ORACLE_PRICE_SCALE());
-    mathint otherContrib = ghostMulDivDown(otherCollatValue, otherLltv, WAD());
-    mathint maxDebtBefore = oldContrib + otherContrib;
 
     mathint gap = debtBefore - maxDebtBefore;
     mathint rcfDenominator = WAD_SQUARED() - lifTimesLltv;


### PR DESCRIPTION
This uses a solidity helper to compute maxDebt covered by collateral, instead of doing it in CVL.  This simplifies the spec and allows to drop the restriction to two collaterals.  There is still the restriction because we need a finite CVL function to match the market with the ghost market, though.  The current spec allows three collaterals and uses an loop unrolling depth of 3.



